### PR TITLE
fix: spell out three-way guard and add unknown-base fallback in sync-template

### DIFF
--- a/.claude/skills/sync-template/SKILL.md
+++ b/.claude/skills/sync-template/SKILL.md
@@ -26,11 +26,16 @@ If the delta is empty, say so and stop.
 
 ## 2. File classes, in scope only
 
-- Machinery (`.claude/agents/`, `.claude/skills/`, `.claude/workflows/`): copy the template
-  version over the local file. Guard first: if the local file differs from
-  BOTH the old template version (from the stamp) and the new one, it was
-  modified locally; do not overwrite, list it in the PR as a conflict for
-  the user. Never delete local agents or skills the template does not have.
+- Machinery (`.claude/agents/`, `.claude/skills/`, `.claude/workflows/`): three-way
+  guard before copying. Get the three versions: old = `git show <stamp>:<path>` in
+  the template clone; new = the checked-out file in the template clone (HEAD);
+  local = the file in this repo. If local == old, overwrite with new. If local
+  differs from BOTH old and new, the file was modified locally; do not overwrite,
+  list it in the PR as a conflict for the user. (If local already matches new, no
+  action needed.) In unknown-base mode (no stamp), the old version does not exist
+  so the three-way test cannot run; treat every machinery file as a conflict, do
+  not overwrite, list it in the PR. Never delete local agents or skills the
+  template does not have.
 - `.claude/settings.json`: merge by key. Template-shipped keys (such as its
   `enabledPlugins` entries) update; project keys (permissions, hooks, env)
   stay.


### PR DESCRIPTION
## What

Augments the Machinery bullet in `sync-template` SKILL.md Section 2 to make the three-way conflict guard executable.

## Why

The guard stated the right rule (do not overwrite if local differs from both old and new) but never explained how to obtain "the old template version". A worker reading the skill could not execute the guard without knowing the retrieval step.

## Changes

- Spells out the three versions: old = `git show <stamp>:<path>` in the template clone; new = the checked-out HEAD file; local = the file in this repo.
- Keeps the two-condition logic distinct: overwrite when local == old; conflict when local differs from both old and new; no-op when local already matches new.
- Adds the unknown-base fallback: no stamp means no old version, so the three-way test cannot run; treat machinery as a conflict, do not overwrite.
- Keeps the existing "never delete local-only agents/skills" clause verbatim.

Closes #39