### PR TITLE
fix: polish template and agent docs for clarity

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -33,7 +33,7 @@ dependencies between them as `Blocked by: #N` lines.
 ## ARBITRATION
 
 Input: a reviewer finding and the developer's pushback. Decide who is right and
-state the required outcome. Anchor on the issue text and the four principles
+state the required outcome. Decide using the issue text and the four principles
 in `~/.claude/CLAUDE.md`.
 
 ## Output contract

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -10,7 +10,9 @@ for reading only: `gh pr diff`, `gh issue view`, `git fetch`, `git diff`,
 `git log`.
 
 Input: a PR number or branch name plus its issue number. Get the diff with
-`gh pr diff <n>`, or `git remote set-head origin --auto && git fetch origin && git diff origin/HEAD...origin/<branch>`.
+`gh pr diff <n>` (preferred); fall back to
+`git remote set-head origin --auto && git fetch origin && git diff origin/HEAD...origin/<branch>`
+only when no PR exists.
 Read the issue and its sub-plan comment first; they define the spec.
 
 ## Pass 1: spec compliance
@@ -22,7 +24,7 @@ findings, even when the extra code is good.
 ## Pass 2: code quality
 
 Only after pass 1 is clean. Correctness first, then the principles: simplicity
-first (could 200 lines be 50?), surgical changes, verifiable behavior. Match
+first (could 200 lines be 50?), surgical changes, goal-driven execution. Match
 against the CLAUDE.md code style and writing style sections. A weakened or
 deleted test is always a blocking finding.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ repeat them; it adds only what is specific to this project.
 Read these before proposing changes that touch their area:
 
 - `docs/architecture/` - stack and policy decisions, the data model, the domain
-  math. Locked unless explicitly revisited.
+  math. Locked unless explicitly revisited. (see NEW-PROJECT-SETUP)
 - `docs/operations/` - how to run, deploy, and operate the system: environments,
-  CI/CD, runbooks, secrets policy.
+  CI/CD, runbooks, secrets policy. (see NEW-PROJECT-SETUP)
 - `docs/plans/` - implementation plans, one per task as `<issue-number>-<slug>.md`.
 - `docs/superpowers/specs/` - approved designs from brainstorming, as
   `YYYY-MM-DD-<topic>-design.md`.
@@ -86,11 +86,7 @@ later (see "How to pick up a task").
 
 ### Code style
 
-Project-specific rules go here. Examples to adapt or delete:
-
-- Strict typing; no escape hatches without a `// reason:` comment.
-- Money, units, and identifiers use their dedicated types, never raw primitives.
-- No hard-coded user-facing strings; use the i18n layer.
+Add project-specific style rules here and remove this line before the first implementation session.
 
 ### Writing style (commits, PRs, docs, comments)
 
@@ -170,7 +166,7 @@ A strong orchestrator with efficient workers. The lever is where each model
 runs, not raw effort everywhere.
 
 - Orchestrator (the lead session, including `/tm-kickoff`): Opus 4.8 at max
-  effort. Opus does not over-spawn under ultracode the way Fable 5 does, and it
+  effort. Opus does not over-spawn under ultracode the way Fable 5 (`claude-fable-5`) does, and it
   weighs less against Max-plan quota. Keep the lead here.
 - `ultracode`: use it as a per-prompt keyword, never as a session-wide effort
   setting. Session-wide turns every task into a workflow and chains several per
@@ -224,6 +220,8 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
   skills/            project skills: /tm-advisor, /tm-grill-me, /tm-kickoff, /tm-sync-template, /tm-to-issues
   workflows/         bounded orchestration scripts (tm-review-changes, tm-review-codebase)
   settings.json      project settings; enables the superpowers plugin
+                       enabledPlugins is template-managed (synced by /tm-sync-template);
+                       permissions, hooks, env, and defaultMode are project-owned
 docs/
   architecture/      stack and policy decisions, data model, domain math (see NEW-PROJECT-SETUP)
   operations/        run/deploy/operate: environments, CI/CD, runbooks (see NEW-PROJECT-SETUP)
@@ -271,7 +269,7 @@ not rediscover them.
   (sv-tmueller/claude-template) first, then `/tm-sync-template` it back here;
   local-only edits are overwritten by the next sync.
 - Don't introduce a new dependency without saying why in the PR body.
