### PR TITLE
fix: role agents derive remote default branch and use safer push

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -20,13 +20,17 @@ local default branch, which may be stale, so orient first:
    git checkout --detach FETCH_HEAD
    ```
 
-   Publish every commit with `git push origin HEAD:refs/heads/<branch>`.
+   Publish every commit with `git push --force-with-lease origin HEAD:refs/heads/<branch>`.
 3. Fresh package (no branch on origin): branch from the remote default, not
-   from your worktree's HEAD: `git fetch origin` then
-   `git switch -c feat/<n>-<slug> origin/main` (`fix/` for bug fixes, per
-   CLAUDE.md branch naming). If branch creation collides with leftovers from
-   a crashed run, work detached from `origin/main` and push with the explicit
-   refspec above. If no sub-plan comment exists yet, post one (approach,
+   from your worktree's HEAD: `git fetch origin` then derive the remote
+   default branch with `DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')`,
+   then `git switch -c feat/<n>-<slug> origin/$DEFAULT` (`fix/` for bug fixes,
+   per CLAUDE.md branch naming). If branch creation collides with leftovers
+   from a crashed run, fetch `origin/<branch>` and inspect it: if it holds
+   leftover work (commits or changes not in the upstream), stop and report
+   `NEEDS_CONTEXT` with what you found rather than discarding it; otherwise
+   work detached from `origin/$DEFAULT` and push with the explicit refspec
+   above. If no sub-plan comment exists yet, post one (approach,
    files to touch, order, verification step).
 
 Then:

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -22,16 +22,17 @@ local default branch, which may be stale, so orient first:
 
    Publish every commit with `git push --force-with-lease origin HEAD:refs/heads/<branch>`.
 3. Fresh package (no branch on origin): branch from the remote default, not
-   from your worktree's HEAD: `git fetch origin` then derive the remote
-   default branch with `DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||')`,
-   then `git switch -c feat/<n>-<slug> origin/$DEFAULT` (`fix/` for bug fixes,
-   per CLAUDE.md branch naming). If branch creation collides with leftovers
-   from a crashed run, fetch `origin/<branch>` and inspect it: if it holds
-   leftover work (commits or changes not in the upstream), stop and report
-   `NEEDS_CONTEXT` with what you found rather than discarding it; otherwise
-   work detached from `origin/$DEFAULT` and push with the explicit refspec
-   above. If no sub-plan comment exists yet, post one (approach,
-   files to touch, order, verification step).
+   from your worktree's HEAD: `git fetch origin` then
+   `git remote set-head origin --auto` (ensures `origin/HEAD` is set), then
+   `git switch -c feat/<n>-<slug> origin/HEAD` (`fix/` for bug fixes, per
+   CLAUDE.md branch naming). `origin/HEAD` resolves to the remote default
+   branch and works across tool calls without a shell variable. If branch
+   creation collides with leftovers from a crashed run, fetch `origin/<branch>`
+   and inspect it: if it holds leftover work (commits or changes not in the
+   upstream), stop and report `NEEDS_CONTEXT` with what you found rather than
+   discarding it; otherwise work detached from `origin/HEAD` and push with the
+   explicit refspec above. If no sub-plan comment exists yet, post one
+   (approach, files to touch, order, verification step).
 
 Then:
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -10,7 +10,7 @@ for reading only: `gh pr diff`, `gh issue view`, `git fetch`, `git diff`,
 `git log`.
 
 Input: a PR number or branch name plus its issue number. Get the diff with
-`gh pr diff <n>`, or `git fetch origin && git diff origin/main...origin/<branch>`.
+`gh pr diff <n>`, or `git fetch origin && DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||') && git diff origin/$DEFAULT...origin/<branch>`.
 Read the issue and its sub-plan comment first; they define the spec.
 
 ## Pass 1: spec compliance

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -10,7 +10,7 @@ for reading only: `gh pr diff`, `gh issue view`, `git fetch`, `git diff`,
 `git log`.
 
 Input: a PR number or branch name plus its issue number. Get the diff with
-`gh pr diff <n>`, or `git fetch origin && DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||') && git diff origin/$DEFAULT...origin/<branch>`.
+`gh pr diff <n>`, or `git remote set-head origin --auto && git fetch origin && git diff origin/HEAD...origin/<branch>`.
 Read the issue and its sub-plan comment first; they define the spec.
 
 ## Pass 1: spec compliance


### PR DESCRIPTION
## Summary

- `developer.md`: derive the remote default branch via `git symbolic-ref refs/remotes/origin/HEAD` so branch creation, the detached fallback, and collision handling work on repos where default is not `main`.
- `developer.md`: branch-collision fallback now inspects for leftover work and surfaces `NEEDS_CONTEXT` instead of discarding it silently.
- `developer.md`: fix-round push uses `--force-with-lease` to refuse silently if the remote moved unexpectedly.
- `reviewer.md`: derive the default branch for the `git diff` base instead of hardcoding `origin/main`.

## Test plan

No automated suite (CLAUDE.md "Useful commands" are placeholders). Verified by:
- AC-by-AC read of final file text confirms all four acceptance criteria are met.
- `grep -n 'origin/main' .claude/agents/developer.md .claude/agents/reviewer.md` returns nothing.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)