### PR TITLE
fix: quote sync-template argument-hint as a string

### DIFF
--- a/.claude/skills/sync-template/SKILL.md
+++ b/.claude/skills/sync-template/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-template
 description: Pull the latest claude-template machinery and process updates into this repo and open a PR. Works in repos created from any template version, including repos with no .claude/ at all. User-invocable only.
 disable-model-invocation: true
-argument-hint: [template-repo, default sv-tmueller/claude-template]
+argument-hint: "[template-repo]"
 ---
 
 Sync this repo with its template. Repos created from a GitHub template share


### PR DESCRIPTION
Closes #29

One line: `argument-hint` was YAML flow-sequence syntax (an array), which fails the string type check and silently un-registers the skill. Now a quoted string; the default template repo stays documented in the skill body. Verified all other skills and agents carry string-typed frontmatter fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)