### PR TITLE
docs: mark the new-project-setup labels step optional

### DIFF
--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -9,9 +9,12 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 - [ ] Create the repo (`gh repo create <name> --template sv-tmueller/claude-template --clone`).
 - [ ] Protect `main`: block direct pushes, require a PR, require status checks to
       pass before merge.
-- [ ] Create the labels the workflow uses: the sizing set `size:S`, `size:M`,
-      `size:L`, `size:XL` (see team-guide.md "Sizing") plus `in-progress` and
-      `needs-human` (see team-guide.md "Agent team").
+- [ ] (Optional) Create the labels the workflow uses: the sizing set `size:S`,
+      `size:M`, `size:L`, `size:XL` (see team-guide.md "Sizing") plus
+      `in-progress` and `needs-human` (see team-guide.md "Agent team").
+      `/tm-kickoff` and `/tm-advisor` create these six automatically on first
+      run, so this step is only needed if you file sized issues (for example
+      via `/tm-to-issues`) before the first kickoff or advisor run.
 - [ ] (Optional) Create the labels you will filter on, e.g. `phase:0`, `phase:1`,
       `type:feat`, `type:fix`.
 


### PR DESCRIPTION
Closes #112.

`/tm-kickoff` and `/tm-advisor` auto-create the six workflow labels on first run (folded in by #105), so the manual "create the labels" step in NEW-PROJECT-SETUP.md is now optional, needed only if you file sized issues (e.g. via `/tm-to-issues`) before the first kickoff/advisor run.

Lead-driven quick PR (no team pipeline). Surgical: one checklist item in NEW-PROJECT-SETUP.md. npm test 40/40; no em dashes.