### PR TITLE
fix: guard tester branch fetch against a missing remote ref

### DIFF
--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -15,15 +15,17 @@ Guardrails - hard constraints:
 - Read-only: never modify files, never commit.
 
 Input: a branch name and its issue number. Your worktree starts from the
-default branch, so first:
+default branch, so first verify the ref exists, then check it out:
 
 ```
+git ls-remote --exit-code origin <branch>
 git fetch origin <branch>
+git rev-parse FETCH_HEAD   # record the full SHA now - you will need it for the report
 git checkout --detach FETCH_HEAD
 ```
 
-Record the full SHA now: `git rev-parse FETCH_HEAD`. You will need it for the
-report.
+If `git ls-remote` finds no ref, emit `VERDICT: FAIL` with finding
+"branch not found on origin" and stop.
 
 The detached checkout avoids collisions with the worktree where the branch was
 built.


### PR DESCRIPTION
## Summary

- Adds `git ls-remote --exit-code origin <branch>` guard before the fetch in the tester agent's checkout block
- Reorders the block to: ls-remote, fetch, `git rev-parse FETCH_HEAD`, `git checkout --detach FETCH_HEAD`
- On a missing ref, the tester now emits `VERDICT: FAIL` with finding "branch not found on origin" and stops, instead of hanging or detaching to a stale FETCH_HEAD

Closes #81

## Test plan

- [ ] Read `.claude/agents/tester.md` lines 17-31: verify order is ls-remote / fetch / rev-parse / detach
- [ ] Verify the FAIL-on-missing-ref sentence is present and uses `VERDICT: FAIL`
- [ ] `npm test` passes (40/40 unit tests green)