### PR TITLE
feat: full-codebase review workflow (/review-codebase)

### DIFF
--- a/.claude/workflows/review-codebase.js
+++ b/.claude/workflows/review-codebase.js
@@ -147,7 +147,10 @@ const map = await agent(
   { label: 'scout', phase: 'Scout', model: 'sonnet', schema: MAP_SCHEMA }
 )
 
-const allAreas = map && Array.isArray(map.areas) ? map.areas : []
+// If the scout fails, no area workers run; flag it so the critic cannot approve
+// a review where only the architecture worker saw the repo.
+const scoutFailed = !map || !Array.isArray(map.areas)
+const allAreas = scoutFailed ? [] : map.areas
 // Hard ceiling: never spawn more than MAX_AREAS area workers, even if the scout
 // returns more. Overflow areas are reported as dropped, not silently lost, so the
 // N + 3 bound holds by construction rather than by the scout obeying the prompt.
@@ -184,6 +187,7 @@ const workersFailed = areas
   .filter((_, i) => !areaResults[i])
   .map((a) => a.name)
   .concat(archResult ? [] : ['architecture'])
+  .concat(scoutFailed ? ['scout (returned no area map; no area workers ran)'] : [])
 
 const raw = areaResults
   .filter(Boolean)
@@ -198,6 +202,9 @@ const suggestedNextAction = ceilingReached
 
 phase('Consolidate')
 const coverageNote =
+  (scoutFailed
+    ? ` CRITICAL: the scout returned no valid area map, so NO area workers ran and only the architecture worker saw the repo. This is a failed, not a clean, review: do not return approve on this basis; report it as incomplete and advise re-running.`
+    : '') +
   (workersFailed.length
     ? ` These workers did not return, so their scope is NOT covered: ${workersFailed.join(', ')}.`
     : '') +

