### PR TITLE
feat: add tm-new-project guided setup skill

### DIFF
--- a/.claude/skills/tm-install-team/SKILL.md
+++ b/.claude/skills/tm-install-team/SKILL.md
@@ -40,9 +40,9 @@ they are missing (`mkdir -p`), then process these source items:
 - `.claude/agents/*.md`    -> `T/agents/<name>`     (files)
 - `.claude/skills/tm-*` EXCEPT `tm-install-team`
   -> `T/skills/<name>` (whole skill directories: the operational skills
-  tm-advisor, tm-grill-me, tm-kickoff, tm-to-issues. The excluded skill
-  maintains the template and is run only from a template checkout, so installing
-  it into a consuming config dir would be a footgun.)
+  tm-advisor, tm-grill-me, tm-kickoff, tm-new-project, tm-to-issues. The
+  excluded skill maintains the template and is run only from a template
+  checkout, so installing it into a consuming config dir would be a footgun.)
 - `.claude/workflows/*.js` -> `T/workflows/<name>`   (files; skip the
   `.claude/workflows/__tests__/` directory)
 - `.claude/team-guide.md`  -> `T/team-guide.md`      (file)

--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -88,8 +88,9 @@ placeholder text, leaving the rest of the file untouched:
   the project does, who uses it, and its current status (pre-implementation,
   MVP, in production). Write 2-3 sentences.
 - **"Useful commands"** (`Record the exact commands...` sentinel): ask for
-  the real install, dev, typecheck, lint, test, and e2e commands, and fill
-  the `bash` block with them.
+  the real install, dev, typecheck, lint, test, and e2e commands, delete the
+  caption line that carries the sentinel, and fill the `bash` block with
+  them.
 - **"Code style"** (`Add project-specific style rules here` sentinel): ask
   for any project-specific style rules, then delete the placeholder line
   whether or not the user has rules to add.

--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tm-new-project
-description: Run the once-per-repo new-project setup as a guided flow: create the workflow labels, the docs tree, and fill the CLAUDE.md placeholders by interview; print the human-only steps (branch protection, CI, design-plugin vetting); and retire NEW-PROJECT-SETUP.md once its checklist is done. User-invocable only.
+description: "Run the once-per-repo new-project setup as a guided flow: create the workflow labels, the docs tree, and fill the CLAUDE.md placeholders by interview; print the human-only steps (branch protection, CI, design-plugin vetting); and retire NEW-PROJECT-SETUP.md once its checklist is done. User-invocable only."
 disable-model-invocation: true
 ---
 
@@ -89,7 +89,7 @@ placeholder text, leaving the rest of the file untouched:
   MVP, in production). Write 2-3 sentences.
 - **"Useful commands"** (`Record the exact commands...` sentinel): ask for
   the real install, dev, typecheck, lint, test, and e2e commands, delete the
-  caption line that carries the sentinel, and fill the `bash` block with
+  caption sentence (both wrapped lines), and fill the `bash` block with
   them.
 - **"Code style"** (`Add project-specific style rules here` sentinel): ask
   for any project-specific style rules, then delete the placeholder line

