### PR TITLE
feat: move judgment seats to Fable 5 with Opus 4.8 fallback

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,8 @@
 name: architect
 description: Advisory lead for approach decisions. Use when an issue needs a sub-plan before implementation, when an issue looks mis-sized or needs splitting (size:L or size:XL), or when developer and reviewer disagree. Read-only; decides approach, never writes code.
 tools: Read, Grep, Glob, Bash
-model: opus
+# Judgment role: Fable 5. Fallback is opus (see team-guide, Model policy).
+model: fable
 ---
 
 You are the lead architect. You decide approach; you never write product code.

--- a/.claude/agents/fact-checker.md
+++ b/.claude/agents/fact-checker.md
@@ -1,0 +1,75 @@
+---
+name: fact-checker
+description: Audits the factual claims in a report, sub-plan, PR description, or agent output against reproducible evidence. Use after a developer DONE report, a batch final report, or any output whose claims matter but carry no evidence. Read-only; returns per-claim verdicts (VERIFIED, CONTRADICTED, UNVERIFIED) with the exact command behind each. Never fixes anything.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+isolation: worktree
+---
+
+You audit claims; you never fix code and never rewrite the text you audit.
+Your Bash use is read-only: `gh` reads, `git fetch`, `git log`, `git diff`,
+`git show`, inspection commands. Do not commit, push, edit files, or change
+repo state.
+
+Input: a block of text to audit (quoted verbatim by the caller), plus context:
+the repo state it talks about (a branch, a PR number, an issue number, or the
+default branch). If the text refers to a branch, verify the ref exists and
+check it out detached before auditing, the same way the tester does:
+
+```
+git ls-remote --exit-code origin <branch>
+git fetch origin <branch>
+git rev-parse FETCH_HEAD   # record the SHA for the report
+git checkout --detach FETCH_HEAD
+```
+
+## What counts as a claim
+
+Extract every statement in the input that asserts something checkable about
+the world: a file exists or contains something, a test passed, a command was
+run, a diff does or does not touch something, an issue or PR says something,
+a number (counts, sizes, durations, versions). Skip pure opinions and plans
+("we should", "next I will").
+
+Statements the author explicitly labels as assumption, guess, or untested
+("assuming X", "not verified", "I believe") are compliant as labeled - record
+them as LABELED, do not verify them, and do not count them against the
+verdict. The failure mode you exist to catch is speculation presented as
+fact.
+
+## How you verify
+
+- One status per claim, and every VERIFIED or CONTRADICTED status must cite a
+  command you ran in this session plus the relevant line(s) of its actual
+  output. Never assign a status from memory, plausibility, or what the author
+  seems trustworthy about.
+- Pick the cheapest authoritative evidence: repo state (`git show`, `grep`,
+  file reads), GitHub state (`gh issue view`, `gh pr view`, `gh pr checks`),
+  or a prior report already on the record (a tester VERDICT comment counts as
+  evidence that a suite ran; the claim author's own words do not).
+- Do not re-run test suites or builds to verify "tests pass" claims - that is
+  the tester's job. Verify instead that evidence of the run exists (CI status,
+  a tester verdict, a pasted transcript). If none exists, the claim is
+  UNVERIFIED.
+- If you cannot verify a claim with read-only means, mark it UNVERIFIED and
+  say what would verify it. Never silently drop a claim, and never soften a
+  CONTRADICTED finding.
+
+## Report contract
+
+End with exactly this structure:
+
+```
+VERDICT: GROUNDED | UNGROUNDED
+COMMIT: <full SHA audited, or "n/a" if no branch was involved>
+CLAIMS:
+  1. "<claim, quoted or tightly paraphrased>"
+     STATUS: VERIFIED | CONTRADICTED | UNVERIFIED | LABELED
+     EVIDENCE: <exact command and the output line(s) that decide it; "none" for UNVERIFIED/LABELED>
+     NOTE: <CONTRADICTED: what the evidence shows instead. UNVERIFIED: what would verify it. Otherwise omit.>
+SUMMARY: <n> verified, <n> contradicted, <n> unverified, <n> labeled
+```
+
+VERDICT is GROUNDED only when no claim is CONTRADICTED and every load-bearing
+claim is VERIFIED or LABELED. Any CONTRADICTED claim, or an UNVERIFIED claim
+the caller's decision depends on, makes it UNGROUNDED.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,8 @@
 name: reviewer
 description: Reviews a work package diff against its issue and sub-plan, in two passes, spec compliance then code quality. Read-only; outputs APPROVE or CHANGES_REQUESTED with numbered file:line findings. Never edits files.
 tools: Read, Grep, Glob, Bash
