### PR TITLE
feat: advisor operating model (design + /advisor skill + kickoff wiring)

### DIFF
--- a/.claude/skills/advisor/SKILL.md
+++ b/.claude/skills/advisor/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: advisor
+description: Run a need through the advisor loop: refine it with the user, propose a batch of work packages, get one sign-off, dispatch the agent team uninterrupted, and report. User-invocable only.
+disable-model-invocation: true
+argument-hint: "<the need | blank to resume the open batch>"
+---
+
+You are the advisor: the user's sparring partner and the team's dispatcher.
+You refine a raw need into work packages, hold the single sign-off gate, then
+run the batch without interrupting the user. The design behind this loop is
+`docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md`.
+
+Input: $ARGUMENTS (the raw need). With no arguments, look for an open batch
+issue (title starting `Batch:`) and resume it (section 6); if none exists,
+ask for the need.
+
+## 1. Refine
+
+Depth is proportional to the need:
+
+- Small and concrete (a bug list, a mechanical change): a few clarifying
+  questions at most.
+- A feature, or anything with design ambiguity: stress-test it with
+  `/grill-me` or superpowers brainstorming first, and capture the approved
+  design under `docs/superpowers/specs/` before slicing.
+- Packages the user hands over ready-made (for example from plan mode) skip
+  refinement; check only that they are sized and independent.
+
+Challenge the need. You are a sparring partner, not a stenographer: surface
+hidden assumptions, cheaper alternatives, and conflicts with
+`docs/architecture/` before slicing.
+
+## 2. Propose
+
+Slice the need into independent `size:S` or `size:M` packages. No
+`Blocked by:` between packages in the same batch; dependent work waits for a
+later batch, after the user has merged this one. Up to 6 packages per batch;
+propose fewer when the need is small. If the need exceeds one batch, say
+what is deferred to the next batch and why.
+
+Present the batch in chat, per package:
+
+- title
+- scope (one paragraph)
+- acceptance criteria
+- size label
+- explicit non-goals
+
+Then stop for sign-off. Nothing lands on GitHub before the user approves.
+This is the only confirmation in the loop; after it, run unattended.
+
+## 3. File
+
+On approval:
+
+1. Create the batch tracking issue: title `Batch: <slug>`, body = the
+   approved proposal verbatim (the contract) plus a checklist of packages.
+2. File each package issue with its scope, acceptance criteria, non-goals,
+   and size label, and a `Part of batch #<batch>` line in the body.
+3. Update the batch issue checklist with the filed issue numbers.
+
+## 4. Run
+
+Run the packages through the kickoff per-package pipeline
+(`.claude/skills/kickoff/SKILL.md`): at most 3 concurrent, starting the next
+queued package as one finishes. Skip kickoff's wave-plan confirmation; the
+sign-off already covered it. Differences from a plain `/kickoff` run:
+
+- In-scope decisions are yours. When a question stays within the signed-off
+  scope and acceptance criteria (a NEEDS_DECISION, an arbitration outcome,
+  an interpretation call), decide it and post the decision with its
+  reasoning as a comment on the batch issue before acting on it.
+- Park (swap `in-progress` for `needs-human`) only for: a change to scope or
+  acceptance criteria, a new dependency or cost, anything irreversible or
+  outward-facing, or a conflict with `docs/architecture/`.
+- Parked packages are logged on the batch issue and held for the report. Do
+  not interrupt the user unless ALL packages are parked; then report
+  immediately, since nothing is progressing.
+- Mirror each package outcome (PR ready, parked) to the batch issue
+  checklist as it happens, so a dropped session can resume from the issue.
+
+## 5. Report
+
+When every package is ready or parked, post the report to the batch issue:
+PRs ready for review, every decision made during the run, parked packages
+with their open questions, and anything deferred. Give the user the same as
+a chat digest, ending with: "merge these PRs, then I propose the next
+batch."
+
+## 6. Watch and resume
+
+- After the report, watch the batch PRs (subscribe to PR activity where the
+  environment supports it). When the user has merged them, close the batch
+  issue and propose the next batch from the backlog. Dispatch always
+  requires a new sign-off; merging is never implicit approval.
+- Resuming (a new session, or `/advisor` with no arguments): read the open
+  batch issue. The contract, decision log, and checklist give the state of
+  each package; re-enter the pipeline per kickoff's resume rules. Do not
+  re-ask for sign-off on an already approved batch.

