### PR TITLE
feat: add idempotent ensure-labels step to tm-kickoff and tm-advisor

### DIFF
--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -57,7 +57,18 @@ This is the only confirmation in the loop; after it, run unattended.
 
 ## 3. File
 
-On approval:
+On approval, first ensure the canonical label set exists on this repo (`gh label create` is a GitHub write and must not run before sign-off):
+
+```
+gh label create "size:S"       --color "c2e0c6" --description "Under 1 hour. One focused change." --force
+gh label create "size:M"       --color "BFD4F2" --description "1 to 3 hours. Write a sub-plan first." --force
+gh label create "size:L"       --color "F9D0C4" --description "4 to 6 hours. Split or checkpoint." --force
+gh label create "size:XL"      --color "D93F0B" --description "About 8 hours. Too big. Split it." --force
+gh label create "in-progress"  --color "FBCA04" --description "Package dispatched by /kickoff; resume, do not restart." --force
+gh label create "needs-human"  --color "B60205" --description "Agent loop exhausted or blocked; human decision needed." --force
+```
+
+`--force` upserts: it creates each label when absent and sets identical values when present, so a second run (for example when kickoff's Gate step runs the same block later in the same batch) is a true no-op and exits 0. Then:
 
 1. Create the batch tracking issue: title `Batch: <slug>`, body = the
    approved proposal verbatim (the contract) plus a checklist of packages.

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -19,6 +19,19 @@ numbers as the packages list before proceeding.
 
 ## 1. Gate
 
+Ensure the canonical label set exists on this repo before any dispatch:
+
+```
+gh label create "size:S"       --color "c2e0c6" --description "Under 1 hour. One focused change." --force
+gh label create "size:M"       --color "BFD4F2" --description "1 to 3 hours. Write a sub-plan first." --force
+gh label create "size:L"       --color "F9D0C4" --description "4 to 6 hours. Split or checkpoint." --force
+gh label create "size:XL"      --color "D93F0B" --description "About 8 hours. Too big. Split it." --force
+gh label create "in-progress"  --color "FBCA04" --description "Package dispatched by /kickoff; resume, do not restart." --force
+gh label create "needs-human"  --color "B60205" --description "Agent loop exhausted or blocked; human decision needed." --force
+```
+
+`--force` upserts: it creates each label when absent and sets identical values when present, so a second run (including the advisor→kickoff double-run in a batch) is a true no-op and exits 0.
+
 For each issue, `gh issue view <n> --comments`, and
 `gh pr list --state open --search "Closes #<n>"` to find an existing PR.
 


### PR DESCRIPTION
Closes #105

## Summary

- Adds a `gh label create ... --force` block for the six canonical labels at the start of `tm-kickoff`'s Gate section (before any per-issue dispatch).
- Adds the same block as the first action in `tm-advisor`'s File section (after sign-off, since `gh label create` is a GitHub write that must not run before user approval).
- Both use `--force` for true idempotent upsert: creates labels when absent, sets identical values when present, exits 0 either way.
- A half-sentence in each step notes the advisor→kickoff double-run in a batch is benign by design.

## Idempotency verification

Run against this repo (all six labels already present — exercises the no-op/upsert path):

```
gh label list > /tmp/labels-before

gh label create "size:S"       --color "c2e0c6" --description "Under 1 hour. One focused change." --force
gh label create "size:M"       --color "BFD4F2" --description "1 to 3 hours. Write a sub-plan first." --force
gh label create "size:L"       --color "F9D0C4" --description "4 to 6 hours. Split or checkpoint." --force
gh label create "size:XL"      --color "D93F0B" --description "About 8 hours. Too big. Split it." --force
gh label create "in-progress"  --color "FBCA04" --description "Package dispatched by /kickoff; resume, do not restart." --force
gh label create "needs-human"  --color "B60205" --description "Agent loop exhausted or blocked; human decision needed." --force

gh label list > /tmp/labels-mid
echo "run1 exit=$?"

gh label create "size:S"       --color "c2e0c6" --description "Under 1 hour. One focused change." --force
gh label create "size:M"       --color "BFD4F2" --description "1 to 3 hours. Write a sub-plan first." --force
gh label create "size:L"       --color "F9D0C4" --description "4 to 6 hours. Split or checkpoint." --force
gh label create "size:XL"      --color "D93F0B" --description "About 8 hours. Too big. Split it." --force
gh label create "in-progress"  --color "FBCA04" --description "Package dispatched by /kickoff; resume, do not restart." --force
gh label create "needs-human"  --color "B60205" --description "Agent loop exhausted or blocked; human decision needed." --force

gh label list > /tmp/labels-after
echo "run2 exit=$?"

diff /tmp/labels-before /tmp/labels-after
```

**Result:** empty diff, both runs exit 0. Labels unchanged. No-op path confirmed.

**Note:** the fresh-create path (a repo missing these labels) is not exercised here - that would require a scratch repo with no labels. Out of scope for this verification per the sub-plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)