### PR TITLE
docs: note .claude/settings.json macOS-only hook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A starting `CLAUDE.md` and a bootstrap checklist for new projects.
   writing style, and workflow defaults.
 - `NEW-PROJECT-SETUP.md` - the once-per-repo checklist: branch protection, docs
   structure, CI/CD and e2e wiring, and filling in the `CLAUDE.md` placeholders.
+- `.claude/settings.json` - notification "pling" hooks (`Notification` and
+  `Stop`). macOS only (`afplay`); the command no-ops elsewhere. Delete the file
+  to opt out.
 
 Generalized from two project `CLAUDE.md` files (a Python advisory bot and a
 TypeScript web app), keeping the shared backbone and dropping the project


### PR DESCRIPTION
## What
Add a `.claude/settings.json` bullet to the README file list, flagging the macOS-only (`afplay`) caveat and the opt-out. The README previously omitted the file shipped in #11.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)