### PR TITLE
fix: validate review-workflow inputs to fail safe on bad args

### DIFF
--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -21,7 +21,7 @@ export const meta = {
 // contains shell metacharacters. Protects both the git command string and the
 // agent prompts that interpolate the value.
 function safeRef(value, fallback) {
-  return typeof value === 'string' && /^[\w.~^\/\-]+$/.test(value) ? value : fallback
+  return typeof value === 'string' && /^[\w.~^\/\-]+$/.test(value) && !value.includes('..') ? value : fallback
 }
 const base = safeRef(args && args.base, 'origin/main')
 

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -43,10 +43,10 @@ const opts = parseArgs(args)
 // metacharacters. Protects both the git command string and the agent prompts
 // that interpolate the value.
 function safeRef(value, fallback) {
-  return typeof value === 'string' && /^[\w.~^\/\-]+$/.test(value) ? value : fallback
+  return typeof value === 'string' && /^[\w.~^\/\-]+$/.test(value) && !value.includes('..') ? value : fallback
 }
 const root = safeRef(opts.path, '.')
-const MAX_AREAS = opts.areas || 24
+const MAX_AREAS = Number.isInteger(opts.areas) && opts.areas > 0 ? opts.areas : 24
 
 const FINDING = {
   type: 'object',


### PR DESCRIPTION
## What

Make the review workflows fail safe on bad arguments. Two one-line fixes:

- `tm-review-codebase.js`: `MAX_AREAS` falls back to the default unless `areas` is a positive integer (was `opts.areas || 24`, which accepted any truthy value).
- `tm-review-codebase.js` and `tm-review-changes.js`: `safeRef` rejects any `..` sequence, so a `path`/`base` arg cannot traverse outside the repo.

Closes #59. Non-safety polish for these workflows is tracked in #69.

## Why

`opts.areas || 24` accepted a non-numeric or negative `areas`: `slice(0, NaN)` returned `[]`, so zero area workers ran while the run still looked normal and the critic could return `approve`. And `safeRef`'s class allowed `..`, which is interpolated into the `git ls-files` / `git diff` command the agents run.

## Verification

No automated suite exists in this template; the fixes are pure input-validation logic, verified with `node -e`:

```
MAX_AREAS clamp:    "ten"->24  -1->24  0->24  12.5->24  undef->24  8->8   (all OK)
safeRef traversal:  ../../etc->"."  src->"src"  origin/main->"origin/main"  v1.2.3->"v1.2.3"  (all OK)
```

A durable unit test for these helpers is #68 (pending the runtime-import decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