--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: tm-new-project
+description: Run the once-per-repo new-project setup as a guided flow: create the workflow labels, the docs tree, and fill the CLAUDE.md placeholders by interview; print the human-only steps (branch protection, CI, design-plugin vetting); and retire NEW-PROJECT-SETUP.md once its checklist is done. User-invocable only.
+disable-model-invocation: true
+---
+
+Run the setup in `NEW-PROJECT-SETUP.md` against the current repo (the cwd):
+automate what can be automated, print exact commands for what cannot, and
+retire the checklist file once it is done. Idempotent: each section below
+checks its own precondition and skips what is already done, so re-running
+after a partial setup only finishes what is left.
+
+## 1. Detect state
+
+Check, in this repo:
+
+- The three CLAUDE.md placeholder sentinels (exact-string match against
+  `CLAUDE.md`):
+  - `Describe in 2-3 sentences what this project does`
+  - `Add project-specific style rules here`
+  - `Record the exact commands once the project is scaffolded`
+- The five docs dirs: `docs/architecture`, `docs/operations`, `docs/plans`,
+  `docs/reviews`, `docs/superpowers/specs`.
+- `NEW-PROJECT-SETUP.md` at the repo root.
+
+**Already set up:** all three sentinels absent, all five dirs present, and no
+`NEW-PROJECT-SETUP.md`. Stop here; do not run sections 2-7. Also check
+whether the six canonical labels exist (`gh label list`), skipping that check
+with a note if there is no GitHub remote or `gh` auth. Missing labels are
+noted in the report but do not block the exit or get created. Report:
+
+    Already set up: no CLAUDE.md placeholders, docs tree present, no
+    NEW-PROJECT-SETUP.md. Nothing to do.
+    Labels: <all present | missing: <names> | not checked: <reason>>
+
+**No CLAUDE.md** (a config-dir or plugin install into a repo this template
+never seeded): skip section 4 (interview), with a note; this skill does not
+author a CLAUDE.md from scratch. Sections 2, 3, and 5 do not depend on
+CLAUDE.md and still run. Section 6 (clean up) depends only on
+`NEW-PROJECT-SETUP.md`'s presence, not on CLAUDE.md; see section 6.
+
+Otherwise, continue through sections 2-7 below. Each checks its own
+precondition and skips what is already done, so a mixed (partially set up)
+state only finishes what is left.
+
+## 2. Labels
+
+Skip this section, with a note, if there is no GitHub remote (`git remote
+get-url origin` fails) or `gh` is not authenticated (`gh auth status`
+fails). Otherwise run:
+
+```
+gh label create "size:S"       --color "c2e0c6" --description "Under 1 hour. One focused change." --force
+gh label create "size:M"       --color "BFD4F2" --description "1 to 3 hours. Write a sub-plan first." --force
+gh label create "size:L"       --color "F9D0C4" --description "4 to 6 hours. Split or checkpoint." --force
+gh label create "size:XL"      --color "D93F0B" --description "About 8 hours. Too big. Split it." --force
+gh label create "in-progress"  --color "FBCA04" --description "Package dispatched by /kickoff; resume, do not restart." --force
+gh label create "needs-human"  --color "B60205" --description "Agent loop exhausted or blocked; human decision needed." --force
+```
+
+`--force` upserts: it creates each label when absent and sets identical
+values when present, so re-running this section is a no-op.
+
+## 3. Docs tree
+
+Create the docs dirs that are missing (`mkdir -p`):
+
+```
+docs/architecture/
+docs/operations/
+docs/plans/
+docs/reviews/
+docs/superpowers/specs/
+```
+
+Git does not track empty directories, so a newly created dir will not show up
+in `git status` until a file lands inside it. That is expected; do not add
+placeholder files just to force tracking.
+
+## 4. CLAUDE.md interview
+
+Skip this section, with a note, if there is no `CLAUDE.md` (see section 1) or
+if none of the three sentinels are present (already filled in). Otherwise,
+for each sentinel still present, ask the user and replace only that
+placeholder text, leaving the rest of the file untouched:
+
+- **"What this repo is"** (`Describe in 2-3 sentences...` sentinel): ask what
+  the project does, who uses it, and its current status (pre-implementation,
+  MVP, in production). Write 2-3 sentences.
+- **"Useful commands"** (`Record the exact commands...` sentinel): ask for
+  the real install, dev, typecheck, lint, test, and e2e commands, and fill
+  the `bash` block with them.
+- **"Code style"** (`Add project-specific style rules here` sentinel): ask
+  for any project-specific style rules, then delete the placeholder line
+  whether or not the user has rules to add.
+
+## 5. Print human-only steps
+
+These need a browser or a human decision; print them, do not run them.
+
+**Branch protection.** In the repo's GitHub settings, protect `main`: block
+direct pushes, require a PR, require status checks to pass before merge.
+
+**Tests and CI/CD.** Decide the e2e approach for this app and scaffold
+`e2e/`. Add a CI workflow that runs typecheck, lint, unit tests, build, and
+e2e. Make the relevant CI jobs required status checks on `main` (the setting
+above). If you deploy, make e2e a pre-deploy gate.
+
+**Claude Code plugins.** Accept the superpowers plugin prompt that
+`.claude/settings.json` triggers. If no prompt appears (a known gap,
+https://github.com/anthropics/claude-code/issues/32606), run
+`/plugin install superpowers@claude-plugins-official`.
+
+(Optional, UI projects only) Enable the design plugins. They are not on by
+default, so the template stays generic. Vet the two third-party plugins
+before enabling them in a project others build on; their install steps live
+in their repos and may change.
+
+- `frontend-design@claude-plugins-official` (official marketplace, like
+  superpowers): `/plugin install frontend-design@claude-plugins-official`.
+- `ui-ux-pro-max@ui-ux-pro-max-skill`, from
+  `nextlevelbuilder/ui-ux-pro-max-skill`:
+  `/plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill`, then
+  `/plugin install ui-ux-pro-max@ui-ux-pro-max-skill`.
+- `impeccable@impeccable`, from `pbakaus/impeccable`:
+  `/plugin marketplace add pbakaus/impeccable`, then
+  `/plugin install impeccable@impeccable`.
+
+**First slice of work.** Brainstorm the first design via
+`superpowers:brainstorming`; save the spec to
+`docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`. File the first issues
+(`gh issue create`), sized, with `Blocked by: #N` lines for dependencies. For
+a single issue: post a short sub-plan, branch, open a draft PR (`Closes #N`),
+then expand it to a full plan in `docs/plans/`. For a batch of refined
+issues: run `/tm-kickoff` (see team-guide.md "Agent team").
+
+## 6. Clean up
+
+Only when `NEW-PROJECT-SETUP.md` exists at the repo root (if it is already
+gone, skip this section, nothing to do). The human-only steps in section 5
+are still open at this point, so confirm with the user before touching
+anything: tell them branch protection, CI, and first-slice-of-work are
+manual and still outstanding, and ask whether to clean up anyway. On
+confirmation, mirroring `NEW-PROJECT-SETUP.md` section 7's order:
+
+1. Remove every `(see NEW-PROJECT-SETUP)` pointer from `CLAUDE.md`, in
+   "Where decisions live" and "Repo layout" (there is no fixed count; remove
+   every occurrence, not a specific number). If `CLAUDE.md` does not exist,
+   there is nothing to remove; go straight to step 2.
+2. Delete `NEW-PROJECT-SETUP.md`.
+
+## 7. Report
+
+Report, in this order:
+
+- Labels: created, already present, or skipped (and why).
+- Docs dirs: created, already present.
+- CLAUDE.md: sections filled, sections already filled (skipped), or skipped
+  entirely (no CLAUDE.md).
+- The human-only steps from section 5, so the user has them without
+  re-reading this file.
+- Clean up: pointers removed and file deleted, or skipped (why: no
+  `NEW-PROJECT-SETUP.md`, or the user declined).
+
+All changes are left uncommitted for the user to review and commit. This
+skill never runs `git commit`.

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -225,7 +225,7 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
 ```
 .claude/
   agents/            role agents: architect, developer, tester, reviewer
-  skills/            project skills: /tm-advisor, /tm-grill-me, /tm-install-team, /tm-kickoff, /tm-to-issues
+  skills/            project skills: /tm-advisor, /tm-grill-me, /tm-install-team, /tm-kickoff, /tm-new-project, /tm-to-issues
   workflows/         bounded orchestration scripts (tm-review-changes, tm-review-codebase)
   settings.json      project settings; enables the superpowers plugin
                        enabledPlugins is template-managed;

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -1,5 +1,8 @@
 # New-project setup
 
+Prefer a guided flow? Run `/tm-new-project` to automate what it can here and
+print exact commands for the rest.
+
 Run once when starting a new repo from this template. Create the repo from the
 GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 `CLAUDE.md` placeholders as you go.
@@ -27,7 +30,8 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 - [ ] Check the agent team is loaded: `/agents` should list architect,
       developer, tester, and reviewer.
 - [ ] Check the skills are registered: `/skills` should list tm-advisor,
-      tm-kickoff, tm-grill-me, tm-to-issues, and tm-install-team.
+      tm-kickoff, tm-grill-me, tm-to-issues, tm-install-team, and
+      tm-new-project.
 - [ ] (Optional) If this project builds UI, enable the design plugins. They are
       not on by default, so the template stays generic and free of third-party
       defaults. Add each to `.claude/settings.json` under `enabledPlugins` and

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ ready-made agent team for Claude Code.
   being committed anywhere. Copies the operational skills, agents,
   workflows, and `team-guide.md`, and checks superpowers is enabled. The user-scope path for repos
   you do not want to carry the team (an org repo).
+- `.claude/skills/tm-new-project/` - `/tm-new-project`: runs the
+  `NEW-PROJECT-SETUP.md` checklist as a guided flow. Creates the workflow
+  labels and docs tree, interviews the user to fill the `CLAUDE.md`
+  placeholders, prints the human-only steps (branch protection, CI,
+  design-plugin vetting), and retires `NEW-PROJECT-SETUP.md` once its
+  checklist is done.
 - `.claude/workflows/` - bounded orchestration scripts. `tm-review-changes`
   reviews a diff with a fixed set of Sonnet reviewers plus one Opus critic;
   `tm-review-codebase` audits the whole repo with a Sonnet scout that splits it into
@@ -104,7 +110,7 @@ Code can install the team without cloning or copying anything:
 /plugin install sv-tmueller@claude-template
 ```
 
-This installs the 4 agents and all 7 skills under the `sv-tmueller` namespace,
+This installs the 4 agents and all 8 skills under the `sv-tmueller` namespace,
 for example `/sv-tmueller:tm-advisor` and `/sv-tmueller:tm-kickoff`. The two
 review workflows (`tm-review-changes`, `tm-review-codebase`) ship as thin
 wrapper skills, since plugin `workflows/` is not an official component type.


### PR DESCRIPTION
Closes #136

Adds `/tm-new-project`, a user-invocable skill that runs the
NEW-PROJECT-SETUP.md checklist as a guided flow: creates the six workflow
labels, the docs tree, interviews the user to fill the CLAUDE.md
placeholders, prints the human-only steps, and retires
NEW-PROJECT-SETUP.md when its checklist is done.

Three decisions from the architect sub-plan on #136:

1. **Placeholder detection.** Exact-string sentinels against CLAUDE.md plus
   two filesystem checks (the docs tree, NEW-PROJECT-SETUP.md). "Already set
   up" exits early with a short report; otherwise each step is independently
   idempotent, so a partial setup only finishes what is left.
2. **CI scaffolding.** Printed instructions only, no workflow YAML stub. The
   stack is undecided at setup time, so any stub would be speculative
   placeholders.
3. **Shrink-to-pointer.** Out of scope for this PR (follow-up issue). This PR
   only adds a one-line pointer from NEW-PROJECT-SETUP.md to the new skill.

## Design notes

Cleanup (section 6) gates only on `NEW-PROJECT-SETUP.md`'s presence, per
sub-plan Files-to-touch item 5, not also on CLAUDE.md existing. The
CLAUDE.md-absent case is handled inside the section itself: "If CLAUDE.md
does not exist, there is nothing to remove; go straight to step 2." Tester
verified every reachable state degrades gracefully.

## Verification

- Grepped each sentinel string quoted in SKILL.md against CLAUDE.md: exact
  match.
- Diffed the six label commands in SKILL.md against tm-kickoff's Gate block:
  byte-identical.
- Frontmatter: `disable-model-invocation: true` present, `name` matches the
  directory.
- `npm test` passes (40/40, unaffected by this change).
