### PR TITLE
refactor: harden developer agent (drop Agent tool, add CHECKS evidence)

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,6 +1,7 @@
 ---
 name: developer
 description: Implements exactly one GitHub issue end to end: branch, TDD, conventional commits, draft PR.
+tools: Read, Grep, Glob, Bash, Write, Edit, TodoWrite
 model: sonnet
 isolation: worktree
 skills: superpowers:test-driven-development
@@ -55,7 +56,8 @@ Then:
   (`gh pr create --draft`, body contains `Closes #<n>`), in that order: the
   PR needs a pushed commit to exist.
 - Implement with TDD per the preloaded skill. Run the full check suite from
-  CLAUDE.md "Useful commands" before reporting.
+  CLAUDE.md "Useful commands" before reporting. Record each check command and
+  its exit code for the CHECKS line.
 - Commits and style per CLAUDE.md. Push after each green step.
 - On a fix round, fix exactly the numbered findings you were given. If a
   finding is wrong, say so in your report instead of silently skipping it.
@@ -68,6 +70,7 @@ End with exactly this structure:
 STATUS: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
 BRANCH: <feat|fix>/<n>-<slug>
 PR: <url; "none" only with NEEDS_CONTEXT or BLOCKED>
+CHECKS: <each check command and its exit code, e.g. `npm test` -> 0; "none" only with NEEDS_CONTEXT or BLOCKED>
 DEVIATIONS: <anything done differently from the sub-plan, or "none">
 NOTES: <concerns, the questions (NEEDS_CONTEXT), or the blocker (BLOCKED)>
 ```


### PR DESCRIPTION
Closes #115

Two edits to `.claude/agents/developer.md`:

1. Add an explicit `tools:` line (`Read, Grep, Glob, Bash, Write, Edit, TodoWrite`). The developer had no tools line, so it inherited everything including the subagent-spawn tool; the flat-star "only the lead spawns" was a convention, not a guarantee. The enumeration removes only the spawn capability and keeps what the developer uses to implement. Applies the source tutorial maxim "the tools line is the safety model" to our one writer agent.
2. Add a `CHECKS:` line to the report contract (each check command + exit code, required on DONE/DONE_WITH_CONCERNS), plus a body sentence. Adopts the tutorial evidence-over-assertion discipline.

## Verification
No automated test covers the agent files (`npm test` exercises only the workflow helpers, 40 pass). I verified the toolset directly instead:
- Read the active superpowers TDD skill (the developer only preloaded skill). It drives the work with `npm test` (Bash) and test/code file edits (Read/Write/Edit) only; it never spawns and invokes no other skill. `TodoWrite` is kept for the developer multi-step tracking.
- The developer.md flow uses git/gh via Bash, file edits, and reads; nothing in it calls the spawn tool.
- Precedent: the `tester` already runs a preloaded superpowers skill on a no-spawn toolset and works.

Residual: the only end-to-end proof is a live `/tm-kickoff` run. Per the plan (grill Q1) we merge on this verification and let the next real run confirm the developer still branches, edits, pushes, and opens a draft PR.

## Non-goals
No change to architect/tester/reviewer. No nesting. No specialist reviewer fan-out.