### PR TITLE
docs: cover CLAUDE_CONFIG_DIR setups in sync-template bootstrap

### DIFF
--- a/.claude/skills/sync-template/SKILL.md
+++ b/.claude/skills/sync-template/SKILL.md
@@ -45,9 +45,10 @@ If the delta is empty, say so and stop.
 
 - Ensure the workflow labels exist (`size:S/M/L/XL`, `in-progress`,
   `needs-human`); create missing ones with `gh label create`.
-- If `~/.claude/skills/sync-template/` exists on this machine and is older
-  than the template's copy, update it too; it is the bootstrap for repos
-  that do not carry this skill yet.
+- If a user-scope copy of this skill exists on this machine (under
+  `$CLAUDE_CONFIG_DIR/skills/` or `~/.claude/skills/`) and is older than the
+  template's copy, update it too; it is the bootstrap for repos that do not
+  carry this skill yet.
 
 ## 4. Ship it
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ mkdir -p ~/.claude/skills
 cp -r /tmp/ct/.claude/skills/sync-template ~/.claude/skills/
 ```
 
+If you launch Claude Code through a `CLAUDE_CONFIG_DIR` alias (separate
+personal and work config dirs), each config dir has its own user-scope
+skills: copy into `$CLAUDE_CONFIG_DIR/skills/` instead, once per config dir
+you use.
+
 Then open the old repo in Claude Code and run `/sync-template`. The first
 run has no version stamp, so it ports everything conservatively and stamps
 the repo; later runs apply only the template's delta.


### PR DESCRIPTION
Closes #31

README bootstrap notes the per-config-dir skills location; the skill's user-copy refresh step now covers both `$CLAUDE_CONFIG_DIR/skills/` and `~/.claude/skills/`. Found because the author's own machine uses claude-personal/claude-work aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)