### PR TITLE
fix: stop the developer fresh path tangling the lead's checkout

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -12,10 +12,10 @@ local default branch, which may be stale, so orient first:
 1. Read the issue and its comments (`gh issue view <n> --comments`). The
    sub-plan comment is your spec. If your task includes fix findings, those
    take precedence.
-2. Orient and check out, one pattern for both cases. You always work on your
-   own package branch in your dispatched worktree; never `git switch` a shared
-   or default checkout. Fetch first (`git fetch origin`), then resolve the
-   branch:
+2. Orient and check out. Both cases work on a detached HEAD in your dispatched
+   worktree and publish to your package branch on origin; you never create a
+   local branch or `git switch` a shared or default checkout. Fetch first
+   (`git fetch origin`), then resolve the base:
 
    - Fix round or resume (the branch exists on origin): verify the ref before
      detaching, so a bad branch name fails fast instead of detaching to a stale
@@ -27,15 +27,18 @@ local default branch, which may be stale, so orient first:
      ```
 
      If `ls-remote` finds no ref, stop and report `NEEDS_CONTEXT`; do not detach.
-   - Fresh package (no branch on origin): create your branch from an explicit
-     base, `git switch -c feat/<n>-<slug> origin/main` (`fix/` for bug fixes,
-     per CLAUDE.md branch naming). If the default branch is not `main`, run
+   - Fresh package (no branch on origin): check out the resolved base detached,
+     so no local branch ref is created and no shared HEAD moves. The base is
+     `origin/main`, and the eventual branch (`feat/<n>-<slug>`, or `fix/` for
+     bug fixes, per CLAUDE.md branch naming) is created on origin by the push
+     refspec below, never locally. If the default branch is not `main`, run
      `git remote set-head origin --auto` and use `origin/HEAD`; if that cannot
      resolve (for example a network error), fall back to `origin/main` and note
-     the deviation in your report. If branch creation collides with leftovers
-     from a crashed run, fetch `origin/<branch>` and inspect it: if it holds
-     work not in the upstream, stop and report `NEEDS_CONTEXT` rather than
-     discarding it; otherwise work detached from it.
+     the deviation in your report:
+
+     ```
+     git checkout --detach origin/main   # origin/HEAD when the default is not main
+     ```
 
    Publish every commit with the same refspec:
    `git push --force-with-lease origin HEAD:refs/heads/<branch>`. If no sub-plan

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -27,14 +27,18 @@ local default branch, which may be stale, so orient first:
      ```
 
      If `ls-remote` finds no ref, stop and report `NEEDS_CONTEXT`; do not detach.