--- a/.claude/workflows/review-codebase.js
+++ b/.claude/workflows/review-codebase.js
@@ -1,0 +1,211 @@
+export const meta = {
+  name: 'review-codebase',
+  description:
+    'Token-bounded full-repo review: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker reviews each area plus one Sonnet architecture worker audits repo-wide structure, and one Opus critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits an expensive session model, and the agent count scales with repo size only up to a hard ceiling.',
+  phases: [
+    { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', model: 'sonnet' },
+    { title: 'Review', detail: 'one Sonnet worker per area plus one architecture worker', model: 'sonnet' },
+    { title: 'Consolidate', detail: 'one Opus critic verifies, writes the report, consolidates', model: 'opus' },
+  ],
+}
+
+// Bounded by construction. The scout sizes the number of areas N to the repo, and
+// the script hard-clamps N to MAX_AREAS, so a run is 1 scout + (N area workers +
+// 1 architecture worker) + 1 critic = N + 3 agents, with N <= MAX_AREAS. The
+// count scales with repo size but never exceeds MAX_AREAS + 3, no matter how
+// large the repo is or how many areas the scout proposes. There is no per-file
+// fan-out and no loop. Models are pinned per stage, so a high-cost session model
+// never leaks into the scout or the workers.
+//
+// When the repo is too big for MAX_AREAS areas to cover, the leftover paths are
+// reported (coverage.ceilingReached, coverage.areasDropped, and a suggested next
+// action), never silently skipped, so the caller can re-run with a higher cap or
+// a scoped path.
+//
+// Invoke with optional args:
+//   Workflow({ name: 'review-codebase', args: { path: 'src', areas: 24 } })
+
+// args may arrive as an object or, depending on the caller, as a JSON string.
+// Normalize so { path, areas } work either way.
+function parseArgs(a) {
+  if (a && typeof a === 'object') return a
+  if (typeof a === 'string' && a.trim()) {
+    try {
+      return JSON.parse(a)
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+const opts = parseArgs(args)
+const root = opts.path || '.'
+const MAX_AREAS = opts.areas || 24
+
+const FINDING = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    area: { type: 'string' },
+    dimension: { type: 'string' },
+    file: { type: 'string' },
+    line: { type: 'string', description: 'line number or range, or "n/a"' },
+    severity: { type: 'string', enum: ['must-fix', 'should-fix', 'nit'] },
+    problem: { type: 'string' },
+    fix: { type: 'string' },
+  },
+  required: ['area', 'dimension', 'file', 'line', 'severity', 'problem', 'fix'],
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { findings: { type: 'array', items: FINDING } },
+  required: ['findings'],
+}
+
+const AREA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    name: { type: 'string' },
+    paths: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'directories or globs that make up this area',
+    },
+    why: { type: 'string', description: 'why this is one coherent area and how it ranks' },
+  },
+  required: ['name', 'paths', 'why'],
+}
+
+const MAP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    areas: { type: 'array', items: AREA },
+    dropped: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'paths left uncovered because the repo exceeded the area ceiling',
+    },
+  },
+  required: ['areas', 'dropped'],
+}
+
+const REPORT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['approve', 'changes-requested'] },
+    summary: { type: 'string' },
+    reportPath: { type: 'string' },
+    mustFix: { type: 'array', items: FINDING },
+    shouldFix: { type: 'array', items: FINDING },
+    nits: { type: 'array', items: FINDING },
+    dismissed: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { problem: { type: 'string' }, why: { type: 'string' } },
+        required: ['problem', 'why'],
+      },
+      description: 'findings judged false-positive or out of scope, with the reason',
+    },
+    coverage: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        areasReviewed: { type: 'array', items: { type: 'string' } },
+        areasDropped: { type: 'array', items: { type: 'string' } },
+        workersFailed: { type: 'array', items: { type: 'string' } },
+        ceilingReached: { type: 'boolean' },
+        suggestedNextAction: {
+          type: 'string',
+          description: 'when ceilingReached, how to cover the rest: re-run with a higher areas cap or a scoped path',
+        },
+      },
+      required: ['areasReviewed', 'areasDropped', 'workersFailed', 'ceilingReached'],
+    },
+  },
+  required: ['verdict', 'summary', 'reportPath', 'mustFix', 'coverage'],
+}
+
+const scope = `Work from the repo root scoped to "${root}". List source files with \`git ls-files -- ${root}\` (it already respects .gitignore); ignore vendored and generated trees (node_modules, dist, build, vendor, .git, coverage) and lockfiles.`
+
+const dimensions = `Review across these dimensions:
+- bugs: adversarial correctness. Logic errors, wrong or missing edge-case handling, broken error paths, races and ordering bugs, off-by-one, misused or wrongly-assumed APIs, null and boundary handling, resource leaks.
+- security: untrusted input reaching a sink (injection, path traversal, SSRF, unsafe deserialization), missing authn or authz, secrets or credentials in code or logs, unsafe defaults, weak crypto, risky dependencies.
+- scope: speculative abstraction, dead configurability, code that could be much smaller.
+- tests: behavior with no test pinning it, logic with a right answer lacking a test, integration points with no fixture coverage.
+- style: project code and writing style (em dashes, AI-cliche phrases, hard-coded user-facing strings, raw primitives where dedicated types exist, comments that restate code).`
+
+phase('Scout')
+const map = await agent(
+  `You map a repository into coherent review areas. You do not review code in this step.\n\n${scope}\n\nFirst gauge the repo's size (for example \`git ls-files -- ${root} | wc -l\`). Then split the files into N coherent areas, where an area is a set of files that belong together (a module, package, or directory subtree) and is small enough to read in one pass. Size N to the repo: make one area per top-level module or per a few thousand lines of related code, using as few areas as cover it well. Do NOT split finer just to use the budget; only a genuinely large codebase should approach ${MAX_AREAS} areas. Return at most ${MAX_AREAS} areas, ranked by importance (size and how central they are to the system). If the repo is larger than ${MAX_AREAS} areas can cover at a readable size, return the ${MAX_AREAS} most important and put every path you cannot fit in "dropped" so it is reported, not lost. Return areas (name, paths, why) and dropped.`,
+  { label: 'scout', phase: 'Scout', model: 'sonnet', schema: MAP_SCHEMA }
+)
+
+const allAreas = map && Array.isArray(map.areas) ? map.areas : []
+// Hard ceiling: never spawn more than MAX_AREAS area workers, even if the scout
+// returns more. Overflow areas are reported as dropped, not silently lost, so the
+// N + 3 bound holds by construction rather than by the scout obeying the prompt.
+const areas = allAreas.slice(0, MAX_AREAS)
+const scoutDropped = (map && Array.isArray(map.dropped) ? map.dropped : []).concat(
+  allAreas.slice(MAX_AREAS).map((a) => a.name)
+)
+
+phase('Review')
+const repoMap = areas.map((a) => `- ${a.name}: ${a.paths.join(', ')}`).join('\n')
+
+const reviewThunks = areas.map((a) => () =>
+  agent(
+    `You review one area of a codebase and report findings only. You never edit.\n\nArea: ${a.name}\nPaths: ${a.paths.join(', ')}\n\nRead these files in full, with surrounding context where needed. ${dimensions}\n\nReport every finding with area ("${a.name}"), dimension, file, line, severity (must-fix | should-fix | nit), the problem, and the required fix. If the area is clean, return an empty findings array. Stay within your area.`,
+    { label: `area:${a.name}`, phase: 'Review', model: 'sonnet', schema: FINDINGS_SCHEMA }
+  )
+)
+
+reviewThunks.push(() =>
+  agent(
+    `You audit a repository's structure and report findings only. You never edit. Use dimension "architecture".\n\n${scope}\n\nRead the directory layout, module boundaries, imports, and dependency manifests. Read signatures and imports rather than full file bodies, so you can hold the whole tree in view. The area map is:\n${repoMap}\n\nFlag: module boundaries and layering that have drifted, the same logic duplicated across modules, dead or orphaned code, dependency health (unused, outdated, risky), and test-coverage gaps at the suite level. Report each finding with area (the module name or "repo"), dimension ("architecture"), file, line or "n/a", severity, the problem, and the fix.`,
+    { label: 'architecture', phase: 'Review', model: 'sonnet', schema: FINDINGS_SCHEMA }
+  )
+)
+
+const reviews = await parallel(reviewThunks)
+const areaResults = reviews.slice(0, areas.length)
+const archResult = reviews[areas.length]
+
+// parallel() null-pads a worker that errors or is skipped. Track which workers
+// actually returned so the critic knows where coverage is partial.
+const reviewedAreas = areas.filter((_, i) => areaResults[i]).map((a) => a.name)
+const workersFailed = areas
+  .filter((_, i) => !areaResults[i])
+  .map((a) => a.name)
+  .concat(archResult ? [] : ['architecture'])
+
+const raw = areaResults
+  .filter(Boolean)
+  .flatMap((r) => r.findings)
+  .concat(archResult ? archResult.findings : [])
+
+// The repo did not fit the ceiling: surface it loudly so the caller can act.
+const ceilingReached = scoutDropped.length > 0
+const suggestedNextAction = ceilingReached
+  ? `Coverage is partial: ${scoutDropped.length} path(s) exceeded the ${MAX_AREAS}-area ceiling and were not reviewed. Re-run with a higher cap (args.areas: ${MAX_AREAS * 2}) or scope follow-up runs to the leftover with args.path. Uncovered: ${scoutDropped.join(', ')}.`
+  : ''
+
+phase('Consolidate')
+const coverageNote =
+  (workersFailed.length
+    ? ` These workers did not return, so their scope is NOT covered: ${workersFailed.join(', ')}.`
+    : '') +
+  (ceilingReached ? ` COVERAGE IS PARTIAL. ${suggestedNextAction}` : '')
+
+const report = await agent(
+  `You are the senior reviewer consolidating a full-codebase review. The workers below produced the raw findings.${coverageNote}\n\nVerify each finding against the actual code, drop false positives and anything out of scope, merge duplicates (including the same problem found in two areas), and set a final severity. You may add a finding only if it is a clear must-fix the workers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nThen write the report file. Run \`date +%F\` for today's date, make the reviews/ directory if it does not exist, and write reviews/<date>-codebase-review.md with: the verdict and summary first; then, if coverage is partial, a prominent "Coverage: PARTIAL" callout immediately after the verdict that states how many paths were not reviewed and the suggested next action; then the must-fix, should-fix, and nit findings grouped by area; then a final "Coverage" section listing the areas reviewed, the paths not covered, the workers that failed, and (if partial) the suggested next action. Set reportPath to the file you wrote.\n\nReturn the structured summary. Set coverage.areasReviewed to ${JSON.stringify(reviewedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}, and coverage.suggestedNextAction to ${JSON.stringify(suggestedNextAction)}.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
+  { label: 'consolidate', phase: 'Consolidate', model: 'opus', schema: REPORT_SCHEMA }
+)
+
+return report

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .claude/settings.local.json
+/reviews/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,11 @@ runs, not raw effort everywhere.
   `.claude/workflows/` is the worked example: a fixed set of Sonnet reviewers
   plus one Opus critic, bounded by construction so it cannot fan out into the
   100-agent review that an unpinned session model produces.
+  `review-codebase` applies the same discipline to a whole-repo audit: a Sonnet
+  scout splits the repo into N areas (sized to the repo, capped at a ceiling),
+  Sonnet workers review each area plus repo-wide structure, and one Opus critic
+  consolidates. The agent count is N + 3, so it scales with repo size up to the
+  ceiling and never fans out unboundedly.
 - Do not set `CLAUDE_CODE_SUBAGENT_MODEL`. It overrides both the per-call model
   and the frontmatter `model:`, flattening every subagent to one model and
   defeating the split above. Use it only as a temporary per-session seatbelt
@@ -216,7 +221,7 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
 .claude/
   agents/            role agents: architect, developer, tester, reviewer
   skills/            project skills: /advisor, /kickoff
-  workflows/         bounded orchestration scripts (review-changes)
+  workflows/         bounded orchestration scripts (review-changes, review-codebase)
   settings.json      project settings; enables the superpowers plugin
 docs/
   architecture/      stack and policy decisions, data model, domain math

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ ready-made agent team for Claude Code.
   versions into a repo created from this one (machinery copied, prose merged
   by judgment, labels ensured) and opens a PR.
 - `.claude/workflows/` - bounded orchestration scripts. `review-changes`
-  reviews a diff with a fixed set of Sonnet reviewers plus one Opus critic,
-  models pinned in-script so the cost is bounded by construction.
+  reviews a diff with a fixed set of Sonnet reviewers plus one Opus critic;
+  `review-codebase` audits the whole repo with a Sonnet scout that splits it into
+  areas (scaled to the repo, capped at a ceiling), per-area Sonnet workers, an
+  architecture worker, and one Opus critic. Both pin models in-script so the cost
+  is bounded by construction.
 - `.claude/settings.json` - enables obra's superpowers plugin per project
   (`superpowers@claude-plugins-official`; the methodology skills:
   brainstorming, writing-plans, TDD, verification).

--- a/docs/plans/37-review-codebase.md
+++ b/docs/plans/37-review-codebase.md
@@ -1,0 +1,378 @@
+# review-codebase Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `/review-codebase` workflow that audits an entire repo (defects and structure), bounded by construction and model-pinned per stage, producing a dated markdown report.
+
+**Architecture:** A Sonnet scout maps the repo into at most N coherent areas (default 8). One Sonnet worker reviews each area in depth plus one Sonnet architecture worker audits repo-wide structure, all in one parallel barrier. One Opus critic verifies, dedups, writes the report file, and returns a structured summary. Agents per run = N + 3, independent of repo size.
+
+**Tech Stack:** Claude Code Workflow runtime (plain JS, ESM-style `export const meta` plus a top-level `return`). Models pinned in-script (Sonnet workers, Opus critic). No external dependencies. Spec: `docs/superpowers/specs/2026-06-13-review-codebase-design.md`.
+
+---
+
+## Testing approach (read first)
+
+This repo has no JS toolchain and no unit-test harness (`review-changes` ships none). Workflow scripts run only inside the Claude Code workflow runtime: they use runtime-injected globals (`agent`, `parallel`, `phase`, `args`) and a top-level `return`, so `node --check` cannot even parse them (the top-level return is illegal outside the runtime's function wrapper). 
+
+The authoritative test is a live run, the same gate `review-changes` and the repo's own CLAUDE.md rely on ("e2e is the safety net unit tests cannot be"). So the order is: write the whole script, run it once on this repo to confirm it works and stays bounded, and only then commit. That is test-then-commit, with an e2e run standing in for the unit test.
+
+## File structure
+
+- Create: `.claude/workflows/review-codebase.js` - the workflow. One file, one responsibility, sibling to `review-changes.js`. Around 150 lines.
+- Modify: `CLAUDE.md` - two one-line touch-ups (model-policy worked example, repo-layout workflow list).
+- Modify: `.gitignore` - ignore generated `reviews/` output.
+- No change needed: `.claude/skills/sync-template/SKILL.md` already copies `.claude/workflows/`, so the new workflow propagates to downstream repos automatically.
+
+## Conventions to match (from review-changes.js)
+
+- `export const meta` with `name`, `description`, and a `phases` array; each phase carries `title`, `detail`, and `model`.
+- Schemas are plain JSON Schema objects with `additionalProperties: false` and explicit `required`.
+- Each `agent()` call passes `{ label, phase, model, schema }`. Workers are pinned `sonnet`, the critic `opus`.
+- Coverage is tracked by detecting null-padded entries from `parallel()` (a worker that errors or is skipped resolves to `null`), so the critic is told what was not covered. This mirrors the existing review-changes coverage handling.
+
+---
+
+## Task 1: Implement the review-codebase workflow
+
+**Files:**
+- Create: `.claude/workflows/review-codebase.js`
+
+Write the file in four contiguous blocks (meta + args + schemas, then scout, then review, then consolidate). The complete file is below; add it in order so the script reads top to bottom.
+
+- [ ] **Step 1: Write meta, args, and schemas**
+
+```js
+export const meta = {
+  name: 'review-codebase',
+  description:
+    'Token-bounded full-repo review: a Sonnet scout maps the repo into a capped set of areas, Sonnet workers review each area plus repo-wide structure, and one Opus critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits an expensive session model and the agent count does not grow with repo size.',
+  phases: [
+    { title: 'Scout', detail: 'one Sonnet agent maps the repo into <=N areas', model: 'sonnet' },
+    { title: 'Review', detail: 'one Sonnet worker per area plus one architecture worker', model: 'sonnet' },
+    { title: 'Consolidate', detail: 'one Opus critic verifies, writes the report, consolidates', model: 'opus' },
+  ],
+}
+
+// Bounded by construction. The scout caps the number of areas at CAP, so a run is
+// exactly 1 scout + (CAP area workers + 1 architecture worker) + 1 critic = CAP + 3
+// agents, regardless of repo size. There is no per-file fan-out and no loop.
+// Models are pinned per stage, so a Fable or Opus session never leaks into the
+// scout or the workers.
+//
+// Invoke with optional args:
+//   Workflow({ name: 'review-codebase', args: { path: 'src', areas: 8 } })
+
+const root = (args && args.path) || '.'
+const CAP = (args && args.areas) || 8
+
+const FINDING = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    area: { type: 'string' },
+    dimension: { type: 'string' },
+    file: { type: 'string' },
+    line: { type: 'string', description: 'line number or range, or "n/a"' },
+    severity: { type: 'string', enum: ['must-fix', 'should-fix', 'nit'] },
+    problem: { type: 'string' },
+    fix: { type: 'string' },
+  },
+  required: ['area', 'dimension', 'file', 'line', 'severity', 'problem', 'fix'],
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { findings: { type: 'array', items: FINDING } },
+  required: ['findings'],
+}
+
+const AREA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    name: { type: 'string' },
+    paths: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'directories or globs that make up this area',
+    },
+    why: { type: 'string', description: 'why this is one coherent area and how it ranks' },
+  },
+  required: ['name', 'paths', 'why'],
+}
+
+const MAP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    areas: { type: 'array', items: AREA },
+    dropped: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'paths left uncovered because the area cap was reached',
+    },
+  },
+  required: ['areas', 'dropped'],
+}
+
+const REPORT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['approve', 'changes-requested'] },
+    summary: { type: 'string' },
+    reportPath: { type: 'string' },
+    mustFix: { type: 'array', items: FINDING },
+    shouldFix: { type: 'array', items: FINDING },
+    nits: { type: 'array', items: FINDING },
+    dismissed: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { problem: { type: 'string' }, why: { type: 'string' } },
+        required: ['problem', 'why'],
+      },
+      description: 'findings judged false-positive or out of scope, with the reason',
+    },
+    coverage: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        areasReviewed: { type: 'array', items: { type: 'string' } },
+        areasDropped: { type: 'array', items: { type: 'string' } },
+        workersFailed: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['areasReviewed', 'areasDropped', 'workersFailed'],
+    },
+  },
+  required: ['verdict', 'summary', 'reportPath', 'mustFix', 'coverage'],
+}
+
+const scope = `Work from the repo root scoped to "${root}". List source files with \`git ls-files -- ${root}\` (it already respects .gitignore); ignore vendored and generated trees (node_modules, dist, build, vendor, .git, coverage) and lockfiles.`
+
+const dimensions = `Review across these dimensions:
+- bugs: adversarial correctness. Logic errors, wrong or missing edge-case handling, broken error paths, races and ordering bugs, off-by-one, misused or wrongly-assumed APIs, null and boundary handling, resource leaks.
+- security: untrusted input reaching a sink (injection, path traversal, SSRF, unsafe deserialization), missing authn or authz, secrets or credentials in code or logs, unsafe defaults, weak crypto, risky dependencies.
+- scope: speculative abstraction, dead configurability, code that could be much smaller.
+- tests: behavior with no test pinning it, logic with a right answer lacking a test, integration points with no fixture coverage.
+- style: project code and writing style (em dashes, AI-cliche phrases, hard-coded user-facing strings, raw primitives where dedicated types exist, comments that restate code).`
+```
+
+- [ ] **Step 2: Append the scout stage**
+
+```js
+phase('Scout')
+const map = await agent(
+  `You map a repository into coherent review areas. You do not review code in this step.\n\n${scope}\n\nGroup the files into at most ${CAP} areas. An area is a set of files that belong together (a module, package, or directory subtree) and is small enough to read in one pass. Rank areas by importance: size and how central they are to the system. If the repo needs more than ${CAP} areas to cover fully, cover the ${CAP} most important and put every path you leave out in "dropped". Return areas (name, paths, why) and dropped.`,
+  { label: 'scout', phase: 'Scout', model: 'sonnet', schema: MAP_SCHEMA }
+)
+
+const areas = map && Array.isArray(map.areas) ? map.areas : []
+const scoutDropped = map && Array.isArray(map.dropped) ? map.dropped : []
+```
+
+- [ ] **Step 3: Append the review stage**
+
+```js
+phase('Review')
+const repoMap = areas.map((a) => `- ${a.name}: ${a.paths.join(', ')}`).join('\n')
+
+const reviewThunks = areas.map((a) => () =>
+  agent(
+    `You review one area of a codebase and report findings only. You never edit.\n\nArea: ${a.name}\nPaths: ${a.paths.join(', ')}\n\nRead these files in full, with surrounding context where needed. ${dimensions}\n\nReport every finding with area ("${a.name}"), dimension, file, line, severity (must-fix | should-fix | nit), the problem, and the required fix. If the area is clean, return an empty findings array. Stay within your area.`,
+    { label: `area:${a.name}`, phase: 'Review', model: 'sonnet', schema: FINDINGS_SCHEMA }
+  )
+)
+
+reviewThunks.push(() =>
+  agent(
+    `You audit a repository's structure and report findings only. You never edit. Use dimension "architecture".\n\n${scope}\n\nRead the directory layout, module boundaries, imports, and dependency manifests. Read signatures and imports rather than full file bodies, so you can hold the whole tree in view. The area map is:\n${repoMap}\n\nFlag: module boundaries and layering that have drifted, the same logic duplicated across modules, dead or orphaned code, dependency health (unused, outdated, risky), and test-coverage gaps at the suite level. Report each finding with area (the module name or "repo"), dimension ("architecture"), file, line or "n/a", severity, the problem, and the fix.`,
+    { label: 'architecture', phase: 'Review', model: 'sonnet', schema: FINDINGS_SCHEMA }
+  )
+)
+
+const reviews = await parallel(reviewThunks)
+const areaResults = reviews.slice(0, areas.length)
+const archResult = reviews[areas.length]
+
+// parallel() null-pads a worker that errors or is skipped. Track which workers
+// actually returned so the critic knows where coverage is partial.
+const reviewedAreas = areas.filter((_, i) => areaResults[i]).map((a) => a.name)
+const workersFailed = areas
+  .filter((_, i) => !areaResults[i])
+  .map((a) => a.name)
+  .concat(archResult ? [] : ['architecture'])
+
+const raw = areaResults
+  .filter(Boolean)
+  .flatMap((r) => r.findings)
+  .concat(archResult ? archResult.findings : [])
+```
+
+- [ ] **Step 4: Append the consolidate stage and return**
+
+```js
+phase('Consolidate')
+const coverageNote =
+  (workersFailed.length
+    ? ` These workers did not return, so their scope is NOT covered: ${workersFailed.join(', ')}.`
+    : '') +
+  (scoutDropped.length
+    ? ` The scout could not fit the whole repo in ${CAP} areas; these paths were not reviewed: ${scoutDropped.join(', ')}.`
+    : '')
+
+const report = await agent(
+  `You are the senior reviewer consolidating a full-codebase review. The workers below produced the raw findings.${coverageNote}\n\nVerify each finding against the actual code, drop false positives and anything out of scope, merge duplicates (including the same problem found in two areas), and set a final severity. You may add a finding only if it is a clear must-fix the workers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nThen write the report file. Run \`date +%F\` for today's date, make the reviews/ directory if it does not exist, and write reviews/<date>-codebase-review.md: verdict and summary first, then must-fix, should-fix, and nit findings grouped by area, then a final "Coverage" section listing the areas reviewed, the paths the scout dropped, and the workers that failed. Set reportPath to the file you wrote.\n\nReturn the structured summary. Set coverage.areasReviewed to ${JSON.stringify(reviewedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, and coverage.workersFailed to ${JSON.stringify(workersFailed)}.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
+  { label: 'consolidate', phase: 'Consolidate', model: 'opus', schema: REPORT_SCHEMA }
+)
+
+return report
+```
+
+- [ ] **Step 5: Re-read the whole file**
+
+Read `.claude/workflows/review-codebase.js` start to finish. Confirm braces, parens, and template-literal backticks are balanced, the four blocks are in order, and every schema referenced (`MAP_SCHEMA`, `FINDINGS_SCHEMA`, `REPORT_SCHEMA`) is defined above its use. Do not commit yet; validation is Task 2.
+
+## Task 2: Validate by live run, then commit
+
+**Files:** none changed; this is the green gate.
+
+- [ ] **Step 1: Run the workflow on this repo**
+
+Invoke via the Workflow tool:
+
+```
+Workflow({ name: 'review-codebase' })
+```
+
+Expected:
+- The progress tree shows three phases: `Scout` (1 agent), `Review` (areas + 1 agents), `Consolidate` (1 agent).
+- Total agents = number of areas + 3. On this small template repo expect a handful of areas (for example `.claude/agents`, `.claude/skills`, `.claude/workflows`, `docs`), so well under the cap, and `dropped` empty.
+- A file `reviews/<today>-codebase-review.md` exists, grouped by severity then area, ending with a Coverage section.
+- The returned object validates against `REPORT_SCHEMA` (has `verdict`, `summary`, `reportPath`, `mustFix`, `coverage`).
+
+- [ ] **Step 2: Confirm the report file landed**
+
+Run: `ls reviews/ && head -40 reviews/*-codebase-review.md`
+Expected: the dated report prints, with a verdict line and findings.
+
+If no file was written, the consolidate agent lacks file tools in this runtime. Fallback: add a `markdown` string field to `REPORT_SCHEMA`, have the critic return the rendered report instead of writing it, and write the file from the returned `markdown` in the session that invoked the workflow. Re-run Step 1.
+
+- [ ] **Step 3: Exercise the cap and coverage path**
+
+Run: `Workflow({ name: 'review-codebase', args: { areas: 2 } })`
+Expected: the scout returns 2 areas and a non-empty `dropped`; the report's Coverage section lists the dropped paths; `coverage.areasDropped` is non-empty. This proves coverage is never silently truncated.
+
+- [ ] **Step 4: Commit the workflow**
+
+```bash
+git add .claude/workflows/review-codebase.js
+git commit -m "feat: add bounded full-codebase review workflow
+
+review-changes only sees the branch diff. review-codebase audits the whole
+repo for defects and structure while staying bounded: a Sonnet scout caps
+the repo at N areas, Sonnet workers review each area plus repo-wide
+structure, and an Opus critic writes a dated report. Agents per run are
+N + 3 regardless of repo size.
+
+Closes #37
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+## Task 3: Update docs and gitignore
+
+**Files:**
+- Modify: `CLAUDE.md` (model-policy worked example; repo-layout workflow list)
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Extend the model-policy worked example**
+
+In `CLAUDE.md`, the "Model policy" section, find the Workflows bullet that ends:
+
+```
+  `.claude/workflows/` is the worked example: a fixed set of Sonnet reviewers
+  plus one Opus critic, bounded by construction so it cannot fan out into the
+  100-agent review that an unpinned session model produces.
+```
+
+Append one sentence to that bullet:
+
+```
+  `review-codebase` applies the same discipline to a whole-repo audit: a Sonnet
+  scout caps the repo at N areas, Sonnet workers review each area plus repo-wide
+  structure, and one Opus critic consolidates, so the agent count is N + 3
+  regardless of repo size.
+```
+
+- [ ] **Step 2: Update the repo-layout workflow list**
+
+In the "Repo layout" code block, change:
+
+```
+  workflows/         bounded orchestration scripts (review-changes)
+```
+
+to:
+
+```
+  workflows/         bounded orchestration scripts (review-changes, review-codebase)
+```
+
+- [ ] **Step 3: Ignore generated review output**
+
+Append to `.gitignore`:
+
+```
+/reviews/
+```
+
+Reasoning: the report is a generated artifact, like a build output. Keeping `reviews/` untracked stops audits from being committed by accident here and in downstream repos. A user who wants to keep a specific report can `git add -f` it.
+
+- [ ] **Step 4: Confirm sync-template needs no change**
+
+Run: `grep -n "workflows" .claude/skills/sync-template/SKILL.md`
+Expected: the machinery copy list already includes `.claude/workflows/`. No edit needed; the new workflow propagates on the next `/sync-template`.
+
+- [ ] **Step 5: Commit the docs**
+
+```bash
+git add CLAUDE.md .gitignore
+git commit -m "docs: list review-codebase in model policy and repo layout
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+## Task 4: Open the PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/37-review-codebase
+```
+
+- [ ] **Step 2: Open a PR linking the issue**
+
+```bash
+gh pr create --title "feat: full-codebase review workflow (/review-codebase)" \
+  --body "Adds a bounded, model-pinned /review-codebase workflow (scout + capped area workers + architecture worker + Opus critic) that audits the whole repo and writes a dated report. Verified by live runs (default and areas:2 to exercise the coverage path).
+
+Spec: docs/superpowers/specs/2026-06-13-review-codebase-design.md
+Plan: docs/plans/37-review-codebase.md
+
+Closes #37"
+```
+
+Note: pushing and opening a PR are outward-facing. Confirm with the user before running Task 4 if they have not already authorized it.
+
+---
+
+## Self-review (filled in during planning)
+
+- **Spec coverage:** Scout, area workers, architecture worker, and Opus critic are all in Task 1. The N+3 bound is asserted in Task 2 Step 1. The markdown report and coverage section are in Task 1 Step 4 and verified in Task 2 Steps 2-3. The CLAUDE.md and sync-template notes from the spec are Task 3. The `area`/`dimension` finding fields and the `coverage`/`reportPath` summary fields are in the Task 1 schemas. The "verified by live run" decision matches the spec's testing note. No spec section is left unimplemented.
+- **Placeholder scan:** No TBD/TODO. Every code step shows complete code; every command shows expected output.
+- **Type/name consistency:** `MAP_SCHEMA`, `FINDINGS_SCHEMA`, `REPORT_SCHEMA`, `FINDING`, `AREA` are defined once and referenced consistently. `areas`, `areaResults`, `archResult`, `reviewedAreas`, `workersFailed`, `scoutDropped`, `raw`, `repoMap`, `coverageNote` are each defined before use. The phase names (`Scout`, `Review`, `Consolidate`) match `meta.phases`.

--- a/docs/plans/37-review-codebase.md
+++ b/docs/plans/37-review-codebase.md
@@ -10,6 +10,21 @@
 
 ---
 
+## Design updates after planning
+
+During implementation the design evolved per discussion and supersedes the code
+blocks below where they differ. The shipped `.claude/workflows/review-codebase.js`
+and the updated spec are canonical:
+
+- The area count is a ceiling (`MAX_AREAS`, default 24), not a fixed cap of 8. The
+  scout sizes N to the repo and the script hard-clamps with
+  `areas.slice(0, MAX_AREAS)`, so N + 3 holds by construction and scales with repo
+  size up to MAX_AREAS + 3.
+- When the repo exceeds the ceiling, the shortfall is reported
+  (`coverage.ceilingReached`, `areasDropped`, `suggestedNextAction`), never
+  silently dropped.
+- `args` is normalized for both object and JSON-string callers.
+
 ## Testing approach (read first)
 
 This repo has no JS toolchain and no unit-test harness (`review-changes` ships none). Workflow scripts run only inside the Claude Code workflow runtime: they use runtime-injected globals (`agent`, `parallel`, `phase`, `args`) and a top-level `return`, so `node --check` cannot even parse them (the top-level return is illegal outside the runtime's function wrapper). 

--- a/docs/superpowers/specs/2026-06-13-review-codebase-design.md
+++ b/docs/superpowers/specs/2026-06-13-review-codebase-design.md
@@ -66,8 +66,9 @@ consolidate (opus, 1 agent)
   write the markdown report, return a structured summary
 ```
 
-Every worker receives the scout's repo-map for global context. Scout and all
-workers are pinned to Sonnet (cheap, parallel). The critic is pinned to Opus
+The architecture worker receives the scout's repo-map for global context; area
+workers receive only their own name and paths. Scout and all workers are pinned
+to Sonnet (cheap, parallel). The critic is pinned to Opus
 (synthesis and judgment). This is the model split the CLAUDE.md model policy
 prescribes; review-codebase becomes a second worked example next to
 review-changes.
@@ -93,12 +94,20 @@ review-changes.
 ## Bounding guarantee
 
 Agents per run = 1 (scout) + (N + 1) (area workers + architecture worker) + 1
-(critic) = N + 3. With the default cap N = 8 that is 11 agents. The cap is
-enforced by the scout, there is no per-file fan-out and no loop, so the count
-cannot grow with repo size. When the repo has more areas than the cap, the scout
-records the remainder in `dropped[]` and the critic reports it. Coverage is never
-silently truncated, matching the recent review-changes fix that flags uncovered
-dimensions when a worker fails to return.
+(critic) = N + 3. N is the number of areas, sized by the scout to the repo and
+hard-clamped in-script to a ceiling `MAX_AREAS` (default 24), so the count scales
+with repo size but never exceeds MAX_AREAS + 3 (27 by default). A small repo uses
+far fewer; the scout is told to size N to the codebase, not pad to the ceiling.
+There is no per-file fan-out and no loop. The ceiling is overridable per run via
+`args.areas`.
+
+The clamp is structural (`areas.slice(0, MAX_AREAS)`), so the bound holds even if
+the scout returns more areas than asked. When the repo is too big for MAX_AREAS
+areas, the leftover is reported, not silently skipped: `coverage.ceilingReached`
+is set, `coverage.areasDropped` lists the uncovered paths, and
+`coverage.suggestedNextAction` tells the caller to re-run with a higher `areas`
+cap or a scoped `path`. This is the same no-silent-truncation discipline as the
+review-changes coverage fix.
 
 ## What each reviewer looks for
 
@@ -142,8 +151,9 @@ workers) and `reportPath`.
   writes the report file itself, since the script cannot. Area and architecture
   workers stay read-only.
 - Optional args: `path` (scope to a subdirectory, default the whole repo),
