### PR TITLE
feat: efficient agent-team model routing + bounded review workflow

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Advisory lead for approach decisions. Use when an issue needs a sub-plan before implementation, when an issue looks mis-sized or needs splitting (size:L or size:XL), or when developer and reviewer disagree. Read-only; decides approach, never writes code.
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: opus
 ---
 
 You are the lead architect. You decide approach; you never write product code.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,7 +1,7 @@
 ---
 name: developer
 description: Implements exactly one GitHub issue end to end. Branch, TDD, conventional commits, draft PR. Use once per work package during /kickoff fan-out, for fix rounds on an existing package branch, or to implement a single refined issue on request.
-model: inherit
+model: sonnet
 isolation: worktree
 skills: superpowers:test-driven-development
 ---

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Reviews a work package diff against its issue and sub-plan, in two passes, spec compliance then code quality. Read-only; outputs APPROVE or CHANGES_REQUESTED with numbered file:line findings. Never edits files.
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: opus
 ---
 
 You review; you never fix. You have no Edit or Write access on purpose. Bash is

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -2,7 +2,7 @@
 name: tester
 description: Independent verification of a work package branch. Runs the full check suite and tries to break the change. Read-only on the repo; reports PASS or numbered failures with reproduction commands. Never fixes code.
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: sonnet
 isolation: worktree
 skills: superpowers:verification-before-completion
 ---

--- a/.claude/skills/sync-template/SKILL.md
+++ b/.claude/skills/sync-template/SKILL.md
@@ -26,7 +26,7 @@ If the delta is empty, say so and stop.
 
 ## 2. File classes, in scope only
 
-- Machinery (`.claude/agents/`, `.claude/skills/`): copy the template
+- Machinery (`.claude/agents/`, `.claude/skills/`, `.claude/workflows/`): copy the template
   version over the local file. Guard first: if the local file differs from
   BOTH the old template version (from the stamp) and the new one, it was
   modified locally; do not overwrite, list it in the PR as a conflict for

