### PR TITLE
chore: ship notification-sound hook in template

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay /System/Library/Sounds/Glass.aiff",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay /System/Library/Sounds/Glass.aiff",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,9 @@ Standing preferences for this project:
   verification-before-completion).
 - Parallel work: fan out subagents for independent research or implementation
   streams. Default to parallel over serial.
-- Notifications: optional macOS sound hook on the `Notification` and `Stop`
-  events (a "pling" when a session waits or finishes). See NEW-PROJECT-SETUP.md.
+- Notifications: `.claude/settings.json` adds a macOS sound hook on the
+  `Notification` and `Stop` events (a "pling" when a session waits or finishes).
+  Delete that file to opt out. See NEW-PROJECT-SETUP.md.
 
 ## How to pick up a task
 

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -37,11 +37,11 @@ new repo's root and fill in its placeholders as you go.
 - [ ] Fill "Useful commands" with the real install/dev/test/lint/e2e commands.
 - [ ] Tailor "Code style" and "What not to do" to this project; delete the rest.
 - [ ] Confirm "Workflow defaults" still match how you want to work here.
-- [ ] (Optional, macOS, set once globally) Pling on input: add `Notification`
-      and `Stop` hooks to `~/.claude/settings.json` that run
-      `afplay /System/Library/Sounds/Glass.aiff` (async). A short sound when a
-      session waits for you or finishes a turn. Swap the file for another sound
-      in `/System/Library/Sounds/`.
+- [ ] (Optional, macOS) Notification pling: this template ships
+      `.claude/settings.json` with `Notification` and `Stop` hooks that run
+      `afplay /System/Library/Sounds/Glass.aiff` (async), a short sound when a
+      session waits for you or finishes a turn. Delete `.claude/settings.json`
+      to opt out, or swap the file for another sound in `/System/Library/Sounds/`.
 
 ## 5. First slice of work
 


### PR DESCRIPTION
## What
- Add tracked `.claude/settings.json` with `Notification` + `Stop` pling hooks (`afplay` Glass, async).
- Reconcile docs from #9: `NEW-PROJECT-SETUP.md` and `CLAUDE.md` now say the template ships the hooks (delete the file to opt out) rather than framing them as a global-only tip.
- Add `.gitignore` for `.DS_Store`.

## Why
Ship the dev-experience pling with the template so it does not have to be re-added per machine.

## Caveat
macOS-only (`afplay`); the command no-ops harmlessly elsewhere. Delete `.claude/settings.json` to opt out.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)