### PR TITLE
fix: kickoff Gate's gh pr list --search false-positive matches existing PRs

### DIFF
--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -33,7 +33,8 @@ gh label create "needs-human"  --color "B60205" --description "Agent loop exhaus
 `--force` upserts: it creates each label when absent and sets identical values when present, so a second run (including the advisor→kickoff double-run in a batch) is a true no-op and exits 0.
 
 For each issue, `gh issue view <n> --comments`, and
-`gh pr list --state open --search "Closes #<n>"` to find an existing PR.
+`gh pr list --state open --limit 100 --json number,isDraft,closingIssuesReferences --jq '.[] | select(.closingIssuesReferences[]?.number == <n>)'`
+to find an existing PR.
 
 - Closed issues and issues labeled `needs-human` are skipped and listed in
   the report; resuming a `needs-human` package is the user's call.


### PR DESCRIPTION
## Summary
- `.claude/skills/tm-kickoff/SKILL.md`'s Gate step found an existing PR for an issue with `gh pr list --state open --search "Closes #<n>"`. GitHub's `--search` is a loose free-text match, not anchored to an exact issue number, so it can return unrelated PRs (verified: `--search "Closes #12"` returned PRs 12, 35, 53, 70, 74, 88, none of which close issue 12).
- Replaces it with the structured `closingIssuesReferences` relationship GitHub already tracks: `gh pr list --state open --limit 100 --json number,isDraft,closingIssuesReferences --jq '.[] | select(.closingIssuesReferences[]?.number == <n>)'`.

## Test plan
- [x] Live verification: confirm `closingIssuesReferences` populates on this very open draft PR (the load-bearing check from the sub-plan, since prior verification was only against merged/non-draft PRs).
- [x] True negative: query for an issue nothing closes returns empty.
- [x] `npm test`

Closes #125