### PR TITLE
fix: close .env gitignore gap with .env.* pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .DS_Store
 .claude/settings.local.json
 .env
-.env.local
-.env*.local
+.env.*
+!.env.example
+!.env.sample
 
 # Review reports under docs/reviews/ are tracked documentation; do not add reviews/ here.


### PR DESCRIPTION
Closes #66

## Summary

- Added `.env.*` to the `.env` block, covering `.env.production`, `.env.staging`, `.env.development`, and `.env.test`.
- Removed `.env.local` and `.env*.local` (redundant lines; orphans this change created).
- Added `!.env.example` and `!.env.sample` negations after `.env.*` (gitignore is order-sensitive) so committable example files this template is meant to ship stay committable.

## Verification output

```
$ git check-ignore -v .env.production .env.staging .env.development .env.test
.gitignore:4:.env.*	.env.production
.gitignore:4:.env.*	.env.staging
.gitignore:4:.env.*	.env.development
.gitignore:4:.env.*	.env.test
exit code: 0

$ git check-ignore .env.example .env.sample
exit code: 1  (still committable — negation rules work)

$ git status --porcelain
 M .gitignore

$ git ls-files '.env*'
(empty — nothing tracked is newly ignored)
```

All four acceptance criteria pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)