### PR TITLE
docs: add agent-team architecture doc (flat-star diagrams + rationale)

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -84,7 +84,8 @@ The template ships four role agents in `.claude/agents/` and a set of skills.
 The lead is the main session: subagents cannot call each other, so the
 session running `/tm-kickoff` routes every handoff, and GitHub (sub-plan and
 verdict comments, draft PRs, labels) holds the state that makes a dropped
-session resumable.
+session resumable. A diagram of this flat-star model and the per-package
+pipeline lives in `docs/team-architecture.md`.
 
 - `architect` - advisory, read-only: sub-plans, split proposals, arbitration.
 - `developer` - one issue end to end in an isolated worktree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ docs/
   plans/             implementation plans, <issue-number>-<slug>.md
   reviews/           dated codebase-review reports from /tm-review-codebase
   superpowers/specs/ approved designs, YYYY-MM-DD-<topic>-design.md
+  team-architecture.md  flat-star agent-team diagrams and rationale
 e2e/                 end-to-end tests; structure depends on the app (see NEW-PROJECT-SETUP)
 ```
 

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -1,0 +1,89 @@
+# Agent team architecture
+
+How the orchestrator team actually runs. The operating rules live in
+`.claude/team-guide.md`; this doc adds the picture. The per-package mechanics
+(parking, caps, routing) live in `.claude/skills/tm-kickoff/SKILL.md`.
+
+## Flat star, not a nested tree
+
+Claude Code now lets a subagent spawn its own subagents (a nested tree; the
+tutorial this doc draws on reports a fixed depth cap, which we have not measured
+here). We deliberately do not nest. The lead session is the only spawner and
+routes every handoff. Three of the four role agents are read-only by tool
+restriction; the developer writes code but is held to the same no-spawn rule, so
+the star is structural, not just convention.
+
+The reason is resumability. A nested tree lives and dies inside one session, so
+a dropped connection loses the in-flight sub-tree. Our handoffs go through the
+lead and land as GitHub artifacts (sub-plan comments, PR verdict comments,
+labels), so a dropped session resumes from GitHub instead of restarting. We keep
+the separation a nested model gives (one concern per agent, evidence flows up,
+independent review, draft PR with the human merging) without trading away
+resumability. Parallelism comes from worktree isolation, not nesting.
+
+```mermaid
+graph TD
+    H["Human<br/>files and sizes issues, merges PRs"] --> L
+    L["LEAD - main session<br/>message bus and router<br/>owns no code; durable state lives in GitHub"]
+
+    L -->|"JOB: SUB_PLAN / SPLIT / ARBITRATION"| A["architect (opus)<br/>read-only - approach, splits, arbitration"]
+    L -->|"issue + sub-plan"| D["developer (sonnet)<br/>one issue end to end - worktree - TDD - draft PR"]
+    L -->|"branch + issue"| T["tester (sonnet)<br/>read-only - re-runs suite, attacks change"]
+    L -->|"PR + issue + untested claims"| R["reviewer (opus)<br/>read-only - spec pass then quality pass"]
+
+    A -.->|"SUB_PLAN / NEEDS_DECISION"| L
+    D -.->|"STATUS / BRANCH / PR / CHECKS"| L
+    T -.->|"VERDICT / FINDINGS"| L
+    R -.->|"VERDICT / FINDINGS"| L
+
+    L <-->|"sub-plans, PR verdicts, labels = resumable state"| G[("GitHub")]
+```
+
+Four peers under one lead, no third level. Evidence flows back to the lead, which
+routes it into the next agent. GitHub holds the state that makes a dropped
+session resumable.
+
+## The per-package pipeline
+
+For one issue, the lead runs the agents in sequence and loops on failure. This is
+the happy path with the two fix loops. It omits parking (`needs-human`),
+`NEEDS_CONTEXT`, architect arbitration on developer pushback, and the 3-round fix
+caps, all of which live in `.claude/skills/tm-kickoff/SKILL.md`.
+
+```mermaid
+sequenceDiagram
+    participant L as Lead (router)
+    participant A as architect
+    participant D as developer
+    participant T as tester
+    participant R as reviewer
+    L->>A: JOB: SUB_PLAN (issue n)
+    A-->>L: SUB_PLAN (or NEEDS_DECISION)
+    Note over L: post sub-plan comment, label in-progress
+    L->>D: issue + sub-plan
+    D-->>L: STATUS: DONE (branch, draft PR, CHECKS)
+    L->>T: branch + issue
+    alt VERDICT: FAIL
+        T-->>L: FINDINGS (repro commands)
+        L->>D: fix exactly these
+        D-->>L: STATUS: DONE
+        L->>T: re-test
+    end
+    T-->>L: VERDICT: PASS
+    L->>R: PR + issue + untested claims
+    alt CHANGES_REQUESTED
+        R-->>L: must-fix FINDINGS
+        L->>D: fix exactly these
+        Note over L,T: re-test, then re-review
+    end
+    R-->>L: VERDICT: APPROVE
+    Note over L: gh pr ready, summary comment. Human merges.
+```
+
+Up to three packages run this pipeline at once, in isolated worktrees. The lead
+never edits code; it routes reports and decides escalations.
+
+---
+
+Source: drawn from a tutorial on nested subagents in Claude Code
+(owainlewis/youtube-tutorials), adapted to our flat-star model.


### PR DESCRIPTION
Closes #114

Adds `docs/team-architecture.md`: two mermaid diagrams of how the team runs (the flat-star routing model and the per-package pipeline) plus the rationale for flat-star over nested subagents (resumability via GitHub-backed state). Adds a one-line pointer from `.claude/team-guide.md` and a line in the CLAUDE.md repo map.

Came from reviewing an external nested-subagents tutorial. We keep our flat-star structure as master; the diagrams are redrawn for our architecture, not copied. The nesting depth cap is attributed to the source, not stated as a measured fact.

## Checks
- `npm test`: 40 pass, 0 fail.
- Mermaid checked by reading only, not rendered locally (no renderer in the repo). GitHub renders both blocks in this PR, so please glance at the rendered diagrams to confirm they look right.

## Non-goals
No nesting added. No `tm-install-team` change (doc stays repo-only, like the other `docs/` paths team-guide references). No change to the role agents or README.