--- a/.claude/workflows/review-changes.js
+++ b/.claude/workflows/review-changes.js
@@ -1,0 +1,114 @@
+export const meta = {
+  name: 'review-changes',
+  description:
+    'Token-bounded code review: Sonnet workers review the diff across fixed dimensions, one Opus critic consolidates. Models are pinned per stage in-script, so it never inherits an expensive session model or fans out unboundedly.',
+  phases: [
+    { title: 'Review', detail: 'one Sonnet worker per dimension', model: 'sonnet' },
+    { title: 'Consolidate', detail: 'one Opus critic verifies and merges findings', model: 'opus' },
+  ],
+}
+
+// Bounded by construction. The dimension list is fixed, there is no per-file
+// fan-out and no loop, so a run is exactly DIMENSIONS.length Sonnet workers plus
+// one Opus critic. It cannot become the 100-agent fan-out that an unpinned
+// session-model review produces. Models are pinned per stage, so a Fable or Opus
+// session never leaks into the workers.
+//
+// Invoke with an optional base ref:
+//   Workflow({ name: 'review-changes', args: { base: 'origin/main' } })
+
+const base = (args && args.base) || 'origin/main'
+
+const DIMENSIONS = [
+  {
+    key: 'bugs',
+    brief:
+      'Bugs, adversarially. Do not just read for correctness; look for inputs or states that break the change: logic errors, wrong or missing edge-case handling, broken error paths, races and ordering bugs, off-by-one, misused or wrongly-assumed APIs, null and boundary handling, resource leaks. A weakened or deleted test is a finding.',
+  },
+  {
+    key: 'security',
+    brief:
+      'Security. Untrusted input reaching a sink (injection, path traversal, SSRF, unsafe deserialization), missing authn or authz checks, secrets or credentials in code or logs, unsafe defaults, weak crypto, and supply-chain risk from new or bumped dependencies. The /security-review skill is the deep standalone pass; here, flag what this diff exposes.',
+  },
+  {
+    key: 'scope',
+    brief:
+      'Scope and simplicity (CLAUDE.md principles 2 and 3). Code beyond what the change requires, speculative abstraction, drive-by refactoring, reformatted unrelated lines, configurability nothing uses. Ask whether 200 lines could be 50.',
+  },
+  {
+    key: 'tests',
+    brief:
+      'Test coverage. Behavior changed with no test pinning it, logic with a right answer lacking a failing-then-passing test, integration touched without fixture coverage.',
+  },
+  {
+    key: 'style',
+    brief:
+      'Project style (CLAUDE.md code style and writing style). Em dashes, AI-cliche phrases, hard-coded user-facing strings, raw primitives where dedicated types exist, comments that restate code, escape hatches with no // reason: comment.',
+  },
+]
+
+const FINDING = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    file: { type: 'string' },
+    line: { type: 'string', description: 'line number or range, or "n/a"' },
+    severity: { type: 'string', enum: ['must-fix', 'should-fix', 'nit'] },
+    problem: { type: 'string' },
+    fix: { type: 'string' },
+  },
+  required: ['file', 'line', 'severity', 'problem', 'fix'],
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { findings: { type: 'array', items: FINDING } },
+  required: ['findings'],
+}
+
+const REPORT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['approve', 'changes-requested'] },
+    summary: { type: 'string' },
+    mustFix: { type: 'array', items: FINDING },
+    shouldFix: { type: 'array', items: FINDING },
+    nits: { type: 'array', items: FINDING },
+    dismissed: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { problem: { type: 'string' }, why: { type: 'string' } },
+        required: ['problem', 'why'],
+      },
+      description: 'findings judged false-positive or out of scope, with the reason',
+    },
+  },
+  required: ['verdict', 'summary', 'mustFix'],
+}
+
+const diffHint =
+  `Get the change under review with \`git diff ${base}...HEAD\` for committed work on the branch, and \`git diff\` plus \`git status\` for any uncommitted changes; review the union. Read surrounding code before judging, and do not flag what the diff does not touch.`
+
+phase('Review')
+const reviews = await parallel(
+  DIMENSIONS.map((d) => () =>
+    agent(
+      `You review one dimension of a code change and report findings only; you never edit.\n\nDimension: ${d.brief}\n\n${diffHint}\n\nReport every finding with file, line, severity (must-fix | should-fix | nit), the problem, and the required fix. If the dimension is clean, return an empty findings array. Stay strictly within your dimension.`,
+      { label: `review:${d.key}`, phase: 'Review', model: 'sonnet', schema: FINDINGS_SCHEMA }
+    )
+  )
+)
+
+const raw = reviews.filter(Boolean).flatMap((r) => r.findings)
+
+phase('Consolidate')
+const report = await agent(
+  `You are the senior reviewer. ${DIMENSIONS.length} parallel reviewers produced the raw findings below. ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
+  { label: 'consolidate', phase: 'Consolidate', model: 'opus', schema: REPORT_SCHEMA }
+)
+
+return report

--- a/.claude/workflows/review-changes.js
+++ b/.claude/workflows/review-changes.js
@@ -105,9 +105,18 @@ const reviews = await parallel(
 
 const raw = reviews.filter(Boolean).flatMap((r) => r.findings)
 
+// parallel() null-pads a worker that errors or is skipped, so a dead reviewer
+// would otherwise drop its whole dimension while the critic assumes full
+// coverage. Track which dimensions actually reported.
+const covered = DIMENSIONS.filter((_, i) => reviews[i])
+const dropped = DIMENSIONS.filter((_, i) => !reviews[i])
+const coverageNote = dropped.length
+  ? ` ${dropped.length} reviewer(s) did not return, so these dimensions are NOT covered: ${dropped.map((d) => d.key).join(', ')}. Treat the review as partial and say so in your summary.`
+  : ''
+
 phase('Consolidate')
 const report = await agent(
-  `You are the senior reviewer. ${DIMENSIONS.length} parallel reviewers produced the raw findings below. ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
+  `You are the senior reviewer. ${covered.length} parallel reviewers produced the raw findings below.${coverageNote} ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
   { label: 'consolidate', phase: 'Consolidate', model: 'opus', schema: REPORT_SCHEMA }
 )
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,31 @@ Labels: `in-progress` (package dispatched; resume, do not restart) and
 `needs-human` (parked: question, blocker, or exhausted fix loop), on top of
 the sizing set.
 
+## Model policy
+
+A strong orchestrator with efficient workers. The lever is where each model
+runs, not raw effort everywhere.
+
+- Orchestrator (the lead session, including `/kickoff`): Opus 4.8 at max
+  effort. Opus does not over-spawn under ultracode the way Fable 5 does, and it
+  weighs less against Max-plan quota. Keep the lead here.
+- `ultracode`: use it as a per-prompt keyword, never as a session-wide effort
+  setting. Session-wide turns every task into a workflow and chains several per
+  request; the keyword scopes orchestration to the one task that needs it.
+- Role agents (set in each agent's frontmatter `model:`): `developer` and
+  `tester` run `sonnet` (efficient implementation and verification);
+  `architect` and `reviewer` run `opus` (the judgment roles).
+- Workflows: pin worker stages to a cheap model in the script and reserve the
+  strong model for synthesis or critique. The `review-changes` workflow in
+  `.claude/workflows/` is the worked example: a fixed set of Sonnet reviewers
+  plus one Opus critic, bounded by construction so it cannot fan out into the
+  100-agent review that an unpinned session model produces.
+- Do not set `CLAUDE_CODE_SUBAGENT_MODEL`. It overrides both the per-call model
+  and the frontmatter `model:`, flattening every subagent to one model and
+  defeating the split above. Use it only as a temporary per-session seatbelt
+  (for example `claude-sonnet-4-6` before one heavy ad-hoc run), knowing it
+  downgrades the reviewer too.
+
 ## How to pick up a task
 
 1. `gh issue list --state open` (add `--label phase:<current>` if you use phase
@@ -168,6 +193,7 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
 .claude/
   agents/            role agents: architect, developer, tester, reviewer
   skills/            project skills, /kickoff
+  workflows/         bounded orchestration scripts (review-changes)
   settings.json      project settings; enables the superpowers plugin
 docs/
   architecture/      stack and policy decisions, data model, domain math


### PR DESCRIPTION
Closes #33

## What

- Role agents pinned in frontmatter: `developer` and `tester` = `sonnet`;
  `architect` and `reviewer` = `opus`.
- New bounded review workflow `.claude/workflows/review-changes.js`: 5 Sonnet
  dimensions (bugs, security, scope, tests, style) plus 1 Opus critic. Models
  pinned in-script, bounded by construction (exactly N workers + 1 critic).
- `CLAUDE.md`: new "Model policy" section and the `workflows/` layout line.
- `sync-template`: `.claude/workflows/` added to the machinery copy class so the
  workflow syncs to downstream repos.

## Why

Fable 5 under ultracode fans out subagents that inherit the session model (100+
Fable workers in one review). Pinning workers to Sonnet and keeping Opus for the
judgment roles gives a strong orchestrator with efficient workers.
`CLAUDE_CODE_SUBAGENT_MODEL` is deliberately left unset; it would override and
flatten the per-role pins.

## Verification

Workflow script syntax-checked as a module (parse-only, no agents spawned). The
`review-changes` workflow is being run against this diff as a dogfood; results
posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