-model: opus
+# Judgment role: Fable 5. Fallback is opus (see team-guide, Model policy).
+model: fable
 ---
 
 You review; you never fix. You have no Edit or Write access on purpose. Bash is

--- a/.claude/skills/tm-review-changes/SKILL.md
+++ b/.claude/skills/tm-review-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tm-review-changes
-description: Token-bounded code review of the current diff, run as a workflow (fixed Sonnet reviewers plus one Opus critic). Plugin-only wrapper; the committed-repo and config-dir roots invoke the tm-review-changes workflow directly by name. User-invocable only.
+description: Token-bounded code review of the current diff, run as a workflow (fixed Sonnet reviewers plus one Fable critic). Plugin-only wrapper; the committed-repo and config-dir roots invoke the tm-review-changes workflow directly by name. User-invocable only.
 disable-model-invocation: true
 argument-hint: "[base ref, default origin/main]"
 ---

--- a/.claude/skills/tm-review-codebase/SKILL.md
+++ b/.claude/skills/tm-review-codebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tm-review-codebase
-description: Token-bounded full-repo review, run as a workflow (Sonnet scout and area workers plus one Opus critic that writes a dated report). Plugin-only wrapper; the committed-repo and config-dir roots invoke the tm-review-codebase workflow directly by name. User-invocable only.
+description: Token-bounded full-repo review, run as a workflow (Sonnet scout and area workers plus one Fable critic that writes a dated report). Plugin-only wrapper; the committed-repo and config-dir roots invoke the tm-review-codebase workflow directly by name. User-invocable only.
 disable-model-invocation: true
 ---
 

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -80,7 +80,7 @@ Standing preferences for this project:
 
 ## Agent team
 
-The template ships four role agents in `.claude/agents/` and a set of skills.
+The template ships five role agents in `.claude/agents/` and a set of skills.
 The lead is the main session: subagents cannot call each other, so the
 session running `/tm-kickoff` routes every handoff, and GitHub (sub-plan and
 verdict comments, draft PRs, labels) holds the state that makes a dropped
@@ -91,6 +91,12 @@ pipeline lives in `docs/team-architecture.md`.
 - `developer` - one issue end to end in an isolated worktree.
 - `tester` - independent verification on the branch, read-only.
 - `reviewer` - spec pass then quality pass, read-only.
+- `fact-checker` - audits the claims in a report or PR description against
+  reproducible evidence, read-only. Per-claim verdicts: VERIFIED with the
+  command that proves it, CONTRADICTED, UNVERIFIED, or LABELED (the author
+  marked it as an assumption). Dispatch it when a report's claims matter but
+  carry no evidence; a CONTRADICTED claim is never dropped, it goes back to
+  the agent that made it.
 
 Refine and size issues in discussion first (`/tm-grill-me` stress-tests the
 plan, `/tm-to-issues` turns it into sized issues); mark dependencies with a
@@ -165,10 +171,14 @@ else. The lever is where each model runs, not raw effort everywhere.
   "Adjust effort level".)
 - Role agents (set in each agent's frontmatter `model:`): `architect` and
   `reviewer` run `fable` (the plan/decision roles; `opus` is the documented
-  fallback); `developer` and `tester` run `sonnet`, which resolves to Sonnet
-  5 (code generation and verification are execution roles, not decision
-  roles). Subagents inherit the session's effort, so a max-effort lead gives
-  the judgment agents max effort too.
+  fallback); `developer`, `tester`, and `fact-checker` run `sonnet`, which
+  resolves to Sonnet 5 (code generation, verification, and claim auditing
+  are execution roles, not decision roles). The `fact-checker` stays on
+  Sonnet rather than Haiku because claim extraction is the step that fails
+  silently: a model that misses an unsupported claim defeats the role's
+  purpose, and the agent runs rarely enough that the cost difference does
+  not matter. Subagents inherit the session's effort, so a max-effort lead
+  gives the judgment agents max effort too.
 - Workflows: pin worker stages to a cheap model in the script and reserve the
   strong model for synthesis or critique. The `tm-review-changes` workflow in
   `.claude/workflows/` is the worked example: a fixed set of Sonnet reviewers

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -130,62 +130,63 @@ session-wide:
 
 ## Model policy
 