-- (Add project-specific traps here: the mistakes that quietly break this codebase.)
+<!-- Add project-specific traps here: the mistakes that quietly break this codebase. -->
 
 ## When in doubt
 

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -6,7 +6,7 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 
 ## 1. Repository and protection
 
-- [ ] Create the repo (`gh repo create <name> --template sv-tmueller/claude-template`).
+- [ ] Create the repo (`gh repo create <name> --template sv-tmueller/claude-template --clone`).
 - [ ] Protect `main`: block direct pushes, require a PR, require status checks to
       pass before merge.
 - [ ] Create the labels the workflow uses: the sizing set `size:S`, `size:M`,
@@ -19,16 +19,20 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 
 - [ ] Open the repo in Claude Code and trust the folder. Accept the superpowers
       plugin prompt that `.claude/settings.json` triggers. If no prompt appears
-      (a known gap, claude-code#32606), run
+      (a known gap, https://github.com/anthropics/claude-code/issues/32606), run
       `/plugin install superpowers@claude-plugins-official`.
 - [ ] Check the agent team is loaded: `/agents` should list architect,
       developer, tester, and reviewer.
+- [ ] Check the skills are registered: `/skills` should list tm-advisor,
+      tm-kickoff, tm-grill-me, tm-to-issues, and tm-sync-template.
 - [ ] Stamp the template version, so `/tm-sync-template` can apply future
       template updates incrementally:
       ```
       gh api repos/sv-tmueller/claude-template/commits/main --jq .sha > .claude/template-version
       ```
-      Commit the file.
+      Commit the file. (The file ships as `unknown` in the template; that is
+      intentional - `/tm-sync-template` treats any non-SHA value as an unknown
+      base and prompts for a conservative merge until you stamp it here.)
 - [ ] (Optional) If this project builds UI, enable the design plugins. They are
       not on by default, so the template stays generic and free of third-party
       defaults. Add each to `.claude/settings.json` under `enabledPlugins` and


### PR DESCRIPTION
## Summary

- **CLAUDE.md "Where decisions live"**: add `(see NEW-PROJECT-SETUP)` to `docs/architecture/` and `docs/operations/` entries, matching the Repo-layout parentheticals.
- **CLAUDE.md "Code style"**: replace "Examples to adapt or delete" + 3 bullets with a single instruction line; removes filler that ships into real projects.
- **CLAUDE.md "What not to do"**: convert the `(Add project-specific traps here...)` placeholder to an HTML comment, matching the existing `<!-- Modes ... -->` style.
- **CLAUDE.md "Model policy"**: add `claude-fable-5` public model ID alongside the Fable 5 comparison (per lead decision: keep the comparison, add the ID).
- **CLAUDE.md Repo layout**: add `settings.json` ownership note - `enabledPlugins` is template-managed; `permissions`, `hooks`, `env`, `defaultMode` are project-owned.
- **NEW-PROJECT-SETUP step 1**: add `--clone` to the `gh repo create` command.
- **NEW-PROJECT-SETUP step 2**: fix `claude-code#32606` -> full URL `https://github.com/anthropics/claude-code/issues/32606`; add skills-registered check naming all five tm- skills; add explanation of the `unknown` stamp value in `.claude/template-version`.
- **architect.md ARBITRATION**: replace "Anchor on" with "Decide using".
- **reviewer.md**: prefer `gh pr diff <n>`; fall back to git form only when no PR exists; rename "verifiable behavior" -> "goal-driven execution" in Pass 2.

## Notes

- **Copyright year**: verified correct (upstream LICENSE = 2026); strings live in tm-grill-me/tm-to-issues which are out of scope - no edit.
- **`.claude/template-version`**: not changed. The `unknown` value is intentional (tm-sync-template treats any non-SHA as unknown-base mode). Adding a `#` comment would be overwritten on the next sync (step 4.1 writes the SHA directly). The explanation is placed in NEW-PROJECT-SETUP step 2 instead.
- This template has no executable check suite.

## Test plan

- [x] Grep CLAUDE.md: no "Fable 5" without model ID, no "adapt or delete", no "Add project-specific traps" as plain text
- [x] Grep reviewer.md: no "verifiable behavior", no "Anchor on" in architect.md
- [x] Grep NEW-PROJECT-SETUP.md: no `claude-code#32606`; `--clone` present; full URL present; all five tm- skill names listed
- [x] `git diff --name-only` lists only: `CLAUDE.md`, `NEW-PROJECT-SETUP.md`, `.claude/agents/architect.md`, `.claude/agents/reviewer.md`

Closes #67