### PR TITLE
fix: backlog scan, merge checks, and close guard in tm-advisor

### DIFF
--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -34,8 +34,8 @@ hidden assumptions, cheaper alternatives, and conflicts with
 
 Slice the need into independent `size:S` or `size:M` packages. If the user
 hands over a ready-made package labelled `size:L` or `size:XL`, reject it
-before sign-off and ask to split it first - a single oversized package risks
-hitting the session limit mid-task. No `Blocked by:` between packages in the
+before sign-off and ask to split it first (a single oversized package risks
+hitting the session limit mid-task). No `Blocked by:` between packages in the
 same batch; dependent work waits for a later batch, after the user has merged
 this one. Up to 6 packages per batch; propose fewer when the need is small.
 If the need exceeds one batch, say what is deferred to the next batch and why.
@@ -109,14 +109,15 @@ With no arguments, `/tm-advisor` enters the resume path:
 4. If all packages are ready or parked: first make sure the report has been
    posted to the batch issue (if the run ended before the report step above
    ran, post it now), then check for unresolved parked packages. If any
-   package still carries `needs-human`, list them and stop - do not close the
-   batch issue until the user has either dismissed each one or its PR has been
-   merged. Once every package has a merged PR or the user explicitly dismisses
-   the parked ones, confirm merges: for each PR number recorded in the batch
-   checklist, run `gh pr view <n> --json state` and verify the state is
-   `MERGED`. If any PR is not yet merged, report which ones are outstanding
-   and stop. When all PRs are confirmed merged, close the batch issue and
-   propose the next batch (see below).
+   package still carries `needs-human`, list them and stop. Do not close the
+   batch issue until every package either has a merged PR or no longer blocks
+   closure. A parked package stops blocking closure once it no longer carries
+   `needs-human` (the user removed the label or closed the issue). Once every
+   package has a merged PR or has cleared that label, confirm merges: for each
+   PR number recorded in the batch checklist, run `gh pr view <n> --json state`
+   and verify the state is `MERGED`. If any PR is not yet merged, report which
+   ones are outstanding and stop. When all PRs are confirmed merged, close the
+   batch issue and propose the next batch (see below).
 
    At closure, strip the `Part of batch #<batch>` line from any parked issues
    that were not resolved (the ones the user dismissed rather than merged).

--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -24,7 +24,7 @@ Depth is proportional to the need:
   `/tm-grill-me` or superpowers brainstorming first, and capture the approved
   design under `docs/superpowers/specs/` before slicing.
 - Packages the user hands over ready-made (for example from plan mode) skip
-  refinement; check only that they are sized and independent.
+  refinement; check only that they are sized and independent (see section 2).
 
 Challenge the need. You are a sparring partner, not a stenographer: surface
 hidden assumptions, cheaper alternatives, and conflicts with
@@ -32,11 +32,13 @@ hidden assumptions, cheaper alternatives, and conflicts with
 
 ## 2. Propose
 
-Slice the need into independent `size:S` or `size:M` packages. No
-`Blocked by:` between packages in the same batch; dependent work waits for a
-later batch, after the user has merged this one. Up to 6 packages per batch;
-propose fewer when the need is small. If the need exceeds one batch, say
-what is deferred to the next batch and why.
+Slice the need into independent `size:S` or `size:M` packages. If the user
+hands over a ready-made package labelled `size:L` or `size:XL`, reject it
+before sign-off and ask to split it first - a single oversized package risks
+hitting the session limit mid-task. No `Blocked by:` between packages in the
+same batch; dependent work waits for a later batch, after the user has merged
+this one. Up to 6 packages per batch; propose fewer when the need is small.
+If the need exceeds one batch, say what is deferred to the next batch and why.
 
 Present the batch in chat, per package:
 
@@ -64,20 +66,22 @@ On approval:
 Run the packages through the kickoff per-package pipeline
 (`.claude/skills/tm-kickoff/SKILL.md`): at most 3 concurrent, starting the next
 queued package as one finishes. Skip kickoff's wave-plan confirmation; the
-sign-off already covered it. Differences from a plain `/tm-kickoff` run:
+sign-off already covered it. The advisor differs from a plain `/tm-kickoff` run
+in three ways:
 