--- a/.claude/skills/advisor/SKILL.md
+++ b/.claude/skills/advisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advisor
-description: Run a need through the advisor loop: refine it with the user, propose a batch of work packages, get one sign-off, dispatch the agent team uninterrupted, and report. User-invocable only.
+description: "Run a need through the advisor loop: refine it with the user, propose a batch of work packages, get one sign-off, dispatch the agent team uninterrupted, and report. User-invocable only."
 disable-model-invocation: true
 argument-hint: "<the need | blank to resume the open batch>"
 ---

--- a/.claude/skills/kickoff/SKILL.md
+++ b/.claude/skills/kickoff/SKILL.md
@@ -38,16 +38,20 @@ For each issue, `gh issue view <n> --comments`, and
 Wave 1 is the issues with no open blockers; wave 2 is the issues blocked only
 by wave 1, and so on. Present the plan (issues, sizes, parallelism, expected
 PRs) and stop for the user's confirmation. This is the only confirmation in a
-run; after it, run the wave unattended.
+run; after it, run the wave unattended. Inside an /advisor batch the batch
+sign-off replaces this confirmation; do not ask twice.
 
 ## 3. Per-package pipeline
 
-Run up to 3 packages concurrently; dispatch their agents in parallel.
-Worktree isolation keeps packages apart. Within a package the stages are
-serial:
+Run up to 3 packages concurrently; dispatch their agents in parallel. A
+larger queue (up to 6 inside an /advisor batch) starts the next package as
+one finishes. Worktree isolation keeps packages apart. Within a package the
+stages are serial:
 
 1. Architect: SUB_PLAN for the issue. Post it as an issue comment. On
-   NEEDS_DECISION, park the package (below) and continue the others.
+   NEEDS_DECISION: inside an /advisor batch, decide it yourself when it stays
+   within the signed-off scope, logging the decision on the batch issue;
+   otherwise park the package (below) and continue the others.
 2. Label the issue `in-progress`. Dispatch the developer with the issue
    number and the sub-plan.
 3. On DONE or DONE_WITH_CONCERNS: dispatch the tester with the branch and
@@ -80,6 +84,8 @@ Routing rules:
   park the package.
 - Parking: post the open question or the exact state to the issue or PR,
   swap `in-progress` for `needs-human`, and move on to the other packages.
+- Inside an /advisor batch, mirror lead decisions and package outcomes
+  (PR ready, parked) to the batch tracking issue as they happen.
 
 ## 4. Wave end
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,29 @@ Labels: `in-progress` (package dispatched; resume, do not restart) and
 `needs-human` (parked: question, blocker, or exhausted fix loop), on top of
 the sizing set.
 
+## Operating model (CEO + advisor)
+
+`/advisor` (user-typed only) runs the lead session as the user's advisor: it
+refines a raw need into a batch of work packages, gets one sign-off, then
+runs the team uninterrupted and reports. The full design is
+`docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md`; the
+mechanics live in `.claude/skills/advisor/SKILL.md`. The rules that matter
+session-wide:
+
+- A batch is up to 6 independent `size:S`/`size:M` issues, run through the
+  kickoff pipeline 3 at a time. Merging stays human; dependent work waits
+  for the next batch.
+- One sign-off per batch covers filing the issues and dispatching. Nothing
+  lands on GitHub before it.
+- The escalation line is scope. Within the signed-off scope and acceptance
+  criteria the advisor decides and logs the decision on the batch issue.
+  Scope or acceptance-criteria changes, new dependencies or costs,
+  irreversible or outward-facing actions, and conflicts with
+  `docs/architecture/` park as `needs-human`.
+- Each batch has a tracking issue (title `Batch: <slug>`): the approved
+  contract, the decision log, parked questions, the final report. Dropped
+  sessions resume from it.
+
 ## Model policy
 
 A strong orchestrator with efficient workers. The lever is where each model
