### PR TITLE
docs: clarify agent team is not the experimental agent-teams feature

### DIFF
--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -4,6 +4,12 @@ How the orchestrator team actually runs. The operating rules live in
 `.claude/team-guide.md`; this doc adds the picture. The per-package mechanics
 (parking, caps, routing) live in `.claude/skills/tm-kickoff/SKILL.md`.
 
+"Agent team" is this template's name for the flat-star pattern below, not
+Claude Code's experimental agent-teams feature (enabled with
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`), where separate full sessions
+coordinate peer-to-peer. Ours is built from subagents and dynamic workflows:
+the lead spawns role agents that report back to it and never call each other.
+
 ## Flat star, not a nested tree
 
 Claude Code now lets a subagent spawn its own subagents (a nested tree; the


### PR DESCRIPTION
## What

Add a short note near the top of `docs/team-architecture.md` clarifying that
"agent team" is this template's name for the flat-star subagent pattern, not
Claude Code's experimental agent-teams feature
(`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, where separate full sessions coordinate
peer-to-peer).

## Why

The doc title and prose use "agent team," which collides with Claude Code's
experimental primitive of the same name, so a fast reader could assume the
template uses that primitive. It does not. The machinery is subagents (one lead
spawns role agents that report back and never call each other) plus dynamic
workflows (`.claude/workflows/tm-review-*`), with no
`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` and no peer mailbox anywhere (verified by
grep). One note removes the ambiguity. The rest of the doc already describes the
mechanism correctly, so this is a single insertion, no rewording.

## Checks

- `npm test` -> 0 (40 passed)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