-   - Fresh package (no branch on origin): check out the resolved base detached,
-     so no local branch ref is created and no shared HEAD moves. The base is
-     `origin/main`, and the eventual branch (`feat/<n>-<slug>`, or `fix/` for
-     bug fixes, per CLAUDE.md branch naming) is created on origin by the push
-     refspec below, never locally. If the default branch is not `main`, run
-     `git remote set-head origin --auto` and use `origin/HEAD`; if that cannot
-     resolve (for example a network error), fall back to `origin/main` and note
-     the deviation in your report:
+   - Fresh package (no branch on origin): first confirm the branch really is
+     absent on origin (`git ls-remote --exit-code origin <branch>`), so a
+     leftover from a crashed run is not silently overwritten by the push below.
+     If the ref is found, stop and report `NEEDS_CONTEXT`: a prior run pushed
+     this branch, so it is a resume, not a fresh start. If it is absent, check
+     out the resolved base detached, so no local branch ref is created and no
+     shared HEAD moves. The base is `origin/main`, and the eventual branch
+     (`feat/<n>-<slug>`, or `fix/` for bug fixes, per CLAUDE.md branch naming)
+     is created on origin by the push refspec below, never locally. If the
+     default branch is not `main`, run `git remote set-head origin --auto` and
+     use `origin/HEAD`; if that cannot resolve (for example a network error),
+     fall back to `origin/main` and note the deviation in your report:
 
      ```
      git checkout --detach origin/main   # origin/HEAD when the default is not main

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -108,14 +108,19 @@ Routing rules:
 
 ## Worktree cleanup (deterministic)
 
-The `developer` and `tester` run with Agent `isolation: worktree`. The harness
-registers an isolated worktree under `.claude/worktrees/` per dispatch and may
-leave it behind when the agent returns; the agents publish to origin, so their
-work is safe there regardless. The `developer` no longer creates a local branch
-or moves a shared HEAD (it works detached and pushes a refspec, per
-`developer.md`), which removes the branch-ref and shared-HEAD leak at the
-source. The residue the harness can still leave is the registered worktree, so
-the lead sweeps it.
+The `developer` and `tester` run with Agent `isolation: worktree`, but the
+isolation does not reliably separate the working tree: a dispatched agent's
+`git checkout`/`git switch` can land on the lead's shared checkout. That is the
+mechanical cause of the tangle, and it hits every checkout-running agent, not
+just one (observed live on issue #78: the `tester`'s `git checkout --detach
+FETCH_HEAD` left the lead's checkout detached at the branch tip). The agents
+publish to origin, so their work is safe there regardless; what leaks into the
+lead's checkout is a moved HEAD, sometimes a local branch, and a worktree
+registered under `.claude/worktrees/`. The `developer` fresh path uses a
+detached checkout instead of `git switch -c`, so it no longer leaves a stale
+local branch (the worst residue, a clobber risk against the good remote branch);
+the moved HEAD and the registered worktree are harness-side and cannot be
+prevented by agent commands, so the lead reverses them deterministically.
 
 At wave end, with no agents in flight, run from the lead's main checkout:
 

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -106,10 +106,40 @@ Routing rules:
 - Inside an /tm-advisor batch, mirror lead decisions and package outcomes
   (PR ready, parked) to the batch tracking issue as they happen.
 
+## Worktree cleanup (deterministic)
+
+The `developer` and `tester` run with Agent `isolation: worktree`. The harness
+registers an isolated worktree under `.claude/worktrees/` per dispatch and may
+leave it behind when the agent returns; the agents publish to origin, so their
+work is safe there regardless. The `developer` no longer creates a local branch
+or moves a shared HEAD (it works detached and pushes a refspec, per
+`developer.md`), which removes the branch-ref and shared-HEAD leak at the
+source. The residue the harness can still leave is the registered worktree, so
+the lead sweeps it.
+
+At wave end, with no agents in flight, run from the lead's main checkout:
+
+```
+git worktree prune                 # safe anytime; drops entries for gone worktrees
+git worktree list                  # expect only the main repo
+git status --short --branch        # expect the default branch, clean tree
+```
+
+Remove anything still registered under `.claude/worktrees/`
+(`git worktree remove --force <path>`). If the lead's HEAD was moved off the
+default branch, return to it (`git switch <default>`). Delete a stray local
+package branch only when its work is safe on origin (`git ls-remote --exit-code
+origin <branch>` succeeds), then `git branch -D <branch>`; never delete a branch
+whose commits are not on origin. Do not run `remove` or `branch -D` mid-wave:
+they must not touch a worktree another concurrent package is still using.
+
 ## 4. Wave end
 
 Definition of done per package: last tester verdict is PASS, reviewer
 APPROVE, PR ready with `Closes #N`, summary comment posted.
+
+Before reporting, run the worktree cleanup above (no agents in flight) so the
+lead's checkout is left on the default branch with a clean tree.
 
 Report to the user: PRs ready for review, packages parked (`needs-human`,
 with their open questions), and issues deferred to later waves or stopped at

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -132,7 +132,8 @@ git status --short --branch        # expect the default branch, clean tree
 
 Remove anything still registered under `.claude/worktrees/`
 (`git worktree remove --force <path>`). If the lead's HEAD was moved off the
