### PR TITLE
fix: rename marketplace identifier from claude-template to orchestrai

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-template",
+  "name": "orchestrai",
   "description": "Single-plugin marketplace for the orchestrai orchestrator team.",
   "owner": {
     "name": "Thomas Mueller"

--- a/.claude/skills/tm-review-changes/SKILL.md
+++ b/.claude/skills/tm-review-changes/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[base ref, default origin/main]"
 ---
 
 Run the `tm-review-changes` workflow against the current diff. This skill
-exists only so the plugin install (`orchestrai@claude-template`) can reach the
+exists only so the plugin install (`orchestrai@orchestrai`) can reach the
 workflow: the committed-repo root already exposes it directly as
 `/tm-review-changes` because Claude Code auto-discovers
 `.claude/workflows/*.js`, and plugin `workflows/` is not an official component

--- a/.claude/skills/tm-review-codebase/SKILL.md
+++ b/.claude/skills/tm-review-codebase/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 ---
 
 Run the `tm-review-codebase` workflow against the whole repo. This skill
-exists only so the plugin install (`orchestrai@claude-template`) can reach the
+exists only so the plugin install (`orchestrai@orchestrai`) can reach the
 workflow: the committed-repo root already exposes it directly as
 `/tm-review-codebase` because Claude Code auto-discovers
 `.claude/workflows/*.js`, and plugin `workflows/` is not an official component

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-template
+# OrchestrAI
 
 A starting point for new projects: a `CLAUDE.md`, a bootstrap checklist, and a
 ready-made agent team for Claude Code.
@@ -79,7 +79,7 @@ org's private repo):
 
 ```text
 /plugin marketplace add sv-tmueller/orchestrai
-/plugin install orchestrai@claude-template
+/plugin install orchestrai@orchestrai
 ```
 
 This installs the 5 agents and all 7 skills under the `orchestrai` namespace,
@@ -92,7 +92,7 @@ behavior, and the wrapper skills remain the supported path.
 
 A plugin cannot place `team-guide.md` where a config-dir `CLAUDE.md` can
 import it, so wire that import yourself: add
-`@plugins/marketplaces/claude-template/.claude/team-guide.md` to
+`@plugins/marketplaces/orchestrai/.claude/team-guide.md` to
 `<config-dir>/CLAUDE.md` (the path is relative to that file; the marketplace
 clone auto-updates, so the import always tracks the latest guide). Note that
 a config-dir `CLAUDE.md` replaces `~/.claude/CLAUDE.md` instead of stacking


### PR DESCRIPTION
Closes #145

## Summary
- `.claude-plugin/marketplace.json`: `"name"` field `claude-template` -> `orchestrai`
- Fixed every current-doc reference to the retired identifier: README title, install command, team-guide import path example, and the two `tm-review-*` wrapper SKILL.md files
- Historical docs (`docs/reviews/`, `docs/plans/`, `docs/superpowers/specs/`) untouched

## Test plan
- [x] `grep -rn "claude-template" README.md .claude/` returns nothing
- [x] `.claude-plugin/marketplace.json` parses as valid JSON
- [x] `npm test` - 52 pass, 0 fail

## Post-merge (manual, per config dir - no automated migration)
There's no marketplace-rename equivalent of the plugin `renames` map, so every machine that already has this marketplace added keeps resolving under the old `claude-template` key until manually redone:
```
/plugin marketplace remove claude-template
/plugin marketplace add sv-tmueller/orchestrai
/plugin install orchestrai@orchestrai
```
Also update any `CLAUDE.md` import path from `.../marketplaces/claude-template/...` to `.../marketplaces/orchestrai/...`.