### PR TITLE
feat: add tm-install-team skill (#98)

### DIFF
--- a/.claude/skills/tm-install-team/SKILL.md
+++ b/.claude/skills/tm-install-team/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: tm-install-team
+description: Install or update the orchestrator team (agents, tm- skills, review workflows) into one or more user config dirs, so the team is available in every repo under that config without committing anything to the repo. User-invocable only.
+disable-model-invocation: true
+argument-hint: "[config-dir ...]"
+---
+
+Install the team into user config dirs. This copies the team from THIS template
+checkout into each target config dir's `agents/`, `skills/`, and `workflows/`,
+so every session under that config has the team in every repo, with nothing
+written into any repo working tree. Install and update are the same command:
+re-run to pull a newer template version.
+
+Run this from a checkout of the template (`sv-tmueller/claude-template`). Run
+`git pull` first if you want the latest; the source is this working tree, not a
+clone.
+
+Targets: $ARGUMENTS (one or more config dirs, for example
+`~/.claude-personal ~/.claude-work`). If empty, default to the active
+`$CLAUDE_CONFIG_DIR`. Treat each target independently: run sections 1-5 once per
+target.
+
+## 1. Guard: confirm source and targets
+
+- Confirm the source. This repo must carry the team: check that
+  `.claude/agents/`, `.claude/skills/`, and `.claude/workflows/` all exist
+  here. If not, stop; you are not in the template checkout.
+- Resolve each target to an absolute path (expand a leading `~`). For each,
+  print the resolved path and the list of items that will be written, then ask
+  the user to confirm before any write. Never write to a target the user has
+  not confirmed in this run. The work config dir is sensitive; explicit
+  confirmation is required.
+
+## 2. Copy the team into each target (additive, no silent clobber)
+
+For each confirmed target T, create `T/agents`, `T/skills`, `T/workflows` if
+they are missing (`mkdir -p`), then process these source items:
+
+- `.claude/agents/*.md`    -> `T/agents/<name>`     (files)
+- `.claude/skills/tm-*`    -> `T/skills/<name>`      (whole skill directories)
+- `.claude/workflows/*.js` -> `T/workflows/<name>`   (files; skip the
+  `.claude/workflows/__tests__/` directory)
+
+Decide per item by comparing source SRC to destination DST:
+
+- DST missing: copy it (`cp` for a file, `cp -R` for a skill directory).
+- DST present and identical (`diff -rq SRC DST` prints nothing): skip it.
+- DST present and different: do NOT overwrite. Add it to a conflict list for T.
+
+After walking every item, if T has conflicts, list them and ask the user
+whether to overwrite each with the template version. These are
+template-managed deploy copies, so overwrite is usually correct, but confirm.
+Overwrite only the items the user approves.
+
+## 3. Stamp the version
+
+Read the old stamp first if present (`cat T/.tm-team-version`) and remember it
+for the report. Then write the template HEAD SHA to `T/.tm-team-version`:
+
+    git rev-parse HEAD > T/.tm-team-version
+
+## 4. Check superpowers (detect and instruct, do not mutate)
+
+The team's `developer` and `tester` agents declare `skills: superpowers:...`
+in frontmatter and `tm-advisor` uses superpowers brainstorming, so the team
+needs superpowers enabled in each target config. Check whether it is:
+`grep -r superpowers T/settings.json T/.claude.json` (either file may be
+absent). If superpowers is not found, print these exact steps for the user to
+run in a session launched under that config dir, and note they are required
+for the team to work fully:
+
+    /plugin marketplace add anthropics/claude-plugins-official
+    /plugin install superpowers@claude-plugins-official
+
+Do not edit `settings.json` and do not run `/plugin` yourself.
+
+## 5. Report
+
+For each target, report: the resolved path; files copied; files skipped as
+identical; conflicts, and for each whether it was overwritten or left; the
+version stamp as `old -> new` (or `none -> new` on first install); and whether
+superpowers needs enabling. End with one line: re-run
+`/tm-install-team <targets>` after `git pull` to update.
+
+This skill never writes to any repo working tree. Removing a now-redundant
+committed team from a consuming repo is separate manual work
+(`git rm -r .claude/agents .claude/skills .claude/workflows` plus a PR) and
+never applies to this template repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
 ```
 .claude/
   agents/            role agents: architect, developer, tester, reviewer
-  skills/            project skills: /tm-advisor, /tm-grill-me, /tm-kickoff, /tm-sync-template, /tm-to-issues
+  skills/            project skills: /tm-advisor, /tm-grill-me, /tm-install-team, /tm-kickoff, /tm-sync-template, /tm-to-issues
   workflows/         bounded orchestration scripts (tm-review-changes, tm-review-codebase)
   settings.json      project settings; enables the superpowers plugin
                        enabledPlugins is template-managed (synced by /tm-sync-template);

--- a/docs/plans/98-tm-install-team.md
+++ b/docs/plans/98-tm-install-team.md
@@ -1,0 +1,255 @@
+# tm-install-team Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `/tm-install-team` skill that copies/updates the orchestrator team (agents, `tm-*` skills, review workflows) into one or more user config dirs, so the team works in repos it must not be committed to.
+
+**Architecture:** A single user-invocable prose skill, modelled on `tm-sync-template` but with no git, no PR, and a config-dir destination. The source is the local template working tree. Per target it copies additively, detects conflicts by diff (never silently clobbers), stamps the installed SHA, and checks (does not mutate) superpowers enablement.
+
+**Tech Stack:** Markdown skill file (`SKILL.md`) with YAML frontmatter, executed by the model with embedded shell (`cp`, `diff`, `git rev-parse`, `grep`). No code, no dependencies. Spec: `docs/superpowers/specs/2026-06-15-tm-install-team-design.md`.
+
+---
+
+## File structure
+
+- Create: `.claude/skills/tm-install-team/SKILL.md` - the whole skill.
+- Modify: `CLAUDE.md` - add `/tm-install-team` to the repo-layout skills list.
+
+No code modules, so no test files. Verification is a dry run of the skill's
+shell against throwaway temp dirs (Task 2).
+
+---
+
+### Task 1: Author the skill
+
+**Files:**
+- Create: `.claude/skills/tm-install-team/SKILL.md`
+
+- [ ] **Step 1: Write the file with exactly this content**
+
+````markdown
+---
+name: tm-install-team
+description: Install or update the orchestrator team (agents, tm- skills, review workflows) into one or more user config dirs, so the team is available in every repo under that config without committing anything to the repo. User-invocable only.
+disable-model-invocation: true
+argument-hint: "[config-dir ...]"
+---
+
+Install the team into user config dirs. This copies the team from THIS template
+checkout into each target config dir's `agents/`, `skills/`, and `workflows/`,
+so every session under that config has the team in every repo, with nothing
+written into any repo working tree. Install and update are the same command:
+re-run to pull a newer template version.
+
+Run this from a checkout of the template (`sv-tmueller/claude-template`). Run
+`git pull` first if you want the latest; the source is this working tree, not a
+clone.
+
+Targets: $ARGUMENTS (one or more config dirs, for example
+`~/.claude-personal ~/.claude-work`). If empty, default to the active
+`$CLAUDE_CONFIG_DIR`. Treat each target independently: run sections 1-5 once per
+target.
+
+## 1. Guard: confirm source and targets
+
+- Confirm the source. This repo must carry the team: check that
+  `.claude/agents/`, `.claude/skills/`, and `.claude/workflows/` all exist
+  here. If not, stop; you are not in the template checkout.
+- Resolve each target to an absolute path (expand a leading `~`). For each,
+  print the resolved path and the list of items that will be written, then ask
+  the user to confirm before any write. Never write to a target the user has
+  not confirmed in this run. The work config dir is sensitive; explicit
+  confirmation is required.
+
+## 2. Copy the team into each target (additive, no silent clobber)
+
+For each confirmed target T, create `T/agents`, `T/skills`, `T/workflows` if
+they are missing (`mkdir -p`), then process these source items:
+
+- `.claude/agents/*.md`    -> `T/agents/<name>`     (files)
+- `.claude/skills/tm-*`    -> `T/skills/<name>`      (whole skill directories)
+- `.claude/workflows/*.js` -> `T/workflows/<name>`   (files; skip the
+  `.claude/workflows/__tests__/` directory)
+
+Decide per item by comparing source SRC to destination DST:
+
+- DST missing: copy it (`cp` for a file, `cp -R` for a skill directory).
+- DST present and identical (`diff -rq SRC DST` prints nothing): skip it.
+- DST present and different: do NOT overwrite. Add it to a conflict list for T.
+
+After walking every item, if T has conflicts, list them and ask the user
+whether to overwrite each with the template version. These are
+template-managed deploy copies, so overwrite is usually correct, but confirm.
+Overwrite only the items the user approves.
+
+## 3. Stamp the version
+
+Read the old stamp first if present (`cat T/.tm-team-version`) and remember it
+for the report. Then write the template HEAD SHA to `T/.tm-team-version`:
+
+    git rev-parse HEAD > T/.tm-team-version
+
+## 4. Check superpowers (detect and instruct, do not mutate)
+
+The team's `developer` and `tester` agents declare `skills: superpowers:...`
+in frontmatter and `tm-advisor` uses superpowers brainstorming, so the team
+needs superpowers enabled in each target config. Check whether it is:
+`grep -r superpowers T/settings.json T/.claude.json` (either file may be
+absent). If superpowers is not found, print these exact steps for the user to
+run in a session launched under that config dir, and note they are required
+for the team to work fully:
+
+    /plugin marketplace add anthropics/claude-plugins-official
+    /plugin install superpowers@claude-plugins-official
+
+Do not edit `settings.json` and do not run `/plugin` yourself.
+
+## 5. Report
+
+For each target, report: the resolved path; files copied; files skipped as
+identical; conflicts, and for each whether it was overwritten or left; the
+version stamp as `old -> new` (or `none -> new` on first install); and whether
+superpowers needs enabling. End with one line: re-run
+`/tm-install-team <targets>` after `git pull` to update.
+
+This skill never writes to any repo working tree. Removing a now-redundant
+committed team from a consuming repo is separate manual work
+(`git rm -r .claude/agents .claude/skills .claude/workflows` plus a PR) and
+never applies to this template repo.
+````
+
+- [ ] **Step 2: Verify the frontmatter registers**
+
+Run: `head -6 .claude/skills/tm-install-team/SKILL.md`
+Expected: `name`, `description`, `disable-model-invocation: true`, and a quoted
+`argument-hint` string (quoting matters; an unquoted bracketed value can parse
+as a YAML array and silently fail to register).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/tm-install-team/SKILL.md
+git commit -m "feat: add tm-install-team skill (#98)"
+```
+
+---
+
+### Task 2: Dry-run verification against temp dirs
+
+**Files:** none (runs the skill's shell against throwaway dirs).
+
+This proves the copy, idempotency, conflict detection, multi-target, and
+superpowers-check behaviours without touching any real config dir.
+
+- [ ] **Step 1: Set up two empty targets and run the core copy for T1**
+
+```bash
+T1=$(mktemp -d); T2=$(mktemp -d); echo "T1=$T1 T2=$T2"
+mkdir -p "$T1/agents" "$T1/skills" "$T1/workflows"
+cp .claude/agents/*.md "$T1/agents/"
+for d in .claude/skills/tm-*; do cp -R "$d" "$T1/skills/"; done
+cp .claude/workflows/*.js "$T1/workflows/"
+git rev-parse HEAD > "$T1/.tm-team-version"
+```
+
+- [ ] **Step 2: Confirm the team landed**
+
+Run:
+```bash
+ls "$T1/agents" && ls "$T1/skills" && ls "$T1/workflows" && cat "$T1/.tm-team-version"
+```
+Expected: 4 agent files; the `tm-*` skill dirs (including `tm-install-team`); the
+`tm-review-*.js` files and no `__tests__`; a 40-char SHA.
+
+- [ ] **Step 3: Idempotency, identical files are skipped**
+
+Run: `diff -rq .claude/agents "$T1/agents"; diff -rq .claude/workflows/tm-review-changes.js "$T1/workflows/tm-review-changes.js"`
+Expected: no output (identical), so a re-run would skip every file.
+
+- [ ] **Step 4: Conflict detection, an edited target file is flagged not clobbered**
+
+Run:
+```bash
+printf '\nlocal edit\n' >> "$T1/agents/architect.md"
+diff -q .claude/agents/architect.md "$T1/agents/architect.md"
+```
+Expected: `Files ... differ` - this is the conflict the skill lists and asks
+about, rather than overwriting.
+
+- [ ] **Step 5: Multi-target independence**
+
+Run:
+```bash
+mkdir -p "$T2/agents"; cp .claude/agents/*.md "$T2/agents/"; ls "$T2/agents"
+```
+Expected: T2 populated independently of T1.
+
+- [ ] **Step 6: Superpowers check prints instructions when absent**
+
+Run: `grep -r superpowers "$T1/settings.json" "$T1/.claude.json" 2>/dev/null; echo "exit=$?"`
+Expected: no match (`exit=2`), so the skill would print the two enable
+commands. (Sanity check the positive case against a real config:
+`grep -l superpowers ~/.claude-work/settings.json` prints the path, so the
+skill would report superpowers already enabled there.)
+
+- [ ] **Step 7: Clean up**
+
+```bash
+rm -rf "$T1" "$T2"
+```
+Expected: temp dirs removed. No real config dir was touched.
+
+---
+
+### Task 3: Reference the skill in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` (repo-layout skills list)
+
+- [ ] **Step 1: Add the skill to the list**
+
+In the `Repo layout` block, change the `skills/` line so it reads:
+
+```
+  skills/            project skills: /tm-advisor, /tm-grill-me, /tm-install-team, /tm-kickoff, /tm-sync-template, /tm-to-issues
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: list tm-install-team in repo layout (#98)"
+```
+
+---
+
+### Task 4: Open the PR for review
+
+- [ ] **Step 1: Push and mark the draft ready**
+
+```bash
+git push -u origin feat/98-tm-install-team
+gh pr ready
+```
+
+- [ ] **Step 2: Confirm**
+
+Run: `gh pr view --json state,isDraft`
+Expected: not draft, open. The PR body should reference `Closes #98`.
+
+---
+
+## Self-review
+
+- **Spec coverage:** new skill (Decision 1) -> Task 1; local-checkout source
+  (Decision 2) -> SKILL.md section intro; multi-target (Decision 3) -> SKILL.md
+  targets line + Task 2 step 5; diff-and-confirm conflicts (Decision 4) ->
+  SKILL.md section 2 + Task 2 steps 3-4; superpowers detect-and-instruct
+  (Decision 5) -> SKILL.md section 4 + Task 2 step 6; never touches a repo
+  (Decision 6) -> SKILL.md closing line. Verification list in the spec ->
+  Task 2 steps 1-7. All covered.
+- **Placeholder scan:** none; the full SKILL.md content and every command are
+  inline.
+- **Consistency:** target variable `T`, stamp file `.tm-team-version`, and the
+  agents/skills/workflows source globs are identical across the spec, the
+  SKILL.md, and the verification.

--- a/docs/superpowers/specs/2026-06-15-tm-install-team-design.md
+++ b/docs/superpowers/specs/2026-06-15-tm-install-team-design.md
@@ -142,6 +142,18 @@ throwaway temp dir, never `~/.claude-work`:
 5. With no `superpowers` in a target config, confirm the enable instructions
    print.
 
+The dry run proves the copy mechanics, not that the team loads from a config
+dir. That loading is documented: user-scope workflows are read from
+`~/.claude/workflows/` and are "available in every project," and
+`CLAUDE_CONFIG_DIR` relocates every `~/.claude` path (so the real location is
+`<config-dir>/workflows/`); skills and agents load from the same user dir.
+Because the revert follow-up is destructive, confirm it once empirically before
+that step: in a real session under the target config (for example a
+`claude-work` session) opened in a repo that does not carry the team, check that
+`/tm-advisor` is offered, an agent dispatches, and a `tm-review-*` workflow is
+found. Sources: `code.claude.com/docs/en/workflows.md`,
+`code.claude.com/docs/en/claude-directory.md`.
+
 ## Follow-up work (not this issue)
 
 - **Revert the committed team from personal repos.** Once `tm-install-team`
@@ -149,8 +161,9 @@ throwaway temp dir, never `~/.claude-work`:
   `.claude/{agents,skills,workflows}` in personal consuming repos is redundant
   and can be removed (`git rm -r ...` + PR per repo). Keep each repo's
   `CLAUDE.md`. Do not strip the template repo. This is a dependent batch: it
-  must come after this issue is merged and the install has been run, or the
-  repos would be stranded. It needs the list of personal repos
+  must come after this issue is merged, the install has been run, and a smoke
+  test (see Verification) has confirmed the team loads from the config dir, or
+  the repos would be stranded. It needs the list of personal repos
   (`gh repo list`).
 - **tm-sync-template Section 3 cleanup.** `tm-sync-template` keeps a user-scope
   copy of itself current as a bootstrap. Once `tm-install-team` manages the

--- a/docs/superpowers/specs/2026-06-15-tm-install-team-design.md
+++ b/docs/superpowers/specs/2026-06-15-tm-install-team-design.md
@@ -1,0 +1,158 @@
+# tm-install-team: install the team into user config dirs
+
+Status: approved design, 2026-06-15. Brainstormed and signed off decision by
+decision in session. Issue #98. Not yet implemented.
+
+## Goal
+
+Make the orchestrator team (agents, `tm-*` skills, review workflows) available
+in repos you do not want to commit it to, above all an organization's private
+repo worked under the `claude-work` account. The team should appear in every
+repo under a config dir, with nothing written into any working tree, and the
+same command should both install and update it.
+
+A new user-invocable skill, `/tm-install-team`, copies the team from the local
+template checkout into one or more user config dirs. It is the user-scope
+counterpart to `tm-sync-template`, which syncs the team into a repo and opens a
+PR.
+
+## The model this rests on
+
+Two facts from the Claude Code docs govern the whole design:
+
+- **Scope precedence (highest wins):** managed (org IT policy) > project
+  (team committed in a repo's `.claude/`) > user (team in a config dir). A
+  same-named agent, skill, or workflow in a higher scope shadows the lower one.
+- **Config dirs are isolated per alias:** `claude-personal` ->
+  `~/.claude-personal`, `claude-work` -> `~/.claude-work`. Installing into one
+  does nothing for the other.
+
+So a user-scope install is the default team for every repo under that config
+dir, and a repo that carries its own committed team transparently overrides the
+user-scope copy where present. The two never conflict.
+
+Plugins were rejected as the delivery vehicle for two verified reasons: the
+Workflow scripts (`tm-review-*.js`) are not a pluginnable component, and plugin
+skills are namespaced (`/plugin:tm-advisor`), which would break the bare-name
+cross-references between the `tm-*` skills. User scope keeps bare names, so the
+cross-references keep working unchanged.
+
+## Use cases
+
+| Repo | Team committed in repo? | Team comes from | Action |
+|------|-------------------------|-----------------|--------|
+| Personal public, template-merged | Yes | repo `.claude/` (project) | keep fresh with `tm-sync-template`, or strip it and rely on user scope to avoid publishing the machinery |
+| Personal private, template-merged | Yes | repo `.claude/` (project) | same, committing is low-cost since not public |
+| Org private, no template | No | config dir (user) | `/tm-install-team ~/.claude-work` + enable superpowers there; nothing committed |
+
+The intended end state is full user scope: install into both `~/.claude-personal`
+and `~/.claude-work`, then strip the now-redundant committed team from personal
+repos (see Follow-up). The template repo itself keeps its `.claude/`; it is the
+source of truth.
+
+## Decisions
+
+### 1. A new skill, not a mode in tm-sync-template
+
+`tm-sync-template` is built around a repo: clone the template, three-way merge
+against a version stamp, file an issue, open a PR. A config-dir install has no
+git, no PR, and no issue. Folding a no-git mode into that skill would split it
+across two output models and hurt clarity. `tm-install-team` does one job.
+
+Rejected: a `--target` mode inside `tm-sync-template`.
+
+### 2. Source is the local checkout
+
+The skill copies from the current repo's `.claude/{agents,skills,workflows}`.
+This repo is the canonical template (`origin = sv-tmueller/claude-template`), so
+cloning the remote to read what is already checked out is redundant. The user
+runs `git pull` first when they want the latest.
+
+Rejected: cloning the canonical remote every run (the temp-dir dance
+`tm-sync-template` needs because it can run inside a consuming repo).
+
+### 3. One or more target config dirs per run
+
+The argument is one or more config dirs: `/tm-install-team ~/.claude-personal
+~/.claude-work`. With no argument it defaults to the active session's
+`$CLAUDE_CONFIG_DIR`. Each target is resolved to an absolute path, echoed, and
+confirmed before any write, which satisfies the standing rule not to touch
+`~/.claude-work` casually. Install and update are the same command: re-running
+updates each target in place.
+
+Rejected: a single target only (would force two separate runs for the common
+personal + work case).
+
+### 4. Conflict handling is diff-and-confirm
+
+Per file in each target: absent -> copy; identical -> skip; different -> list it
+and ask before overwriting. The skill writes `<target>/.tm-team-version` (the
+installed template SHA) for visibility on the next run. This is deliberately
+simpler than `tm-sync-template`'s three-way merge, because config-dir copies are
+deploy targets, not files you hand-edit.
+
+Rejected: porting the full three-way merge (heavier, and the precise
+local-edit detection it buys is not worth it for deploy targets).
+
+### 5. Superpowers is detect-and-instruct, never auto-enabled
+
+After copying, the skill checks each target config for `superpowers` in
+`enabledPlugins`; if absent, it prints the exact enable commands. It does not
+edit `settings.json` or run `/plugin`. The team's `developer` and `tester`
+agents declare `skills: superpowers:...` and `tm-advisor` leans on superpowers
+brainstorming, so an unenabled superpowers is a likely cause of the team
+degrading in a fresh config dir. Enabling it is the one manual step left.
+
+Rejected: registering the marketplace and writing `enabledPlugins` for the
+user. `/plugin` is not cleanly scriptable from a skill, and a partial write
+risks a half-configured state.
+
+### 6. The skill never touches a repo
+
+`tm-install-team` writes only to target config dirs. Removing the committed team
+from consuming personal repos is separate work (see Follow-up); the skill does
+not do it.
+
+## What it installs (additive)
+
+- `.claude/agents/*.md` -> `<target>/agents/`
+- `.claude/skills/tm-*` -> `<target>/skills/`
+- `.claude/workflows/*.js` -> `<target>/workflows/` (skips `__tests__/`)
+
+## Non-goals
+
+- Never writes to the org repo or the current working tree.
+- Does not install or enable plugins (detect + instruct only).
+- Does not clone the canonical remote.
+- Does not modify or revert consuming repos.
+- Does not change where the team writes work artifacts (plans, specs, PRs)
+  inside a consuming repo.
+
+## Verification
+
+The skill is prose (no code logic), so it is verified by a dry run against a
+throwaway temp dir, never `~/.claude-work`:
+
+1. Run against an empty temp dir; confirm `agents/`, `skills/`, `workflows/`
+   land with the expected files and `.tm-team-version` is written.
+2. Re-run; confirm identical files are skipped (idempotent).
+3. Edit one target file, re-run; confirm it is reported as a conflict and not
+   clobbered.
+4. Pass two temp dirs in one run; confirm each is handled independently.
+5. With no `superpowers` in a target config, confirm the enable instructions
+   print.
+
+## Follow-up work (not this issue)
+
+- **Revert the committed team from personal repos.** Once `tm-install-team`
+  ships and the team is installed into both config dirs, the committed
+  `.claude/{agents,skills,workflows}` in personal consuming repos is redundant
+  and can be removed (`git rm -r ...` + PR per repo). Keep each repo's
+  `CLAUDE.md`. Do not strip the template repo. This is a dependent batch: it
+  must come after this issue is merged and the install has been run, or the
+  repos would be stranded. It needs the list of personal repos
+  (`gh repo list`).
+- **tm-sync-template Section 3 cleanup.** `tm-sync-template` keeps a user-scope
+  copy of itself current as a bootstrap. Once `tm-install-team` manages the
+  whole team user-scope, that step is redundant and can be dropped. Surgical,
+  left out of this issue.


### PR DESCRIPTION
Closes #98.

## What and why

A new user-invocable skill, `/tm-install-team`, installs or updates the
orchestrator team (agents, `tm-*` skills, review workflows) into one or more
**user config dirs** (e.g. `~/.claude-personal`, `~/.claude-work`). This makes
the team available in every repo under that config, above all an organization's
private repo, with nothing committed to the repo. It is the user-scope
counterpart to `tm-sync-template` (which syncs into a repo and opens a PR).

Plugins were rejected as the vehicle: the Workflow scripts are not a pluginnable
component, and plugin skills get namespaced (`/plugin:tm-advisor`), which would
break the bare-name cross-references between the `tm-*` skills. User scope keeps
bare names, so the cross-references keep working unchanged.

## Contents

- `docs/superpowers/specs/2026-06-15-tm-install-team-design.md` - design + the
  scope-precedence model it rests on.
- `docs/plans/98-tm-install-team.md` - implementation plan + dry-run.
- `.claude/skills/tm-install-team/SKILL.md` - the skill.
- `CLAUDE.md` - skill listed in repo layout.

## Behaviour

- Source is the local template checkout; one or more target config dirs per run
  (defaults to the active `$CLAUDE_CONFIG_DIR`).
- Additive copy of `agents/*.md`, `skills/tm-*`, `workflows/*.js` (skips
  `__tests__/`). Per file: missing -> copy, identical -> skip, different ->
  confirm before overwrite (no silent clobber).
- Writes `<target>/.tm-team-version` (installed SHA). Install and update are the
  same command.
- Detects whether `superpowers` is enabled per target and prints the enable
  commands if not; never edits settings.json or runs `/plugin`.
- Never writes to any repo working tree.

## Verification

- Dry-run against throwaway temp dirs: team lands (no `__tests__`), re-run is
  idempotent, an edited target file is reported as a conflict (not clobbered),
  multiple targets are independent, and the superpowers check prints
  instructions on an empty dir while confirming it is already enabled in
  `~/.claude-work`. No real config dir touched.
- `npm test`: 40 passed, 0 failed.

## Follow-ups (not in this PR)

- Revert the now-redundant committed team from personal consuming repos once
  this ships and the team is installed into both config dirs (dependent work;
  keep each repo's CLAUDE.md; never the template repo).
- Drop `tm-sync-template`'s self-bootstrap step (Section 3), made redundant by
  this skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)