### PR TITLE
docs: clarify ultracode keyword vs session-effort vs team in model policy

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -136,9 +136,19 @@ runs, not raw effort everywhere.
 - Orchestrator (the lead session, including `/tm-kickoff`): Opus 4.8 at max
   effort. Opus does not over-spawn under ultracode the way Fable 5 (`claude-fable-5`) does, and it
   weighs less against Max-plan quota. Keep the lead here.
-- `ultracode`: use it as a per-prompt keyword, never as a session-wide effort
-  setting. Session-wide turns every task into a workflow and chains several per
-  request; the keyword scopes orchestration to the one task that needs it.
+- `ultracode`: a per-prompt keyword, never a session-wide effort setting, and
+  not a substitute for the team machinery above. There is no `/ultracode` slash
+  command: it is either a keyword you type in a prompt or the `ultracode` option
+  in the `/effort` menu. As a session setting it sends `xhigh` reasoning (one
+  notch below `max` on Opus 4.8's `low < medium < high < xhigh < max` ladder) and
+  has Claude plan a dynamic workflow for every substantive task, chaining several
+  per request; as a keyword it scopes that orchestration to the one task you type
+  it on. The workflows it invents have no per-stage model pinning, so their stages
+  run on the session model (Opus), not the Sonnet workers the `tm-review-*`
+  scripts pin. Session-wide `ultracode` is therefore unbounded and buys less
+  reasoning than `max` for more cost: keep `/effort` at `max`, and use the keyword
+  only for a one-off heavy task with no tm- script. (Source:
+  code.claude.com/docs/en/model-config.md, "Adjust effort level".)
 - Role agents (set in each agent's frontmatter `model:`): `developer` and
   `tester` run `sonnet` (efficient implementation and verification);
   `architect` and `reviewer` run `opus` (the judgment roles).


### PR DESCRIPTION
## What

Expands the `ultracode` bullet in the model-policy section of `.claude/team-guide.md` to state the three-way distinction in one place:

- the standing tm- agent team + bounded `tm-review-*` workflows,
- the `ultracode` keyword (per-prompt escape hatch),
- session-wide `ultracode` effort (the anti-pattern).

## Why

The question "should I just switch to ultracode effort instead of the team?" kept recurring. The docs touched on it but did not lay out the full picture, so it got re-asked. This captures the decision and the verified facts.

## Verified facts (per the docs)

- There is no `/ultracode` slash command. It is a keyword in a prompt, or the `ultracode` option in `/effort`.
- The `ultracode` setting sends `xhigh` reasoning, which on Opus 4.8 is one notch below `max`. It is not a stronger effort tier.
- It plans a dynamic workflow per substantive task; those ad-hoc workflows have no per-stage model pinning, so they default to the session model (Opus), not the Sonnet workers the `tm-review-*` scripts pin.
- Recommendation: keep `/effort` at `max`, use the keyword only as a per-prompt escape hatch, never session-wide.

Source: https://code.claude.com/docs/en/model-config.md ("Adjust effort level").

## Distribution

This edits the template source. Consuming config dirs (`~/.claude-personal`, `~/.claude-work`) pick it up on the next `/tm-install-team` after merge, not automatically.

Docs-only change; unit tests pass (40/40). No workflow or code touched.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
