### PR TITLE
fix: align issue-template and kickoff parking prose across skills

### DIFF
--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -51,10 +51,10 @@ sign-off replaces this confirmation; do not ask twice.
 
 ## 3. Per-package pipeline
 
-Run up to 3 packages concurrently; dispatch their agents in parallel. A
-larger queue (up to 6 inside an /tm-advisor batch) starts the next package as
-one finishes. Worktree isolation keeps packages apart. Within a package the
-stages are serial:
+Run up to 3 packages concurrently; dispatch their agents in parallel. When
+the queue is larger (up to 6 in an /tm-advisor batch), start the next queued
+package as one finishes. Worktree isolation keeps packages apart. Within a
+package the stages are serial:
 
 1. Architect: SUB_PLAN for the issue (prefix the message with `JOB: SUB_PLAN`).
    Post it as an issue comment. On NEEDS_DECISION: inside an /tm-advisor batch,
@@ -73,9 +73,10 @@ stages are serial:
 5. On PASS: post the verdict as a PR comment, then dispatch the reviewer
    with the PR, the issue number, and the tester's UNTESTED CLAIMS, if any.
 6. On CHANGES_REQUESTED: post the report as a PR comment with the round
-   number, then the same fix loop as step 4 with the must-fix findings, then
-   re-test, then re-review forwarding the tester's UNTESTED CLAIMS from the
-   new re-test (not the previous round's claims).
+   number, then send the must-fix findings to a fresh developer dispatch in
+   the same format as step 4, then re-test, then re-review forwarding the
+   tester's UNTESTED CLAIMS from the new re-test (not the previous round's
+   claims).
 7. On APPROVE, with the last tester verdict PASS: mark the PR ready (`gh pr
    ready`), remove `in-progress`, and post a summary comment on the issue,
    including should-fix findings and untested claims for the human review. If
@@ -101,8 +102,8 @@ Routing rules:
   (tester fails after a reviewer fix round) re-enters the step-4 loop and
   increments the tester counter. On exhaustion of either counter, park the
   package.
-- Parking: post the open question or the exact state to the issue or PR,
-  swap `in-progress` for `needs-human`, and move on to the other packages.
+- Parking: post the reason on the issue, apply `needs-human` (remove
+  `in-progress` if present), and move on to the other packages.
 - Inside an /tm-advisor batch, mirror lead decisions and package outcomes
   (PR ready, parked) to the batch tracking issue as they happen.
 

--- a/.claude/skills/tm-to-issues/SKILL.md
+++ b/.claude/skills/tm-to-issues/SKILL.md
@@ -38,6 +38,10 @@ file paths or code snippets; they go stale.
 
 - [ ] ...
 - [ ] ...
+
+## Non-goals
+
+- ...
 ```
 
 ---


### PR DESCRIPTION
Closes #84

## Summary

- Added `## Non-goals` section to the issue body template in `tm-to-issues/SKILL.md`, matching the terse placeholder style of other template sections.
- Restated the parking bullet in `tm-kickoff/SKILL.md` to be unambiguous regardless of prior label state: "apply `needs-human` (remove `in-progress` if present)".
- Split the queue note into two distinct facts: the 3-concurrent cap, then the larger-queue start-next behavior.
- Made step 6's antecedent concrete: "send the must-fix findings to a fresh developer dispatch in the same format as step 4", keeping the "from the new re-test (not the previous round's claims)" qualifier.

## Test plan

- [x] `npm test` passes (40 tests, 0 failures) - no workflow code touched
- [x] `git diff --name-only` shows exactly two files changed
- [x] All four prose edits verified against spec; cross-references still resolve
- [x] Worktree cleanup and per-PR pipeline sections untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)