### PR TITLE
feat: add sync-template skill and version stamp

### DIFF
--- a/.claude/skills/sync-template/SKILL.md
+++ b/.claude/skills/sync-template/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: sync-template
+description: Pull the latest claude-template machinery and process updates into this repo and open a PR. Works in repos created from any template version, including repos with no .claude/ at all. User-invocable only.
+disable-model-invocation: true
+argument-hint: [template-repo, default sv-tmueller/claude-template]
+---
+
+Sync this repo with its template. Repos created from a GitHub template share
+no git history with it, so this is a managed copy and judgment merge, not a
+git merge.
+
+Template repo: $ARGUMENTS (default `sv-tmueller/claude-template`).
+
+## 1. Get the delta
+
+Clone the template to /tmp (full history; it is small). Read
+`.claude/template-version` here:
+
+- Stamp present and valid in the clone's history: the delta is
+  `git log --oneline <stamp>..HEAD` and `git diff <stamp> HEAD` in the
+  template clone. Only files in that diff are in scope.
+- No stamp, or unknown SHA (legacy repo): unknown-base mode. Every template
+  file is in scope; be conservative on prose.
+
+If the delta is empty, say so and stop.
+
+## 2. File classes, in scope only
+
+- Machinery (`.claude/agents/`, `.claude/skills/`): copy the template
+  version over the local file. Guard first: if the local file differs from
+  BOTH the old template version (from the stamp) and the new one, it was
+  modified locally; do not overwrite, list it in the PR as a conflict for
+  the user. Never delete local agents or skills the template does not have.
+- `.claude/settings.json`: merge by key. Template-shipped keys (such as its
+  `enabledPlugins` entries) update; project keys (permissions, hooks, env)
+  stay.
+- Prose (`CLAUDE.md`, `README.md`, `.gitignore`): apply only the template's
+  delta hunks, by judgment, into the project's customized text. Never
+  clobber project content. In unknown-base mode, port template sections that
+  are clearly missing; when unsure, leave the file alone and note it in the
+  PR.
+- `NEW-PROJECT-SETUP.md`: skip if the project deleted it after bootstrap.
+
+## 3. Non-file state
+
+- Ensure the workflow labels exist (`size:S/M/L/XL`, `in-progress`,
+  `needs-human`); create missing ones with `gh label create`.
+- If `~/.claude/skills/sync-template/` exists on this machine and is older
+  than the template's copy, update it too; it is the bootstrap for repos
+  that do not carry this skill yet.
+
+## 4. Ship it
+
+1. Write the template clone's HEAD SHA to `.claude/template-version`.
+2. Per the project's process: file a `size:S` issue ("sync template to
+   `<short-sha>`"), branch `chore/<n>-sync-template`, commit
+   (`chore: sync template to <short-sha>`).
+3. Run the project's check suite if one exists.
+4. Open a PR with `Closes #<n>`. The body lists the template commits
+   applied, the files touched per class, and any conflicts or skipped prose
+   from the guards above. Merging stays with the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,9 @@ not rediscover them.
 - Don't merge a PR that has not run the full check suite, including e2e if the
   change touches the stack.
 - Don't bypass git hooks (`--no-verify`). If a hook fails, fix the cause.
+- Don't improve `.claude/` machinery only in this repo. Change the template
+  (sv-tmueller/claude-template) first, then `/sync-template` it back here;
+  local-only edits are overwritten by the next sync.
 - Don't introduce a new dependency without saying why in the PR body.
 - (Add project-specific traps here: the mistakes that quietly break this codebase.)
 

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -23,6 +23,12 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
       `/plugin install superpowers@claude-plugins-official`.
 - [ ] Check the agent team is loaded: `/agents` should list architect,
       developer, tester, and reviewer.
+- [ ] Stamp the template version, so `/sync-template` can apply future
+      template updates incrementally:
+      ```
+      gh api repos/sv-tmueller/claude-template/commits/main --jq .sha > .claude/template-version
+      ```
+      Commit the file.
 
 ## 3. Docs structure
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ ready-made agent team for Claude Code.
 - `.claude/skills/to-issues/` - `/to-issues`: turns an approved plan into
   sized, dependency-ordered issues ready for `/kickoff` (adapted from
   mattpocock/skills, MIT).
+- `.claude/skills/sync-template/` - `/sync-template`: pulls later template
+  versions into a repo created from this one (machinery copied, prose merged
+  by judgment, labels ensured) and opens a PR.
 - `.claude/settings.json` - enables obra's superpowers plugin per project
   (`superpowers@claude-plugins-official`; the methodology skills:
   brainstorming, writing-plans, TDD, verification).
@@ -42,6 +45,25 @@ gh repo create <new-repo> --template sv-tmueller/claude-template --private --clo
 ```
 
 Copying only `CLAUDE.md` works but does not carry the agents and skills.
+
+## Updating existing repos
+
+Repos created from a template share no git history with it, so updates flow
+through `/sync-template` instead of `git merge`. In a repo that already
+carries the skill, run `/sync-template` and review the PR it opens. For
+older repos that predate the skill (or have no `.claude/` at all), install
+it once at user scope, which makes it available in every repo on the
+machine:
+
+```bash
+git clone https://github.com/sv-tmueller/claude-template.git /tmp/ct
+mkdir -p ~/.claude/skills
+cp -r /tmp/ct/.claude/skills/sync-template ~/.claude/skills/
+```
+
+Then open the old repo in Claude Code and run `/sync-template`. The first
+run has no version stamp, so it ports everything conservatively and stamps
+the repo; later runs apply only the template's delta.
 
 ## License
 


### PR DESCRIPTION
Closes #27

- `/sync-template`: clones the template, reads `.claude/template-version`, applies the delta in scope: machinery copied (with a local-modification guard that flags conflicts instead of overwriting), `settings.json` merged by key, prose hunks merged by judgment, labels ensured, stamp updated, then issue + branch + PR per the project process. Falls back to a conservative full sync when no stamp exists.
- NEW-PROJECT-SETUP: stamp step at bootstrap.
- README: skill bullet plus an "Updating existing repos" section with the one-time user-scope bootstrap for legacy repos.
- CLAUDE.md "What not to do": machinery changes go to the template first; local-only edits are overwritten by the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)