### PR TITLE
fix: role-agent guards (tester empty-suite, architect job, read-only frontmatter)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -12,7 +12,9 @@ commands. Do not commit, push, edit files, or change repo state.
 Read `docs/architecture/` before anything else. If the request conflicts with a
 decision recorded there, flag the conflict instead of working around it.
 
-You are dispatched for exactly one of these jobs. Identify which, do only that.
+You are dispatched for exactly one of these jobs. The caller passes the job type
+as the first line of their message: `JOB: SUB_PLAN`, `JOB: SPLIT_PROPOSAL`, or
+`JOB: ARBITRATION`. Read that line; do only that job.
 
 ## SUB_PLAN
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -23,9 +23,14 @@ built.
 
 Then:
 
-1. Read the issue and its sub-plan comment. Extract the acceptance criteria.
-2. Run the full check suite from CLAUDE.md "Useful commands": typecheck, lint,
-   tests, and e2e if the diff touches the full stack.
+1. Read the issue and its sub-plan comment with `gh issue view <n> --comments`.
+   Extract the acceptance criteria.
+2. Check CLAUDE.md "Useful commands". If every command is a placeholder comment
+   (lines starting with `#` and no runnable command after the comment), stop
+   here: emit `VERDICT: FAIL` with finding "check suite not configured" and do
+   not run any tests.
+   Otherwise run the full check suite: typecheck, lint, tests, and e2e if the
+   diff touches the full stack.
 3. Attack the change: edge inputs, the original bug condition for fixes, claims
    in the issue or PR not pinned by any test, weakened or deleted tests.
 


### PR DESCRIPTION
## Summary

- tester.md: emits `VERDICT: FAIL` with "check suite not configured" when CLAUDE.md "Useful commands" holds only placeholder comments, preventing silent PASS on empty runs
- tester.md: makes the issue-read command explicit (`gh issue view <n> --comments`), matching the explicit-command style in reviewer.md
- architect.md: callers now pass `JOB: SUB_PLAN|SPLIT_PROPOSAL|ARBITRATION` as the first line; architect reads it instead of inferring

Note: `tools: Read, Grep, Glob, Bash` was already present in tester.md on origin/main (acceptance criterion 3 was pre-satisfied).

Closes #42

## Test plan

- [ ] Read tester.md: confirm step 1 says `gh issue view <n> --comments`
- [ ] Read tester.md: confirm step 2 has the placeholder-guard and FAIL path
- [ ] Read tester.md: confirm `tools: Read, Grep, Glob, Bash` in frontmatter (already present)
- [ ] Read architect.md: confirm JOB input convention is documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)