### PR TITLE
docs: document optional notification-sound hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ Standing preferences for this project:
   verification-before-completion).
 - Parallel work: fan out subagents for independent research or implementation
   streams. Default to parallel over serial.
+- Notifications: optional macOS sound hook on the `Notification` and `Stop`
+  events (a "pling" when a session waits or finishes). See NEW-PROJECT-SETUP.md.
 
 ## How to pick up a task
 

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -37,6 +37,11 @@ new repo's root and fill in its placeholders as you go.
 - [ ] Fill "Useful commands" with the real install/dev/test/lint/e2e commands.
 - [ ] Tailor "Code style" and "What not to do" to this project; delete the rest.
 - [ ] Confirm "Workflow defaults" still match how you want to work here.
+- [ ] (Optional, macOS, set once globally) Pling on input: add `Notification`
+      and `Stop` hooks to `~/.claude/settings.json` that run
+      `afplay /System/Library/Sounds/Glass.aiff` (async). A short sound when a
+      session waits for you or finishes a turn. Swap the file for another sound
+      in `/System/Library/Sounds/`.
 
 ## 5. First slice of work
 


### PR DESCRIPTION
## What
Documents an optional dev-experience tip: a notification "pling" on the Claude Code `Notification` and `Stop` hook events.

- `NEW-PROJECT-SETUP.md`: optional bullet under the CLAUDE.md step.
- `CLAUDE.md`: one-line pointer under "Workflow defaults".

## Why
The hook is a personal, global (`~/.claude/settings.json`), macOS-specific (`afplay`) preference, so it is documented as an optional tip rather than committed as a hook the template would force on every project cloned from it.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)