### PR TITLE
docs: record why the review wrapper skills stay

### DIFF
--- a/.claude/skills/tm-review-changes/SKILL.md
+++ b/.claude/skills/tm-review-changes/SKILL.md
@@ -9,8 +9,10 @@ Run the `tm-review-changes` workflow against the current diff. This skill
 exists only so the plugin install (`sv-tmueller@claude-template`) can reach the
 workflow: the committed-repo and `/tm-install-team` config-dir roots already
 expose it directly as `/tm-review-changes` because Claude Code auto-discovers
-`.claude/workflows/*.js`, and a plugin does not get that auto-discovery for
-`workflows/` (it is not an official plugin component type).
+`.claude/workflows/*.js`, and plugin `workflows/` is not an official component
+type; any direct registration is undocumented. Retire this wrapper if plugin
+`workflows/` becomes an officially documented component type (see the
+component table in code.claude.com/docs/en/plugins-reference.md).
 
 Input: $ARGUMENTS (an optional base ref, default `origin/main`).
 

--- a/.claude/skills/tm-review-codebase/SKILL.md
+++ b/.claude/skills/tm-review-codebase/SKILL.md
@@ -8,8 +8,10 @@ Run the `tm-review-codebase` workflow against the whole repo. This skill
 exists only so the plugin install (`sv-tmueller@claude-template`) can reach the
 workflow: the committed-repo and `/tm-install-team` config-dir roots already
 expose it directly as `/tm-review-codebase` because Claude Code auto-discovers
-`.claude/workflows/*.js`, and a plugin does not get that auto-discovery for
-`workflows/` (it is not an official plugin component type).
+`.claude/workflows/*.js`, and plugin `workflows/` is not an official component
+type; any direct registration is undocumented. Retire this wrapper if plugin
+`workflows/` becomes an officially documented component type (see the
+component table in code.claude.com/docs/en/plugins-reference.md).
 
 1. Check whether you are running from a plugin install: `echo "$CLAUDE_PLUGIN_ROOT"`.
 2. If `CLAUDE_PLUGIN_ROOT` is set (non-empty), invoke the Workflow tool with

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ Code can install the team without cloning or copying anything:
 This installs the 4 agents and all 7 skills under the `sv-tmueller` namespace,
 for example `/sv-tmueller:tm-advisor` and `/sv-tmueller:tm-kickoff`. The two
 review workflows (`tm-review-changes`, `tm-review-codebase`) ship as thin
-wrapper skills, since a plugin does not auto-register `workflows/`.
+wrapper skills, since plugin `workflows/` is not an official component type.
+Current Claude Code builds may also register the two workflows directly under
+the plugin namespace, producing duplicate menu entries; this is undocumented
+behavior, and the wrapper skills remain the supported path.
 `/sv-tmueller:tm-install-team` ships too (default-directory discovery does not
 exclude it) but is a no-op outside a checkout of this template: it has
 nothing to copy from.


### PR DESCRIPTION
## Summary

Records why the plugin-only wrapper skills (`tm-review-changes`,
`tm-review-codebase`) stay, and notes that current Claude Code builds may
also register the two workflows directly under the plugin namespace,
producing duplicate menu entries. That direct registration is undocumented
behavior; the wrapper skills remain the supported, documented path.

- `README.md`: reworded the "plugin does not auto-register `workflows/`"
  clause (which the 2026-07-02 observation contradicts) to "plugin
  `workflows/` is not an official component type", and added the sentence
  about duplicate menu entries being undocumented.
- `.claude/skills/tm-review-changes/SKILL.md` and
  `.claude/skills/tm-review-codebase/SKILL.md`: added an identical revisit
  trigger (retire the wrapper if plugin `workflows/` becomes an officially
  documented component type). Body-only edits, frontmatter untouched.

Docs-only change, no behavior change. Does not touch the pre-existing "4
agents" count inaccuracy in the README (out of scope per the issue).

Closes #134

## Test plan

- [x] `grep -n "undocumented" README.md` and
      `grep -n -i "revisit\|retire" .claude/skills/tm-review-*/SKILL.md`
      confirm all three insertions landed
- [x] `git diff` on both SKILL.md files shows body-only hunks (frontmatter
      unchanged)
- [x] `npm test` passes (40/40, unaffected by docs-only change)