-  `areas` (override the cap, default 8). Both have safe defaults so `/review-codebase`
-  with no args works in any repo.
+  `areas` (override the ceiling, default 24). args may arrive as an object or, via
+  some callers, as a JSON string, so the script normalizes both. Both have safe
+  defaults so `/review-codebase` with no args works in any repo.
 
 ## Template and process notes
 

--- a/docs/superpowers/specs/2026-06-13-review-codebase-design.md
+++ b/docs/superpowers/specs/2026-06-13-review-codebase-design.md
@@ -1,0 +1,164 @@
+# review-codebase workflow - design
+
+Date: 2026-06-13
+Status: approved (brainstorming), ready for implementation plan
+
+## Context
+
+`/review-changes` reviews the branch diff: a fixed set of Sonnet workers, one per
+dimension, plus one Opus critic. It is bounded because a diff is small. It cannot
+see anything the diff does not touch.
+
+Sometimes a full pass over the whole codebase is needed, not just the branch:
+auditing an inherited or drifting repo, a pre-release sweep, or finding latent
+defects and structural problems that no recent diff would surface.
+
+A naive "review everything" is unbounded. A whole repo does not fit one agent's
+context, and the dimension-per-worker shape of review-changes does not scale (a
+single "bugs" worker cannot read an entire repo). This workflow ships in the
+template and runs in downstream repos of unknown size, so the bound has to hold
+regardless of how large the target repo is.
+
+## Goals
+
+- A `/review-codebase` workflow that reviews an entire repo (or a named subtree).
+- Bounded by construction and model-pinned per stage, the same discipline as
+  `review-changes`, so it never inherits an expensive session model or fans out
+  into a 100-agent review.
+- Surfaces both latent defects and whole-repo structural problems.
+- Produces a durable, dated markdown report plus a short chat summary.
+
+## Non-goals
+
+- No GitHub issue creation. Turn must-fix findings into issues with `/to-issues`
+  afterward.
+- No auto-fix. Workers are read-only; the only file written is the report.
+- No per-file fan-out, no loops, no history or blame analysis.
+
+## Decisions
+
+Three choices were settled during brainstorming:
+
+1. Focus: both defects and structure (not just the review-changes lens, not
+   structure-only).
+2. Bounding: a scout maps the repo into a capped set of areas; one worker reviews
+   each area in depth, plus one dedicated worker audits repo-wide structure.
+3. Output: a markdown report file plus a chat summary.
+
+## Architecture
+
+Four stages. The fan-out unit is the repo area, not the dimension.
+
+```
+scout (sonnet, 1 agent)
+  git ls-files, skip vendored/build dirs, group into <=N coherent areas
+  ranked by importance; emit areas[] + dropped[] (overflow beyond the cap)
+
+review (parallel, sonnet):
+  area#1 ... area#N   depth: each reads its area's files in full and reviews
+                      the defect checklist, returning findings
+  architecture        breadth: reads layout, imports, manifests, and
+                      duplication / dead-code suspects from signatures and
+                      the scout map, not full file bodies
+
+consolidate (opus, 1 agent)
+  verify, dedup (including cross-area), set severities, decide verdict,
+  write the markdown report, return a structured summary
+```
+
+Every worker receives the scout's repo-map for global context. Scout and all
+workers are pinned to Sonnet (cheap, parallel). The critic is pinned to Opus
+(synthesis and judgment). This is the model split the CLAUDE.md model policy
+prescribes; review-codebase becomes a second worked example next to
+review-changes.
+
+### Stages in detail
+
+- Scout (Sonnet): enumerates source files via `git ls-files`, skips vendored and
+  build directories (node_modules, dist, build, vendor, .git, and similar),
+  groups files into at most N coherent areas (by module and directory, sized to
+  fit a worker's context), and ranks areas by importance (size and centrality).
+  Returns `areas[]` (name, paths/globs, rationale) and `dropped[]` (anything not
+  assigned because the repo exceeded the cap). Schema-validated.
+- Area workers (Sonnet, one per area): read the area's files in full and report
+  findings across the defect checklist. Read-only.
+- Architecture worker (Sonnet, one): reviews the repo at the structural level
+  using signatures, imports, manifests, and the scout map rather than full
+  bodies, so it fits context. Read-only.
+- Critic (Opus, one): verifies findings against the code, drops false positives
+  and out-of-scope items, merges duplicates (including the same problem found in
+  two areas), sets final severities, decides the verdict, writes the report file,
+  and returns the structured summary.
+
+## Bounding guarantee
+
+Agents per run = 1 (scout) + (N + 1) (area workers + architecture worker) + 1
+(critic) = N + 3. With the default cap N = 8 that is 11 agents. The cap is
+enforced by the scout, there is no per-file fan-out and no loop, so the count
+cannot grow with repo size. When the repo has more areas than the cap, the scout
+records the remainder in `dropped[]` and the critic reports it. Coverage is never
+silently truncated, matching the recent review-changes fix that flags uncovered
+dimensions when a worker fails to return.
+
+## What each reviewer looks for
+
+Area workers reuse the five review-changes dimensions, worded for whole files
+rather than a diff, reusing the existing briefs where possible for consistency:
+
+- bugs (adversarial correctness, edge cases, error paths, races, resource leaks)
+- security (untrusted input to a sink, authn/authz gaps, secrets, weak crypto,
+  dependency risk)
+- scope and simplicity (speculative abstraction, dead configurability, code that
+  could be much smaller)
+- tests (behavior with no test pinning it, logic lacking a test, untested
+  integration points)
+- style (CLAUDE.md code and writing style)
+
+The architecture worker covers the whole-repo concerns a diff cannot show:
+
+- module boundaries and layering, and where they have drifted
+- duplication across modules
+- dead or orphaned code
+- dependency health (unused, outdated, or risky dependencies)
+- test-coverage gaps at the suite level
+
+## Report contract
+
+The critic writes `reviews/<YYYY-MM-DD>-codebase-review.md`, grouped by severity
+then area, ending with a coverage section that lists areas reviewed, areas
+dropped by the cap, and any worker that failed to return. The chat shows a short
+verdict and summary plus the report path.
+
+The finding shape reuses the review-changes `FINDING` (file, line, severity,
+problem, fix) and adds `area` and `dimension`. The returned summary reuses the
+review-changes `REPORT_SCHEMA` shape (verdict, summary, mustFix, shouldFix, nits,
+dismissed) and adds a `coverage` object (areas reviewed, areas dropped, failed
+workers) and `reportPath`.
+
+## Mechanics and constraints
+
+- Workflow scripts cannot call `Date.now()` or touch the filesystem. The report
+  date is stamped by the critic agent (it runs `date +%F`), and the critic agent
+  writes the report file itself, since the script cannot. Area and architecture
+  workers stay read-only.
+- Optional args: `path` (scope to a subdirectory, default the whole repo),
+  `areas` (override the cap, default 8). Both have safe defaults so `/review-codebase`
+  with no args works in any repo.
+
+## Template and process notes
+
+- The workflow lives at `.claude/workflows/review-codebase.js`. It must be synced
+  to consumers with `/sync-template`.
+- CLAUDE.md needs a one-line addition in the model-policy section (review-codebase
+  as a second bounded example) and in the workflow list.
+- Per the repo process this is a GitHub issue first. It fits the
+  `feat/33-efficient-model-routing` theme or stands as its own issue, then spec
+  (this document) to plan to implementation.
+- Verification is a real run of `/review-codebase` on this template repo,
+  confirming the agent count stays at N + 3 and the report is coherent. JS
+  workflows have no unit-test harness, so the run is the test.
+
+## Out of scope
+
+GitHub issue creation, auto-fix, per-file fan-out, and history or blame analysis
+are deliberately excluded. The report is the deliverable.


### PR DESCRIPTION
## What

Adds `/review-codebase`, a bounded, model-pinned full-repo review workflow, sibling to `review-changes` (which only sees the branch diff).

## Design

- A Sonnet **scout** splits the repo into N coherent areas, sized to the repo and hard-clamped to a ceiling (`MAX_AREAS`, default 24, overridable via `args.areas`).
- One Sonnet **worker per area** reviews defects (bugs, security, scope, tests, style); one Sonnet **architecture worker** audits repo-wide structure (boundaries, duplication, dead code, dependency health, coverage gaps).
- One Opus **critic** verifies, dedups, writes a dated report to `reviews/<date>-codebase-review.md`, and returns a structured summary.
- Bound: agents = N + 3, structurally clamped at no more than MAX_AREAS + 3 (27). Scales with repo size up to the ceiling; never the unbounded fan-out issue #33 was about.
- A repo too big for the ceiling is reported, not silently truncated (`coverage.ceilingReached` plus dropped paths and a suggested next action).

## Validation

JS workflows have no unit harness, so verification is live runs (per the spec):
- Default: the scout chose 7 areas, so 10 agents (scales to size, no padding to the ceiling).
- `args.areas: 3`: 5 agents (override plus scale-down).
- Report written, schema valid, coverage tracked.

Two real bugs the runs exposed were fixed: `args` arrive as a JSON string (now normalized), and named-workflow invocations cache mid-session edits (run via `scriptPath` to test the live file).

## Deviations from the original spec/plan

The signed-off spec used a fixed cap of 8 with overflow dropped. Per discussion this became: scale N to repo size up to a ceiling of 24, a structural clamp, and shortfall reporting. Spec and plan are updated; the plan carries a "Design updates after planning" note.

## Notes

The workflow's first run audited this template and surfaced pre-existing issues (sync-template guard, hardcoded origin/main, README em-dash, no .env ignore, missing template-version stamp, and more). Those are being filed as separate issues, not in this PR.

Spec: `docs/superpowers/specs/2026-06-13-review-codebase-design.md`
Plan: `docs/plans/37-review-codebase.md`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)