### PR TITLE
docs: note the optional design plugins in new-project setup

### DIFF
--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -29,6 +29,24 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
       gh api repos/sv-tmueller/claude-template/commits/main --jq .sha > .claude/template-version
       ```
       Commit the file.
+- [ ] (Optional) If this project builds UI, enable the design plugins. They are
+      not on by default, so the template stays generic and free of third-party
+      defaults. Add each to `.claude/settings.json` under `enabledPlugins` and
+      install it:
+      - `frontend-design@claude-plugins-official` (distinctive frontend UI;
+        official marketplace, like superpowers):
+        `/plugin install frontend-design@claude-plugins-official`.
+      - `ui-ux-pro-max@ui-ux-pro-max-skill` (UI/UX design intelligence: styles,
+        palettes, font pairings). Third-party, from
+        `nextlevelbuilder/ui-ux-pro-max-skill`: add the marketplace
+        (`/plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill`), then
+        `/plugin install ui-ux-pro-max@ui-ux-pro-max-skill`.
+      - `impeccable@impeccable` (frontend interface design and critique).
+        Third-party, from `pbakaus/impeccable`: add the marketplace
+        (`/plugin marketplace add pbakaus/impeccable`), then
+        `/plugin install impeccable@impeccable`.
+      Vet the two third-party plugins before enabling them in a project others
+      build on; their install steps live in their repos and may change.
 
 ## 3. Docs structure
 


### PR DESCRIPTION
## What

Document the three design plugins from #16 as **optional** add-ons in `NEW-PROJECT-SETUP.md` (Section 2, Claude Code), rather than enabling them in the template default.

Closes #16

## Why

The template is generic and its `enabledPlugins` propagates to every downstream project via `/tm-sync-template`. All three are frontend/UI-design tools, and two (`ui-ux-pro-max`, `impeccable`) are third-party GitHub plugins. Defaulting them on would push design tooling plus a third-party dependency onto every project, including backends. Documenting them as optional captures the bookmark without that cost; a UI-focused project enables what it needs.

## Details

Each entry carries its `enabledPlugins` identifier and install command, grounded in the real marketplace/plugin IDs (`frontend-design@claude-plugins-official`, `ui-ux-pro-max@ui-ux-pro-max-skill`, `impeccable@impeccable`), with a note to vet the third-party ones.

## Verification

Docs-only; the diff is confined to `NEW-PROJECT-SETUP.md`, and the install identifiers match the actual marketplace registrations. I skipped a separate reviewer agent given the remaining budget and the low-risk, config-grounded nature of the change — small enough to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
