### PR TITLE
feat: adapt to-issues skill from mattpocock/skills

### DIFF
--- a/.claude/skills/to-issues/SKILL.md
+++ b/.claude/skills/to-issues/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: to-issues
+description: Break an approved plan, spec, or design into independently implementable GitHub issues using vertical slices, sized and dependency-ordered, ready for /kickoff. Use when the user wants to convert a plan or spec into issues, create implementation tickets, or break down work.
+---
+
+Break the plan into issues that `/kickoff` can run: thin vertical slices
+(tracer bullets). Each slice is a complete, verifiable path through every
+layer it touches, never a horizontal layer on its own.
+
+## Process
+
+1. Work from the conversation context. If the user passes a reference (issue
+   number, URL, or a spec under `docs/superpowers/specs/`), read it fully
+   first.
+2. Explore the code enough to use the project's real names, and respect the
+   decisions in `docs/architecture/`.
+3. Draft the slices. Each one delivers narrow but complete end-to-end
+   behavior and is demoable or verifiable on its own. Prefer many thin
+   slices over few thick ones.
+4. Quiz the user with a numbered list: title, proposed size label, and
+   `Blocked by` relationships. Ask: is the granularity right, are the
+   dependencies correct, should any slice be merged or split? Iterate until
+   approved.
+5. Publish with `gh issue create`, blockers first, so `Blocked by: #N` lines
+   reference real issue numbers. Apply the size labels.
+
+## Issue body template
+
+```
+Blocked by: #N            (omit when unblocked)
+
+## What to build
+
+The end-to-end behavior of this slice, in the project's domain terms. No
+file paths or code snippets; they go stale.
+
+## Acceptance criteria
+
+- [ ] ...
+- [ ] ...
+```
+
+---
+
+Adapted from [mattpocock/skills](https://github.com/mattpocock/skills)
+(`skills/engineering/to-issues`), MIT License, Copyright (c) 2026 Matt
+Pocock. The issue-tracker plumbing is replaced with `gh`, this template's
+size labels, and its `Blocked by:` convention.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,9 +128,9 @@ session resumable.
 - `tester` - independent verification on the branch, read-only.
 - `reviewer` - spec pass then quality pass, read-only.
 
-Refine and size issues in discussion first (`/grill-me` stress-tests the plan
-before it becomes issues); mark dependencies with a literal `Blocked by: #N`
-line in the issue body. Then `/kickoff <issues>` (user-typed only; it does not
+Refine and size issues in discussion first (`/grill-me` stress-tests the
+plan, `/to-issues` turns it into sized issues); mark dependencies with a
+literal `Blocked by: #N` line in the issue body. Then `/kickoff <issues>` (user-typed only; it does not
 auto-trigger) runs unblocked issues in parallel waves to ready PRs. Under `/kickoff` the sub-plan comment substitutes for the full plan
 in `docs/plans/`. Merging stays human and gates the next wave. Caps, routing,
 and report contracts live in `.claude/skills/kickoff/SKILL.md` and the agent

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ ready-made agent team for Claude Code.
   ready PR per issue.
 - `.claude/skills/grill-me/` - `/grill-me`: stress-tests a plan one question
   at a time before kickoff (from mattpocock/skills, MIT).
+- `.claude/skills/to-issues/` - `/to-issues`: turns an approved plan into
+  sized, dependency-ordered issues ready for `/kickoff` (adapted from
+  mattpocock/skills, MIT).
 - `.claude/settings.json` - enables obra's superpowers plugin per project
   (`superpowers@claude-plugins-official`; the methodology skills:
   brainstorming, writing-plans, TDD, verification).


### PR DESCRIPTION
Closes #25

Adapts the to-issues skill to this template: vertical-slice decomposition, a user quiz on granularity and dependencies, then `gh issue create` blockers-first with size labels and `Blocked by: #N` lines. MIT attribution and the nature of the adaptation are stated in the skill file. One bullet in the README, half a line in CLAUDE.md.

Harvest decisions recorded on the issue: git-guardrails and the rest of the shortlist are deliberately skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)