### PR TITLE
chore: sync-template clone and user-scope robustness

### DIFF
--- a/.claude/skills/sync-template/SKILL.md
+++ b/.claude/skills/sync-template/SKILL.md
@@ -13,8 +13,8 @@ Template repo: $ARGUMENTS (default `sv-tmueller/claude-template`).
 
 ## 1. Get the delta
 
-Clone the template to /tmp (full history; it is small). Read
-`.claude/template-version` here:
+Clone the template to a fresh temp dir (`CLONE=$(mktemp -d)`; full history;
+it is small). Read `.claude/template-version` here:
 
 - Stamp present and valid in the clone's history: the delta is
   `git log --oneline <stamp>..HEAD` and `git diff <stamp> HEAD` in the
@@ -51,9 +51,14 @@ If the delta is empty, say so and stop.
 - Ensure the workflow labels exist (`size:S/M/L/XL`, `in-progress`,
   `needs-human`); create missing ones with `gh label create`.
 - If a user-scope copy of this skill exists on this machine (under
-  `$CLAUDE_CONFIG_DIR/skills/` or `~/.claude/skills/`) and is older than the
-  template's copy, update it too; it is the bootstrap for repos that do not
-  carry this skill yet.
+  `$CLAUDE_CONFIG_DIR/skills/` or `~/.claude/skills/`), apply the same
+  three-way guard as Section 2: old = `git show <stamp>:<path>` in `$CLONE`,
+  new = the file in `$CLONE` at HEAD, local = the user-scope copy. If
+  local == old, overwrite with new. If local differs from both old and new,
+  the user-scope copy was customized; do not overwrite, note it in the PR.
+  If local already matches new, no action needed. In unknown-base mode (no
+  stamp), do not overwrite; note it in the PR. This copy is the bootstrap
+  for repos that do not carry this skill yet.
 
 ## 4. Ship it
 
@@ -65,3 +70,4 @@ If the delta is empty, say so and stop.
 4. Open a PR with `Closes #<n>`. The body lists the template commits
    applied, the files touched per class, and any conflicts or skipped prose
    from the guards above. Merging stays with the user.
+5. Remove `$CLONE` (`rm -rf "$CLONE"`).

--- a/.claude/skills/sync-template/SKILL.md
+++ b/.claude/skills/sync-template/SKILL.md
@@ -13,8 +13,12 @@ Template repo: $ARGUMENTS (default `sv-tmueller/claude-template`).
 
 ## 1. Get the delta
 
-Clone the template to a fresh temp dir (`CLONE=$(mktemp -d)`; full history;
-it is small). Read `.claude/template-version` here:
+Clone the template to a fresh temp dir: run `mktemp -d` and clone into the
+path it prints (full history; it is small). This skill's steps run as
+separate shell commands, and shell variables do not persist across them, so
+note the literal path (call it CLONE below) and substitute it verbatim in
+every later reference; do not rely on `$CLONE` still being set. Read
+`.claude/template-version` here:
 
 - Stamp present and valid in the clone's history: the delta is
   `git log --oneline <stamp>..HEAD` and `git diff <stamp> HEAD` in the
@@ -28,7 +32,7 @@ If the delta is empty, say so and stop.
 
 - Machinery (`.claude/agents/`, `.claude/skills/`, `.claude/workflows/`): three-way
   guard before copying. Get the three versions: old = `git show <stamp>:<path>` in
-  the template clone; new = the checked-out file in the template clone (HEAD);
+  the clone (CLONE); new = the checked-out file in the clone at HEAD;
   local = the file in this repo. If local == old, overwrite with new. If local
   differs from BOTH old and new, the file was modified locally; do not overwrite,
   list it in the PR as a conflict for the user. (If local already matches new, no
@@ -52,8 +56,8 @@ If the delta is empty, say so and stop.
   `needs-human`); create missing ones with `gh label create`.
 - If a user-scope copy of this skill exists on this machine (under
   `$CLAUDE_CONFIG_DIR/skills/` or `~/.claude/skills/`), apply the same
-  three-way guard as Section 2: old = `git show <stamp>:<path>` in `$CLONE`,
-  new = the file in `$CLONE` at HEAD, local = the user-scope copy. If
+  three-way guard as Section 2: old = `git show <stamp>:<path>` in the clone
+  (CLONE), new = the file in CLONE at HEAD, local = the user-scope copy. If
   local == old, overwrite with new. If local differs from both old and new,
   the user-scope copy was customized; do not overwrite, note it in the PR.
   If local already matches new, no action needed. In unknown-base mode (no
@@ -70,4 +74,6 @@ If the delta is empty, say so and stop.
 4. Open a PR with `Closes #<n>`. The body lists the template commits
    applied, the files touched per class, and any conflicts or skipped prose
    from the guards above. Merging stays with the user.
-5. Remove `$CLONE` (`rm -rf "$CLONE"`).
+5. Remove the clone: `rm -rf` the recorded CLONE path. If an earlier step
+   failed before reaching here, still remove it; mktemp makes the path
+   unique, so a leftover never collides, but clean it up anyway.


### PR DESCRIPTION
## Summary

- Clone the template to `$(mktemp -d)` instead of `/tmp`, so repeated runs and leftovers from a crashed run cannot collide. The temp dir is removed at the end of Section 4 (after all reads from the clone are done).
- Replace the mtime-based user-scope skill check with the same three-way guard already used for machinery files in Section 2. Content comparison against the old baseline (via `git show <stamp>:<path>`) distinguishes a stale-but-unmodified copy from a user-customized one. Customized copies are not overwritten; they are noted in the PR. In unknown-base mode (no stamp), the guard cannot run, so the user-scope copy is left alone and noted.

## Files touched

- `.claude/skills/sync-template/SKILL.md` only

## Verification

Both acceptance criteria checked manually against the resulting text:

- AC1 (unique clone path, removed at end): `CLONE=$(mktemp -d)` in Section 1; `rm -rf "$CLONE"` as final step in Section 4.
- AC2 (content comparison, no silent overwrite of customized copy): three-way guard in Section 3 mirrors Section 2's guard exactly.

Closes #40