### PR TITLE
docs: set dev permission mode to Auto (acceptEdits)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,10 @@ Project-specific rules go here. Examples to adapt or delete:
 Standing preferences for this project:
 
 - Effort: maximum. Use deepest reasoning.
-- Permission mode: bypass during development (user-controlled).
+- Permission mode: Auto (acceptEdits) during development (user-controlled).
   <!-- Modes (set with /permissions or settings.json "defaultMode"): default = prompt on
-       first use of each tool; acceptEdits = auto-accept edits, prompt other actions;
-       plan = read-only; bypassPermissions = no prompts (the mode above). -->
+       first use of each tool; acceptEdits = auto-accept edits, prompt other actions
+       ("Auto", the mode above); plan = read-only; bypassPermissions = no prompts. -->
 - Superpowers: use relevant skills proactively (brainstorming, writing-plans,
   test-driven-development, subagent-driven-development, executing-plans,
   verification-before-completion).


### PR DESCRIPTION
## What

Change the development permission-mode preference in `CLAUDE.md` from `bypassPermissions` to **Auto (`acceptEdits`)**.

## Why

`bypassPermissions` runs with no prompts at all. `acceptEdits` auto-accepts file edits while still prompting for other actions (running commands, etc.), which is a safer default for day-to-day development. The modes comment is updated so the `"Auto"` label points at the correct `settings.json` `defaultMode` value and stays accurate.

The unrelated `--no-verify` "bypass" reference (git hooks section) is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)