### PR TITLE
docs: document team-guide.md delivery and import step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ready-made agent team for Claude Code.
   team into one or more user config dirs (`/tm-install-team ~/.claude-personal
   ~/.claude-work`), so it is available in every repo under that config without
   being committed anywhere. Copies the operational skills, agents, and
-  workflows, and checks superpowers is enabled. The user-scope path for repos
+  workflows, and `team-guide.md`, and checks superpowers is enabled. The user-scope path for repos
   you do not want to carry the team (an org repo).
 - `.claude/workflows/` - bounded orchestration scripts. `tm-review-changes`
   reviews a diff with a fixed set of Sonnet reviewers plus one Opus critic;
@@ -60,7 +60,7 @@ gh repo create <new-repo> --template sv-tmueller/claude-template --private --clo
 # then work through NEW-PROJECT-SETUP.md
 ```
 
-Copying only `CLAUDE.md` works but does not carry the agents and skills.
+Copying only `CLAUDE.md` works but does not carry the agents and skills, and leaves its `@.claude/team-guide.md` import dangling.
 
 ## Getting the team into your repos
 
@@ -78,7 +78,12 @@ git pull                                          # get the latest first
 
 It copies the operational skills, agents, and workflows into each
 `<config-dir>/{skills,agents,workflows}/` and tells you if superpowers needs
-enabling there. Re-run after a `git pull` to update. A repo that carries its own
+enabling there. It also copies `team-guide.md` to `<config-dir>/team-guide.md`.
+For the guide to load, add a `@team-guide.md` line to `<config-dir>/CLAUDE.md`
+yourself; the install prints this and does not edit `CLAUDE.md`. Note that a
+config-dir `CLAUDE.md` replaces `~/.claude/CLAUDE.md` instead of stacking with
+it, so re-import the four global coding principles in the same file if you rely
+on them. Re-run after a `git pull` to update. A repo that carries its own
 committed team overrides the user-scope copy, so the two never clash.
 
 **Committed in the repo.** A repo created from this template carries the team

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ready-made agent team for Claude Code.
 - `.claude/skills/tm-install-team/` - `/tm-install-team`: installs or updates the
   team into one or more user config dirs (`/tm-install-team ~/.claude-personal
   ~/.claude-work`), so it is available in every repo under that config without
-  being committed anywhere. Copies the operational skills, agents, and
+  being committed anywhere. Copies the operational skills, agents,
   workflows, and `team-guide.md`, and checks superpowers is enabled. The user-scope path for repos
   you do not want to carry the team (an org repo).
 - `.claude/workflows/` - bounded orchestration scripts. `tm-review-changes`


### PR DESCRIPTION
Closes #110

## Summary

Three localized edits to README.md:

1. **`/tm-install-team` bullet (line 34):** Added `team-guide.md` to the list of what the install copies.
2. **User-scope subsection (~line 79):** Documented that the install also copies `team-guide.md` to `<config-dir>/team-guide.md`, that the user must add a `@team-guide.md` line to `<config-dir>/CLAUDE.md` for the guide to load (install prints this, never edits CLAUDE.md), and the caveat that a config-dir `CLAUDE.md` replaces `~/.claude/CLAUDE.md` instead of stacking.
3. **"Copying only CLAUDE.md" note (line 63):** Added that it also leaves the `@.claude/team-guide.md` import dangling.

## Verification

- Diff shows exactly three spots changed; no restructure, no license change.
- Config-dir-relative `@team-guide.md` (edit 2) matches SKILL.md line 78; landing path matches SKILL.md line 48.
- Two relative bases are not crossed: edit 2 uses `@team-guide.md` (no prefix), edit 3 uses `@.claude/team-guide.md`.
- `grep -n '@.claude/team-guide.md' CLAUDE.md` returns line 38 - confirms the import underpinning edit 3.
- No em dashes: zero hits.
- `npm test`: 40 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)