### PR TITLE
docs: mention grill-me in CLAUDE.md and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,10 @@ session resumable.
 - `tester` - independent verification on the branch, read-only.
 - `reviewer` - spec pass then quality pass, read-only.
 
-Refine and size issues in discussion first; mark dependencies with a literal
-`Blocked by: #N` line in the issue body. Then `/kickoff <issues>` (user-typed
-only; it does not auto-trigger) runs unblocked issues in parallel waves to
-ready PRs. Under `/kickoff` the sub-plan comment substitutes for the full plan
+Refine and size issues in discussion first (`/grill-me` stress-tests the plan
+before it becomes issues); mark dependencies with a literal `Blocked by: #N`
+line in the issue body. Then `/kickoff <issues>` (user-typed only; it does not
+auto-trigger) runs unblocked issues in parallel waves to ready PRs. Under `/kickoff` the sub-plan comment substitutes for the full plan
 in `docs/plans/`. Merging stays human and gates the next wave. Caps, routing,
 and report contracts live in `.claude/skills/kickoff/SKILL.md` and the agent
 files; they are not repeated here.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ready-made agent team for Claude Code.
 - `.claude/skills/kickoff/` - `/kickoff`: fans refined, sized issues out to
   the agent team in parallel waves, through implement, test, and review, to a
   ready PR per issue.
+- `.claude/skills/grill-me/` - `/grill-me`: stress-tests a plan one question
+  at a time before kickoff (from mattpocock/skills, MIT).
 - `.claude/settings.json` - enables obra's superpowers plugin per project
   (`superpowers@claude-plugins-official`; the methodology skills:
   brainstorming, writing-plans, TDD, verification).


### PR DESCRIPTION
Closes #23

The two one-liners deferred from #21: a README bullet for the skill and its slot in the agent-team workflow (stress-test the plan between refinement and kickoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)