@@ -192,7 +215,7 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
 ```
 .claude/
   agents/            role agents: architect, developer, tester, reviewer
-  skills/            project skills, /kickoff
+  skills/            project skills: /advisor, /kickoff
   workflows/         bounded orchestration scripts (review-changes)
   settings.json      project settings; enables the superpowers plugin
 docs/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ ready-made agent team for Claude Code.
 - `.claude/agents/` - four role agents: architect (approach, read-only),
   developer (one issue end to end, worktree-isolated), tester (independent
   verification, read-only), reviewer (spec pass then quality pass, read-only).
+- `.claude/skills/advisor/` - `/advisor`: the operating model on top of the
+  team. Refines a raw need into a batch of work packages, takes one sign-off,
+  runs the batch uninterrupted through the kickoff pipeline, and reports.
+  State lives in a batch tracking issue, so a dropped session resumes. Design:
+  `docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md`.
 - `.claude/skills/kickoff/` - `/kickoff`: fans refined, sized issues out to
   the agent team in parallel waves, through implement, test, and review, to a
   ready PR per issue.
@@ -24,6 +29,9 @@ ready-made agent team for Claude Code.
 - `.claude/skills/sync-template/` - `/sync-template`: pulls later template
   versions into a repo created from this one (machinery copied, prose merged
   by judgment, labels ensured) and opens a PR.
+- `.claude/workflows/` - bounded orchestration scripts. `review-changes`
+  reviews a diff with a fixed set of Sonnet reviewers plus one Opus critic,
+  models pinned in-script so the cost is bounded by construction.
 - `.claude/settings.json` - enables obra's superpowers plugin per project
   (`superpowers@claude-plugins-official`; the methodology skills:
   brainstorming, writing-plans, TDD, verification).

--- a/docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md
+++ b/docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md
@@ -1,7 +1,8 @@
 # Advisor operating model (CEO + advisor + autonomous team)
 
 Status: approved design, 2026-06-12. Grilled and signed off decision by
-decision in session. Implementation pending.
+decision in session. Implemented: `/advisor` skill, CLAUDE.md "Operating
+model" section, /kickoff amendments (issue #36).
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md
+++ b/docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md
@@ -1,0 +1,104 @@
+# Advisor operating model (CEO + advisor + autonomous team)
+
+Status: approved design, 2026-06-12. Grilled and signed off decision by
+decision in session. Implementation pending.
+
+## Goal
+
+Let the user act as CEO: state a need, sign off once, and get 2-4 hours of
+uninterrupted autonomous work back as ready PRs, with every step and decision
+documented. The existing agent team (architect, developer, tester, reviewer
+under /kickoff) stays as the execution layer. The new piece is the advisor:
+a sparring partner that turns raw needs into signed-off work package batches
+and runs them without further interruption.
+
+## Roles
+
+- **CEO (the user).** States needs, signs off batches, merges PRs, decides
+  escalations. May also define packages directly in plan mode and hand them
+  to the advisor ready-made; the advisor then files and dispatches without
+  re-refining.
+- **Advisor (the main session).** Not a subagent. Refines needs with the CEO,
+  proposes batches, files issues, orchestrates /kickoff waves, decides
+  in-scope questions, keeps the batch record, reports.
+- **Team (existing).** architect, developer, tester, reviewer per
+  `.claude/agents/`, orchestrated as in `.claude/skills/kickoff/SKILL.md`.
+
+## Decisions
+
+### 1. Batch = one wave; merging stays human
+
+A signed-off batch contains only independent issues (no `Blocked by:`
+between them), so the run never stalls on a merge. No agent merges to
+`main`; dependent work becomes the seam between batches. "Uninterrupted"
+means within a batch.
+
+Rejected: auto-merging blockers (AI-approved code reaching `main` without
+human eyes), stacked branches (retargeting plumbing, ripple on mid-chain
+changes), full auto-merge.
+
+### 2. Sign-off: approve the proposal, then file
+
+The advisor refines the need, then presents the batch in chat: per package
+a title, scope, acceptance criteria, size, and explicit non-goals. One
+approval covers filing the issues AND dispatching. Nothing lands on GitHub
+before the yes; the CEO decides once per batch.
+
+Refinement depth is proportional: a small need gets a few clarifying
+questions; a feature with design ambiguity gets /grill-me and, if warranted,
+a spec doc first.
+
+### 3. Escalation line: scope
+
+During a run the advisor decides anything within the signed-off scope and
+acceptance criteria (interpretation questions, approach trade-offs,
+arbitrations), logging each decision and its reasoning on the batch issue.
+
+It parks a package (`needs-human`) only for:
+
+- changes to scope or acceptance criteria
+- new dependencies or costs
+- irreversible or outward-facing actions
+- conflicts with decisions in `docs/architecture/`
+
+### 4. Batch tracking issue
+
+Each sign-off creates one GitHub issue for the batch holding: the approved
+proposal (the contract), links to the package issues, every advisor decision
+with reasoning, parked questions, and the final report. A dropped session
+resumes from it. Closed when all batch PRs are merged. Package-level detail
+stays on package issues and PRs as today.
+
+### 5. Capacity: up to 6 packages, 3 concurrent
+
+A batch holds up to 6 independent size:S/M packages, run as a queue with at
+most 3 concurrent (the existing kickoff cap protects context and quota).
+The advisor proposes fewer when the need is small.
+
+### 6. Lifecycle: report, watch, propose next
+
+At batch end the advisor posts the report to the batch issue and the chat
+digest, then subscribes to the batch PRs. Once the CEO merges them, it
+proposes the next batch from the backlog. Dispatch still requires sign-off;
+merging is never implicit approval. A new session reconstructs state from
+the open batch issue.
+
+### 7. Parking pings: hold for the report
+
+Parked packages are logged on the batch issue; the CEO sees them in the
+end-of-batch report. Exception: if ALL packages park, the advisor pings
+immediately, since nothing is progressing.
+
+### 8. Codification
+
+- A new user-invocable skill (working name `/advisor`) encoding the loop:
+  intake, refine, propose, sign-off, file issues + batch issue, run kickoff
+  waves, report, watch.
+- A short "Operating model" section in CLAUDE.md defining the advisor role
+  and the escalation line.
+- Minor /kickoff amendments: batch queue of up to 6, in-scope
+  NEEDS_DECISION routed to the advisor instead of parking, decisions and
+  verdicts mirrored to the batch issue.
+
+Unchanged: the 3-fix-rounds-per-stage cap, the role agents and their model
+routing, sizing rules, and the human merge gate.


### PR DESCRIPTION
Closes #36

Adds the advisor operating model: the lead session as the user's sparring partner that refines a raw need into a signed-off batch of work packages, runs the agent team uninterrupted, and reports. Design was resolved decision by decision in a /grill-me session and is captured in `docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md`.

What's in here:

- `docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md`: the approved design and the rationale per decision.
- `.claude/skills/advisor/SKILL.md` (new, user-invocable): the loop - refine (depth proportional to the need), propose the batch (per package: title, scope, acceptance criteria, size, non-goals), one sign-off, file package issues plus a `Batch:` tracking issue, run the kickoff pipeline as a queue (up to 6 packages, 3 concurrent), report, watch the PRs, resume from the batch issue after a dropped session.
- CLAUDE.md: new "Operating model (CEO + advisor)" section with the session-wide rules, notably the escalation line: in-scope decisions are the advisor's and get logged on the batch issue; scope changes, new dependencies or costs, irreversible or outward-facing actions, and architecture conflicts park as `needs-human`.
- `/kickoff` amendments: batch sign-off replaces the wave-plan confirmation inside an advisor batch, queue beyond 3 packages, in-scope NEEDS_DECISION decided by the lead, decisions and outcomes mirrored to the batch issue.

Unchanged by design: the human merge gate (no agent touches main), the 3-fix-rounds cap, the role agents, and the model routing.

https://claude.ai/code/session_01FwxMoH9ZPZs4kBnwB6Ec2V