### PR TITLE
feat: add grill-me skill from mattpocock/skills

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+---
+
+Source: [mattpocock/skills](https://github.com/mattpocock/skills)
+(`skills/productivity/grill-me`), MIT License, Copyright (c) 2026 Matt Pocock.


### PR DESCRIPTION
Closes #21

Adds `.claude/skills/grill-me/SKILL.md`, copied verbatim from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, attribution line included; license verified against the upstream LICENSE file).

Where it fits: superpowers brainstorming generates a design, `/grill-me` stress-tests it before `/kickoff`. One question at a time, each with a recommended answer, every decision branch resolved, codebase consulted before asking.

Doc mentions in CLAUDE.md and README are deferred until #20 merges, since #20 rewrites both files and parallel edits would only manufacture a conflict (noted on the issue).

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)