### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .claude/settings.local.json
+# Transient worktrees the harness creates for isolation: worktree agents (see #78); never commit.
+.claude/worktrees/
 .env
 .env.*
 !.env.example


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore` so transient worktree directories created by the isolation harness (see #78) never surface in `git status` or get accidentally committed.
- Change is a two-line addition (comment + rule) after the existing `.claude/settings.local.json` entry. The trailing slash scopes the match to the directory and everything under it.
- No tracked files live under `.claude/worktrees/`, so no `git rm --cached` is needed.

Closes #79

## Verification

- `git check-ignore -v .claude/worktrees/agent-x` matches at `.gitignore:4` (exit 0)
- `git ls-files .claude/ | grep worktrees` returns nothing
- `git diff --name-only` lists exactly `.gitignore`

## Test plan

- [ ] `git check-ignore -v .claude/worktrees/<any-subpath>` returns a match (exit 0)
- [ ] No files under `.claude/worktrees/` appear in `git status`
- [ ] `git ls-files .claude/ | grep worktrees` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)