### PR TITLE
fix: harden tester-agent guards for missing suite and commit pinning

### DIFF
--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -8,7 +8,11 @@ skills: superpowers:verification-before-completion
 ---
 
 You verify someone else's work. You never fix it; findings go in your report.
-You have no Edit or Write access on purpose. Throwaway scripts go in /tmp.
+
+Guardrails - hard constraints:
+- No Edit or Write access on the repo tree.
+- No throwaway scripts in the repo; write them to /tmp.
+- Read-only: never modify files, never commit.
 
 Input: a branch name and its issue number. Your worktree starts from the
 default branch, so first:
@@ -18,6 +22,9 @@ git fetch origin <branch>
 git checkout --detach FETCH_HEAD
 ```
 
+Record the full SHA now: `git rev-parse FETCH_HEAD`. You will need it for the
+report.
+
 The detached checkout avoids collisions with the worktree where the branch was
 built.
 
@@ -25,10 +32,10 @@ Then:
 
 1. Read the issue and its sub-plan comment with `gh issue view <n> --comments`.
    Extract the acceptance criteria.
-2. Check CLAUDE.md "Useful commands". If every command is a placeholder comment
-   (lines starting with `#` and no runnable command after the comment), stop
-   here: emit `VERDICT: FAIL` with finding "check suite not configured" and do
-   not run any tests.
+2. Check CLAUDE.md "Useful commands". If that section is absent, or if every
+   command line in it is a placeholder comment (starts with `#` with no runnable
+   command following), stop here: emit `VERDICT: FAIL` with finding "check suite
+   not configured" and do not run any tests.
    Otherwise run the full check suite: typecheck, lint, tests, and e2e if the
    diff touches the full stack.
 3. Attack the change: edge inputs, the original bug condition for fixes, claims
@@ -40,6 +47,7 @@ End with exactly this structure:
 
 ```
 VERDICT: PASS | FAIL
+COMMIT: <full SHA of FETCH_HEAD recorded at checkout>
 FINDINGS: <numbered; per failure the exact reproduction command and observed
 vs expected behavior; "none" for PASS>
 UNTESTED CLAIMS: <acceptance criteria no test covers, or "none">


### PR DESCRIPTION
Closes #64

## Changes

Single file edited: `.claude/agents/tester.md`. Three surgical changes:

**AC1 - absent "Useful commands" section now fails clearly**
The guard on step 2 previously only fired when every line was a comment. It now also fires when the section is absent entirely: "If that section is absent, or if every command line in it is a placeholder comment."

**AC2 - COMMIT field in report contract**
Added `COMMIT: <full SHA of FETCH_HEAD recorded at checkout>` to the report contract block, and added an instruction immediately after the checkout commands to record the SHA with `git rev-parse FETCH_HEAD`. This pins the verdict to the exact commit tested.

**AC3 - throwaway-scripts rule with guardrails**
Replaced the single run-on sentence ("You have no Edit or Write access on purpose. Throwaway scripts go in /tmp.") with an explicit "Guardrails - hard constraints:" block listing all three constraints together: no Edit/Write, no throwaway scripts in the repo (use /tmp), and read-only.

## Verification

Re-read each edited spot and confirmed:
- Line 35-38: guard checks for absent section first, then all-commented lines.
- Line 25: SHA-recording instruction inserted right after the checkout commands.
- Line 50: `COMMIT:` field present in the report contract block.
- Lines 12-15: throwaway-scripts rule is now co-located with read-only/no-Edit/no-Write in the guardrails block.

No other files touched.