-default branch, return to it (`git switch <default>`). Delete a stray local
+default branch, return to it with `git switch <default>` (the lead's own checkout, the one
+place that command is right). Delete a stray local
 package branch only when its work is safe on origin (`git ls-remote --exit-code
 origin <branch>` succeeds), then `git branch -D <branch>`; never delete a branch
 whose commits are not on origin. Do not run `remove` or `branch -D` mid-wave:


### PR DESCRIPTION
## Summary

Fixes the `/tm-kickoff` worktree tangle: after a full-pipeline run the lead's working checkout was left mutated, with a moved HEAD (switched onto the feature branch, or detached at the branch tip), sometimes a stale local feature branch, and a worktree lingering under `.claude/worktrees/`.

## Root cause

Agent `isolation: worktree` does not reliably separate the working tree for dispatched agents: their `git checkout`/`git switch` can land on the lead's shared checkout. It is harness-side, and it affects **every checkout-running agent**, not just the developer.

**Confirmed live on this run:** the `tester` dispatched for this PR ran `git checkout --detach FETCH_HEAD` and left the lead's checkout detached at the branch tip (`21a45fc`); the cleanup step below then restored it to `main`. So the original diagnosis ("only the developer's `git switch -c` tangles") was incomplete.

PR #72 added a prose warning ("never `git switch` a shared checkout"), but a worker runs the literal command it is given, so prose could not fix it.

Residue that can leak into the lead's checkout: a moved/detached HEAD (any checkout), a stale local branch (`git switch -c` specifically), and a worktree registered under `.claude/worktrees/` (harness).

## Change

Necessary-and-sufficient only in combination: eliminate the worst residue at the source, and deterministically reverse the rest (which is harness-side and unpreventable).

- **developer.md**: the fresh path is now `git checkout --detach origin/main` (or `origin/HEAD`) instead of `git switch -c`, and the existing `git push --force-with-lease origin HEAD:refs/heads/<branch>` refspec creates the branch on origin. This removes the stale **local branch** (a clobber risk against the good remote branch); it does not remove the HEAD move (a detached checkout still moves HEAD), which the cleanup handles. The fresh path also verifies the branch is absent on origin first (`git ls-remote --exit-code`) and reports `NEEDS_CONTEXT` if a prior crashed run already pushed it, so the force-push cannot silently clobber unmerged work (this replaces, and strengthens, the old local-collision clause).
- **tm-kickoff/SKILL.md**: adds a deterministic, **load-bearing** "Worktree cleanup" step. At wave end (no agents in flight) the lead re-attaches to the default branch, prunes worktrees, removes any stale `.claude/worktrees/*`, and drops a stray local package branch only when its work is safe on origin. This reverses the moved HEAD and the registered worktree the agents cannot prevent.

## Verification

Mechanical proof of the developer command change, in a throwaway sandbox:

| check | old `git switch -c` | new detached + refspec |
|---|---|---|
| local feature branch created | yes (the leak) | no |
| HEAD after the sequence | on the branch | detached |
| branch published to origin | n/a | yes |
| `main` ref | - | untouched |

The crash-work guard was also verified: `git ls-remote --exit-code` returns 0 for an existing remote branch (developer reports `NEEDS_CONTEXT`, no clobber) and non-zero when absent (fresh path proceeds).

**Live, on this run:** the tester dispatch detached the lead's checkout (the tangle reproduced itself), and the cleanup step restored it to `main` with `git worktree list` showing only the main repo. This exercises the harness-side path the sandbox cannot.

**Still deferred:** a full non-lean `/tm-kickoff` with a real worktree-isolated `developer`, single-package and a 2-3 package wave, asserting all four end-state conditions. This PR was built in lean mode (lead in a worktree), so the developer stage was not dispatched here.

Refs #78 (deliberately not `Closes`: the real-run acceptance check is deferred per "Still deferred" above, so merging this PR should not auto-close the issue).
