### PR TITLE
docs: add cost-based Fable fallback trigger to model policy

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -156,6 +156,14 @@ else. The lever is where each model runs, not raw effort everywhere.
   outage flip the `fable` pins to `opus` in the two agent frontmatters
   (`architect`, `reviewer`) and the critic stage of both `tm-review-*`
   workflows. Flip them back when Fable returns.
+- Cost-based fallback trigger, separate from the availability fallback above:
+  if Fable 5 stops being included under the Max-plan subscription and shifts
+  to metered API billing, do not switch to Opus automatically. The
+  "affordable" reasoning above is weighed against Max-plan quota, not real
+  dollars, so it stops applying the moment billing changes. Measure the
+  lead's actual $/session cost at API rates first, then decide whether to
+  keep Fable or move the lead to Opus 4.8 permanently, and log the decision
+  and the measured cost here when made.
 - No session-wide `ultracode`, ever, under this policy. There is no
   `/ultracode` slash command: it is either a keyword you type in a prompt or
   the `ultracode` option in the `/effort` menu. As a session setting it sends


### PR DESCRIPTION
Closes #147

## Summary
Adds one bullet to the Model policy section in `.claude/team-guide.md`, right after the existing availability-based fallback bullet, documenting a separate trigger: Fable 5 moving from Max-plan-bundled to metered API billing. Does not commit to a decision (keep Fable vs. switch to Opus) since actual cost is unknown until it happens; the bullet says to measure $/session at API rates first.

## Test plan
- [x] New bullet placed after the existing availability-fallback bullet, does not modify it
- [x] `npm test` - 52 pass, 0 fail