-- In-scope decisions are yours. When a question stays within the signed-off
+- **In-scope decisions are yours.** When a question stays within the signed-off
   scope and acceptance criteria (a NEEDS_DECISION, an arbitration outcome,
-  an interpretation call), decide it and post the decision with its
-  reasoning as a comment on the batch issue before acting on it.
-- Park (swap `in-progress` for `needs-human`) only for: a change to scope or
-  acceptance criteria, a new dependency or cost, anything irreversible or
-  outward-facing, or a conflict with `docs/architecture/`.
-- Parked packages are logged on the batch issue and held for the report. Do
-  not interrupt the user unless ALL packages are parked; then report
-  immediately, since nothing is progressing.
-- Mirror each package outcome (PR ready, parked) to the batch issue
-  checklist as it happens, so a dropped session can resume from the issue.
+  an interpretation call), decide it and post the decision with its reasoning
+  as a comment on the batch issue before acting on it.
+- **Narrower parking gate.** Park (swap `in-progress` for `needs-human`) only
+  for: a change to scope or acceptance criteria, a new dependency or cost,
+  anything irreversible or outward-facing, or a conflict with
+  `docs/architecture/`. Parked packages are logged on the batch issue and held
+  for the report. Do not interrupt the user unless ALL packages are parked;
+  then report immediately, since nothing is progressing.
+- **Live checklist.** Mirror each package outcome (PR ready, parked) to the
+  batch issue checklist as it happens, so a dropped session can resume from
+  the issue.
 
 ## 5. Report
 
@@ -104,15 +108,31 @@ With no arguments, `/tm-advisor` enters the resume path:
    re-ask for sign-off on an already approved batch.
 4. If all packages are ready or parked: first make sure the report has been
    posted to the batch issue (if the run ended before the report step above
-   ran, post it now), then confirm merges by running `gh pr list --state
-   merged` against the batch's PRs. If any PRs are not yet merged, report
-   which ones are outstanding and stop - do not close the batch issue or
-   propose the next batch yet. If all PRs are merged, close the batch issue
-   and propose the next batch (see below).
+   ran, post it now), then check for unresolved parked packages. If any
+   package still carries `needs-human`, list them and stop - do not close the
+   batch issue until the user has either dismissed each one or its PR has been
+   merged. Once every package has a merged PR or the user explicitly dismisses
+   the parked ones, confirm merges: for each PR number recorded in the batch
+   checklist, run `gh pr view <n> --json state` and verify the state is
+   `MERGED`. If any PR is not yet merged, report which ones are outstanding
+   and stop. When all PRs are confirmed merged, close the batch issue and
+   propose the next batch (see below).
 
-**Proposing the next batch.** The backlog is all open issues with no
-`Part of batch #` line in their body, ordered first by dependency (issues
-with unresolved `Blocked by:` lines come after the issues they depend on)
-and then by creation date (oldest first). Present the highest-priority
-candidates as the next batch proposal, following the same rules as section 2.
-Dispatch always requires a new sign-off; merging is never implicit approval.
+   At closure, strip the `Part of batch #<batch>` line from any parked issues
+   that were not resolved (the ones the user dismissed rather than merged).
+   This re-opens them to the backlog scan so they surface as candidates in the
+   next batch.
+
+**Proposing the next batch.** Query the backlog with:
+
+```
+gh issue list --state open --search "NOT Batch: in:title"
+```
+
+Then filter out any issue whose body still contains a `Part of batch #` line
+(those belong to an active batch and must not be re-proposed). Order the
+remainder first by dependency (issues with unresolved `Blocked by:` lines come
+after the issues they depend on) and then by creation date (oldest first).
+Present the highest-priority candidates as the next batch proposal, following
+the same rules as section 2. Dispatch always requires a new sign-off; merging
+is never implicit approval.


### PR DESCRIPTION
Closes #61

## Summary

- **needs-human close guard (must-fix):** section 6 step 4 now checks for `needs-human` packages before closing; the batch stays open until the user dismisses parked packages or their PRs are merged
- **per-PR merge confirmation:** replaced the unscoped `gh pr list --state merged` with per-PR checks via `gh pr view <n> --json state == MERGED`
- **Batch: exclusion from backlog:** added `NOT Batch: in:title` to the backlog query flag
- **parked-issue re-entry:** at batch closure, the `Part of batch #N` line is stripped from dismissed parked issues so they resurface in the next backlog scan; mechanism documented in the skill
- **size:L/XL rejection:** section 2 now rejects oversized ready-made packages before sign-off and asks to split first
- **section-4 dedup:** trimmed restated kickoff mechanics to three advisor-only deltas with the "differs from a plain /tm-kickoff run" framing
- **no sentence-break hyphens:** rewritten step-4 close-gate uses parentheses where needed; em-dash check passes clean

File changed: `.claude/skills/tm-advisor/SKILL.md` only.

## Test plan

- [ ] Verify parked package blocks batch close (needs-human guard)
- [ ] Verify closed-unmerged PR is detected as not-merged (per-PR check)
- [ ] Verify a concurrent `Batch:` issue is excluded from backlog query
- [ ] Verify a parked issue resurfaces after `Part of batch` strip at closure
- [ ] Verify `size:L` package triggers rejection pre-sign-off
- [ ] Verify no kickoff mechanic is duplicated in section 4
- [ ] Verify no em-dashes in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)