### PR TITLE
docs: make NEW-PROJECT-SETUP.md self-disposing after setup

### DIFF
--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -82,3 +82,10 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 - [ ] For a single issue: post a short sub-plan on the issue, branch, open a
       draft PR (`Closes #N`), then expand it to a full plan in `docs/plans/`.
 - [ ] For a batch of refined issues: run `/tm-kickoff` (see team-guide.md "Agent team").
+
+## 7. Clean up
+
+- [ ] Remove all `(see NEW-PROJECT-SETUP)` pointers from `CLAUDE.md`, in
+      "Where decisions live" and "Repo layout".
+- [ ] Delete this file, `NEW-PROJECT-SETUP.md`, once every box above is
+      checked.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Use it as a GitHub template repo, or copy the whole tree including `.claude/`:
 
 ```bash
 gh repo create <new-repo> --template sv-tmueller/claude-template --private --clone
-# then work through NEW-PROJECT-SETUP.md
+# then work through NEW-PROJECT-SETUP.md; delete it once every box is checked
 ```
 
 Copying only `CLAUDE.md` works but does not carry the agents and skills, and leaves its `@.claude/team-guide.md` import dangling.


### PR DESCRIPTION
## Summary

- The checklist ran once per new repo but nothing told the instantiated project to remove it, so every project kept a completed checklist plus the `(see NEW-PROJECT-SETUP)` pointers in CLAUDE.md indefinitely.
- Adds a final `## 7. Clean up` section to `NEW-PROJECT-SETUP.md`: remove all `(see NEW-PROJECT-SETUP)` pointers from `CLAUDE.md` ("Where decisions live" and "Repo layout"), then delete the checklist file itself.
- Notes in `README.md`'s usage snippet that `NEW-PROJECT-SETUP.md` is meant to be deleted once every box is checked.
- Template-side docs change only: this PR does not touch the template's own `CLAUDE.md`. Its pointers are removed by each instantiated project when it runs the new cleanup step.

Closes #135

## Test plan

- [x] `grep -c "see NEW-PROJECT-SETUP" CLAUDE.md` returns 5 (unchanged, confirming this PR left CLAUDE.md alone)
- [x] `grep -n "^## " NEW-PROJECT-SETUP.md` shows sections 1 through 7 in order, with "7. Clean up" last
- [x] README line 64 still reads as one shell comment inside the code block
- [x] `npm test` passes (40/40, unaffected by the docs change)