-A strong orchestrator with efficient workers. The lever is where each model
-runs, not raw effort everywhere.
+The strongest model in every plan/decision seat, efficient workers everywhere
+else. The lever is where each model runs, not raw effort everywhere.
 
-- Orchestrator (the lead session, including `/tm-kickoff`): Opus 4.8 at max
-  effort. Opus does not over-spawn under ultracode the way Fable 5 (`claude-fable-5`) does, and it
-  weighs less against Max-plan quota. Keep the lead here.
-- Sonnet 5 as orchestrator (provisional): if the lead session runs Sonnet 5
-  instead of Opus 4.8, keep it on the team and workflow machinery at max
-  effort by default too, not session-wide ultracode. The team pipeline pins
-  judgment-heavy stages (architect, reviewer, and the critic stage in both
-  `tm-review-*` workflows) to Opus regardless of which model leads, so a
-  Sonnet-5-led run still gets Opus-quality review; a Sonnet-5-led ultracode
-  run does not escalate by default, since ultracode workflows do not pin
-  per-stage models unless told to. A same-day measured trial found that an
-  unbounded, unpinned dynamic workflow (the same shape ultracode authors by
-  default) run on Sonnet 5 against this repo's own review task attempted 287
-  agents against the bounded `tm-review-codebase` script's 9, exhausting the
-  org's monthly spend cap before it produced a usable result; see the
-  addendum in `docs/reviews/2026-06-30-orchestration-comparison.md`. That is
-  one trial on one task shape (a hand-authored stand-in for ultracode's
-  fan-out patterns, not a live ultracode session's own free-form choice), so
-  this default stays provisional pending the appendix's paired-worktree
-  methodology, but it weighs against assuming Sonnet 5 behaves like Opus
-  here.
-- `ultracode`: use it as a per-prompt keyword, not as a session-wide effort
-  setting, and not as a substitute for the team machinery above. There is no
+- Orchestrator (the lead session, including `/tm-advisor` and `/tm-kickoff`):
+  Fable 5 (`claude-fable-5`) at max effort. The lead routes every handoff,
+  refines batches, and makes the dispatch decisions, so it gets the strongest
+  model. This is affordable only because the lead stays on the bounded tm-
+  machinery: Fable's known failure mode is over-spawning under session-wide
+  ultracode, which this policy rules out (next bullet). Fable costs 2x Opus
+  4.8 per token and weighs correspondingly against Max-plan quota; the lead's
+  own token share is small next to the Sonnet-pinned workers, which keeps the
+  premium bounded.
+- Fallback: Opus 4.8 at max effort. Claude Code has no automatic model
+  fallback for the lead or for subagents; the fallback is a procedure. When
+  Fable 5 is unavailable, rate-limited, quota-exhausted, or refuses the
+  workload, switch the lead with `/model claude-opus-4-8`, and for a longer
+  outage flip the `fable` pins to `opus` in the two agent frontmatters
+  (`architect`, `reviewer`) and the critic stage of both `tm-review-*`
+  workflows. Flip them back when Fable returns.
+- No session-wide `ultracode`, ever, under this policy. There is no
   `/ultracode` slash command: it is either a keyword you type in a prompt or
   the `ultracode` option in the `/effort` menu. As a session setting it sends
-  `xhigh` reasoning (one notch below `max` on Opus 4.8's `low < medium < high
-  < xhigh < max` ladder) and has Claude plan a dynamic workflow for every
-  substantive task, chaining several per request; as a keyword it scopes that
-  orchestration to the one task you type it on. The workflows it invents have
-  no per-stage model pinning, so their stages run on whichever model is
-  leading the session, not the Sonnet workers the `tm-review-*` scripts pin.
-  Session-wide `ultracode` is therefore unbounded and buys less reasoning
-  than `max` for more cost on Opus: keep `/effort` at `max`, and use the
-  keyword only for a one-off heavy task with no tm- script. (Source:
-  code.claude.com/docs/en/model-config.md, "Adjust effort level".)
-- Role agents (set in each agent's frontmatter `model:`): `developer` and
-  `tester` run `sonnet` (efficient implementation and verification);
-  `architect` and `reviewer` run `opus` (the judgment roles).
+  `xhigh` reasoning (one notch below `max`) and has Claude author a dynamic
+  workflow for every substantive task; those invented workflows carry no
+  per-stage model pinning, so every stage would run at Fable rates, and Fable
+  over-spawns under exactly this shape. The measured trial behind this rule
+  (287 agents attempted by an unbounded dynamic workflow against the bounded
+  `tm-review-codebase` script's 9, spend cap exhausted) is in
+  `docs/reviews/2026-06-30-orchestration-comparison.md`. Keep `/effort` at
+  `max` and use the tm- scripts; reach for the `ultracode` keyword only for a
+  one-off heavy task with no tm- script, and prefer dropping the lead to Opus
+  4.8 for that one prompt. (Source: code.claude.com/docs/en/model-config.md,
+  "Adjust effort level".)
+- Role agents (set in each agent's frontmatter `model:`): `architect` and
+  `reviewer` run `fable` (the plan/decision roles; `opus` is the documented
+  fallback); `developer` and `tester` run `sonnet`, which resolves to Sonnet
+  5 (code generation and verification are execution roles, not decision
+  roles). Subagents inherit the session's effort, so a max-effort lead gives
+  the judgment agents max effort too.
 - Workflows: pin worker stages to a cheap model in the script and reserve the
   strong model for synthesis or critique. The `tm-review-changes` workflow in
   `.claude/workflows/` is the worked example: a fixed set of Sonnet reviewers
-  plus one Opus critic, bounded by construction so it cannot fan out into the
-  100-agent review that an unpinned session model produces.
-  `tm-review-codebase` applies the same discipline to a whole-repo audit: a Sonnet
-  scout splits the repo into N areas (sized to the repo, capped at a ceiling),
-  Sonnet workers review each area plus repo-wide structure, and one Opus critic
-  consolidates. The agent count is N + 3, so it scales with repo size up to the
-  ceiling and never fans out unboundedly.
+  plus one Fable critic pinned to max effort, bounded by construction so it
+  cannot fan out into the 100-agent review that an unpinned session model
+  produces. `tm-review-codebase` applies the same discipline to a whole-repo
+  audit: a Sonnet scout splits the repo into N areas (sized to the repo,
+  capped at a ceiling), Sonnet workers review each area plus repo-wide
+  structure, and one Fable critic consolidates. The agent count is N + 3, so
+  it scales with repo size up to the ceiling and never fans out unboundedly.
+  Because every stage is pinned, a cheaper-led session (for example Sonnet 5
+  as lead) still gets Fable-quality judgment, and a Fable-led session never
+  pays Fable rates for worker stages.
 - Do not set `CLAUDE_CODE_SUBAGENT_MODEL`. It overrides both the per-call model
   and the frontmatter `model:`, flattening every subagent to one model and
   defeating the split above. Use it only as a temporary per-session seatbelt
   (for example `claude-sonnet-4-6` before one heavy ad-hoc run), knowing it
-  downgrades the reviewer too.
+  downgrades the architect and reviewer too.
 
 ## How to pick up a task
 

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -1,18 +1,19 @@
 export const meta = {
   name: 'tm-review-changes',
   description:
-    'Token-bounded code review: Sonnet workers review the diff across fixed dimensions, one Opus critic consolidates. Models are pinned per stage in-script, so it never inherits an expensive session model or fans out unboundedly.',
+    'Token-bounded code review: Sonnet workers review the diff across fixed dimensions, one Fable critic consolidates. Models are pinned per stage in-script, so it never inherits the session model or fans out unboundedly.',
   phases: [
     { title: 'Review', detail: 'one Sonnet worker per dimension', model: 'sonnet' },
-    { title: 'Consolidate', detail: 'one Opus critic verifies and merges findings', model: 'opus' },
+    { title: 'Consolidate', detail: 'one Fable critic verifies and merges findings', model: 'fable' },
   ],
 }
 
 // Bounded by construction. The dimension list is fixed, there is no per-file
 // fan-out and no loop, so a run is exactly DIMENSIONS.length Sonnet workers plus
-// one Opus critic. It cannot become the 100-agent fan-out that an unpinned
-// session-model review produces. Models are pinned per stage, so a Fable 5 or Opus
-// session never leaks into the workers.
+// one Fable critic. It cannot become the 100-agent fan-out that an unpinned
+// session-model review produces. Models are pinned per stage, so the session
+// model never leaks into the workers; the single critic runs Fable 5 at max
+// effort (flip its pin to 'opus' under the Opus 4.8 fallback, see team-guide).
 //
 // Invoke with an optional base ref:
 //   Workflow({ name: 'tm-review-changes', args: { base: 'origin/main' } })
@@ -126,7 +127,7 @@ const coverageNote = dropped.length
 phase('Consolidate')
 const report = await agent(
   `You are the senior reviewer. ${covered.length} parallel reviewers produced the raw findings below.${coverageNote} ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: 'Consolidate', model: 'opus', schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'max', schema: REPORT_SCHEMA }
 )
 
 return report

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -1,11 +1,11 @@
 export const meta = {
   name: 'tm-review-codebase',
   description:
-    'Token-bounded full-repo review: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker reviews each area plus one Sonnet architecture worker audits repo-wide structure, and one Opus critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits an expensive session model, and the agent count scales with repo size only up to a hard ceiling.',
+    'Token-bounded full-repo review: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker reviews each area plus one Sonnet architecture worker audits repo-wide structure, and one Fable critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling.',
   phases: [
     { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', model: 'sonnet' },
     { title: 'Review', detail: 'one Sonnet worker per area plus one architecture worker', model: 'sonnet' },
-    { title: 'Consolidate', detail: 'one Opus critic verifies, writes the report, consolidates', model: 'opus' },
+    { title: 'Consolidate', detail: 'one Fable critic verifies, writes the report, consolidates', model: 'fable' },
   ],
 }
 
@@ -14,8 +14,9 @@ export const meta = {
 // 1 architecture worker) + 1 critic = N + 3 agents, with N <= MAX_AREAS. The
 // count scales with repo size but never exceeds MAX_AREAS + 3, no matter how
 // large the repo is or how many areas the scout proposes. There is no per-file
-// fan-out and no loop. Models are pinned per stage, so a high-cost session model
-// never leaks into the scout or the workers.
+// fan-out and no loop. Models are pinned per stage, so the session model never
+// leaks into the scout or the workers; the single critic runs Fable 5 at max
+// effort (flip its pin to 'opus' under the Opus 4.8 fallback, see team-guide).
 //
 // When the repo is too big for MAX_AREAS areas to cover, the leftover paths are
 // reported (coverage.ceilingReached, coverage.areasDropped, and a suggested next
@@ -239,7 +240,7 @@ const suggestedNextActionClause = ceilingReached
 
 const report = await agent(
   `You are the senior reviewer consolidating a full-codebase review. The workers below produced the raw findings.${coverageNote}\n\nVerify each finding against the actual code, drop false positives and anything out of scope, merge duplicates (including the same problem found in two areas), and set a final severity. You may add a finding only if it is a clear must-fix the workers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nThen write the report file. Run \`date +%F\` for today's date, make the docs/reviews/ directory if it does not exist, and write docs/reviews/<date>-codebase-review.md with: the verdict and summary first; then, if coverage is partial, a prominent "Coverage: PARTIAL" callout immediately after the verdict that states how many paths were not reviewed and the suggested next action; then the findings as severity sections (must-fix, then should-fix, then nit), each organized by area; then a final "Coverage" section listing the areas reviewed, the paths not covered, the workers that failed, and (if partial) the suggested next action. Set reportPath to the file you wrote.\n\nReturn the structured summary. Set coverage.areasReviewed to ${JSON.stringify(reviewedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: 'Consolidate', model: 'opus', schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'max', schema: REPORT_SCHEMA }
 )
 
 return report

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -30,12 +30,12 @@ resumability. Parallelism comes from worktree isolation, not nesting.
 ```mermaid
 graph TD
     H["Human<br/>files and sizes issues, merges PRs"] --> L
-    L["LEAD - main session<br/>message bus and router<br/>owns no code; durable state lives in GitHub"]
+    L["LEAD - main session (fable, max effort)<br/>message bus and router<br/>owns no code; durable state lives in GitHub"]
 
-    L -->|"JOB: SUB_PLAN / SPLIT / ARBITRATION"| A["architect (opus)<br/>read-only - approach, splits, arbitration"]
+    L -->|"JOB: SUB_PLAN / SPLIT / ARBITRATION"| A["architect (fable)<br/>read-only - approach, splits, arbitration"]
     L -->|"issue + sub-plan"| D["developer (sonnet)<br/>one issue end to end - worktree - TDD - draft PR"]
     L -->|"branch + issue"| T["tester (sonnet)<br/>read-only - re-runs suite, attacks change"]
-    L -->|"PR + issue + untested claims"| R["reviewer (opus)<br/>read-only - spec pass then quality pass"]
+    L -->|"PR + issue + untested claims"| R["reviewer (fable)<br/>read-only - spec pass then quality pass"]
 
     A -.->|"SUB_PLAN / NEEDS_DECISION"| L
     D -.->|"STATUS / BRANCH / PR / CHECKS"| L

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -36,18 +36,23 @@ graph TD
     L -->|"issue + sub-plan"| D["developer (sonnet)<br/>one issue end to end - worktree - TDD - draft PR"]
     L -->|"branch + issue"| T["tester (sonnet)<br/>read-only - re-runs suite, attacks change"]
     L -->|"PR + issue + untested claims"| R["reviewer (fable)<br/>read-only - spec pass then quality pass"]
+    L -->|"report text + branch or PR"| F["fact-checker (sonnet)<br/>read-only - audits claims against evidence"]
 
     A -.->|"SUB_PLAN / NEEDS_DECISION"| L
     D -.->|"STATUS / BRANCH / PR / CHECKS"| L
     T -.->|"VERDICT / FINDINGS"| L
     R -.->|"VERDICT / FINDINGS"| L
+    F -.->|"GROUNDED / UNGROUNDED per claim"| L
 
     L <-->|"sub-plans, PR verdicts, labels = resumable state"| G[("GitHub")]
 ```
 
-Four peers under one lead, no third level. Evidence flows back to the lead, which
+Five peers under one lead, no third level. Evidence flows back to the lead, which
 routes it into the next agent. GitHub holds the state that makes a dropped
-session resumable.
+session resumable. The `fact-checker` sits outside the per-package pipeline:
+the lead dispatches it on demand when a report's claims are load-bearing but
+carry no evidence, and routes any CONTRADICTED claim back to the agent that
+made it.
 
 ## The per-package pipeline
 


### PR DESCRIPTION
## What

New model policy plus a new agent, in two commits.

### Model policy: strongest model in every plan/decision seat, Sonnet workers everywhere else

- Lead session (orchestrator for `/tm-advisor` and `/tm-kickoff`): Fable 5 at max effort, documented in the team guide. Opus 4.8 at max effort is the fallback when Fable is unavailable or refuses; the guide describes the switch procedure since Claude Code has no automatic model fallback.
- `architect` and `reviewer` agent frontmatter: `model: opus` to `model: fable`, with a fallback comment.
- `developer` and `tester` stay on `sonnet` (resolves to Sonnet 5).
- Critic stage in `tm-review-changes` and `tm-review-codebase`: pinned to `fable` at `effort: 'max'`. Worker and scout stages stay pinned to `sonnet`, so the agent-count and cost bounds of both workflows are unchanged.
- Team guide model policy rewritten. Session-wide ultracode is now ruled out entirely (Fable over-spawns under unpinned dynamic workflows; the 287-agent trial in `docs/reviews/2026-06-30-orchestration-comparison.md` is the evidence). The bounded tm- machinery replaces it.
- Skill descriptions and the team-architecture diagram updated to match.

### New agent: `fact-checker` (sonnet, read-only)

Audits the factual claims in a report, sub-plan, or PR description against reproducible evidence. Per-claim verdicts: VERIFIED (with the exact command that proves it), CONTRADICTED, UNVERIFIED, or LABELED (the author explicitly marked it as an assumption). Rules that define the role: a status may only come from a command the agent ran in that session, never from plausibility; a claim it cannot check is UNVERIFIED, never guessed; CONTRADICTED claims are never dropped and route back to the agent that made them. It does not re-run test suites ("tests pass" needs evidence of a run: CI status, a tester verdict, a transcript). Sits outside the per-package pipeline; the lead dispatches it when a report's claims are load-bearing but carry no evidence. Sonnet over Haiku because a missed unsupported claim defeats the role silently. `tm-install-team` picks it up automatically via the `agents/*.md` glob.

## Why

Fable 5 costs 2x Opus 4.8 per token, but judgment stages (lead routing, sub-plans, review verdicts, workflow critics) are a small share of total tokens. Pinning only those seats to Fable buys the strongest planning and review quality while code generation and verification keep running at Sonnet rates. The earlier objection to a Fable-led session was its over-spawning under session-wide ultracode; this policy removes ultracode from the workflow instead of removing Fable from the lead.

The fact-checker closes the remaining trust gap: agent reports asserting things nobody checked. It makes "verified", "assumed", and "wrong" explicit states instead of tone.

Dated specs, plans, and review reports under `docs/` are historical records and were left unchanged.

## Verification

- `npm test`: 40/40 pass (both commits).
- `node --check` on both workflow scripts: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMcQkqhs3jmZJ4x82JwB1V