### PR TITLE
docs: add team-architecture chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ ready-made agent team for Claude Code.
 - `NEW-PROJECT-SETUP.md` - the once-per-repo checklist: branch protection,
   docs structure, CI/CD and e2e wiring, labels, and filling in the `CLAUDE.md`
   placeholders.
-- `.claude/agents/` - four role agents: architect (approach, read-only),
+- `.claude/agents/` - five role agents: architect (approach, read-only),
   developer (one issue end to end, worktree-isolated), tester (independent
-  verification, read-only), reviewer (spec pass then quality pass, read-only).
+  verification, read-only), reviewer (spec pass then quality pass, read-only),
+  fact-checker (audits report and PR claims against evidence, read-only).
 - `.claude/skills/tm-advisor/` - `/tm-advisor`: the operating model on top of the
   team. Refines a raw need into a batch of work packages, takes one sign-off,
   runs the batch uninterrupted through the kickoff pipeline, and reports.
@@ -36,10 +37,10 @@ ready-made agent team for Claude Code.
   design-plugin vetting), and retires `NEW-PROJECT-SETUP.md` once its
   checklist is done.
 - `.claude/workflows/` - bounded orchestration scripts. `tm-review-changes`
-  reviews a diff with a fixed set of Sonnet reviewers plus one Opus critic;
+  reviews a diff with a fixed set of Sonnet reviewers plus one Fable critic;
   `tm-review-codebase` audits the whole repo with a Sonnet scout that splits it into
   areas (scaled to the repo, capped at a ceiling), per-area Sonnet workers, an
-  architecture worker, and one Opus critic. Both pin models in-script so the cost
+  architecture worker, and one Fable critic. Both pin models in-script so the cost
   is bounded by construction.
 - `.claude/settings.json` - enables obra's superpowers plugin per project
   (`superpowers@claude-plugins-official`; the methodology skills:
@@ -55,6 +56,39 @@ specifics.
 
 The four global coding principles live in `~/.claude/CLAUDE.md` and apply to
 every project; this template references them rather than repeating them.
+
+## How the team works
+
+The diagram below is the combined overview; `docs/team-architecture.md` has the
+detailed flat-star and per-package diagrams.
+
+```mermaid
+graph TD
+    H["Human<br/>files and sizes issues, merges PRs"] --> L
+    L["Lead - main session<br/>fable, xhigh<br/>routes every handoff"]
+
+    L -->|"1 sub-plan"| A["architect<br/>fable, xhigh<br/>read-only - approach"]
+    A -.->|"sub-plan"| L
+    L -->|"2 implement"| D["developer<br/>sonnet, high<br/>worktree - TDD - draft PR"]
+    D -.->|"branch + PR"| L
+    L -->|"3 test"| T["tester<br/>sonnet, high<br/>read-only - re-runs suite"]
+    T -.->|"verdict"| L
+    L -->|"4 review"| R["reviewer<br/>fable, xhigh<br/>read-only - spec then quality"]
+    R -.->|"verdict"| L
+    L -.->|"fix loop"| D
+    L -->|"on demand"| F["fact-checker<br/>sonnet, high<br/>read-only - audits claims"]
+    F -.->|"grounded / ungrounded"| L
+
+    L -->|"5 ready PR"| G[("GitHub<br/>sub-plans, verdicts, labels")]
+    G -->|"6 human merges"| H
+
+    subgraph WF["Review workflows"]
+        RC["tm-review-changes<br/>Sonnet reviewers, high<br/>+ 1 Fable critic, xhigh"]
+        RB["tm-review-codebase<br/>Sonnet scout + area workers, high<br/>+ 1 Fable critic, xhigh"]
+    end
+
+    R --> WF
+```
 
 ## Using it
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ graph TD
         RB["tm-review-codebase<br/>Sonnet scout + area workers, high<br/>+ 1 Fable critic, xhigh"]
     end
 
-    R --> WF
+    L -->|"run as slash commands"| WF
 ```
 
 ## Using it


### PR DESCRIPTION
Closes #150

## Summary

Adds a `## How the team works` section to `README.md` right after the intro
(before `## Using it`): a one-line link to `docs/team-architecture.md` for the
detailed diagrams, plus a combined `graph TD` Mermaid chart showing human,
lead (fable, xhigh), the five role agents with model+effort badges, the
numbered per-package flow (1 sub-plan, 2 implement, 3 test, 4 review, 5 ready
PR, 6 human merges), dashed fix-loop and return edges, a GitHub cylinder node
for resumable state, and a `subgraph` cluster for the two review workflows.

Also fixes two accuracy issues surfaced while building the chart:
- `.claude/agents/` bullet said "four role agents" and omitted `fact-checker`;
  now says "five" and lists it.
- The `.claude/workflows/` bullet said "Opus critic" twice; both critics are
  Fable per the current model policy, so both instances are now "Fable critic".

## Label verification (AC 2)

```
$ grep -E "^(model|effort):" .claude/agents/*.md
.claude/agents/architect.md:model: fable
.claude/agents/architect.md:effort: xhigh
.claude/agents/developer.md:model: sonnet
.claude/agents/developer.md:effort: high
.claude/agents/fact-checker.md:model: sonnet
.claude/agents/fact-checker.md:effort: high
.claude/agents/reviewer.md:model: fable
.claude/agents/reviewer.md:effort: xhigh
.claude/agents/tester.md:model: sonnet
.claude/agents/tester.md:effort: high

$ grep -nE "model: '(sonnet|fable)', effort: '(high|xhigh)'" .claude/workflows/tm-review-changes.js .claude/workflows/tm-review-codebase.js
.claude/workflows/tm-review-changes.js:112:      { label: `review:${d.key}`, phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA }
.claude/workflows/tm-review-changes.js:131:  { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }
.claude/workflows/tm-review-codebase.js:158:  { label: 'scout', phase: 'Scout', model: 'sonnet', effort: 'high', schema: MAP_SCHEMA }
.claude/workflows/tm-review-codebase.js:184:    { label: `area:${a.name}`, phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA }
.claude/workflows/tm-review-codebase.js:191:    { label: 'architecture', phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA }
.claude/workflows/tm-review-codebase.js:244:  { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }

$ grep -n "Fable 5 (\`claude-fable-5\`) at xhigh" .claude/team-guide.md
144:  Fable 5 (`claude-fable-5`) at xhigh effort. The lead routes every handoff,
```

All labels in the chart (lead: fable/xhigh; architect/reviewer: fable/xhigh;
developer/tester/fact-checker: sonnet/high; both review-workflow critics:
fable/xhigh, both sets of workers: sonnet/high) match these sources.

## Mermaid syntax validation

Extracted the block exactly as committed and rendered it:

```
$ npx -y @mermaid-js/mermaid-cli -i chart_from_readme.mmd -o out_readme.svg
Generating single mermaid chart
$ echo $?
0
```

## Rendered check on GitHub (AC 3)

Pending: a human or the tester agent should open this branch's README.md on
github.com and confirm the chart renders as expected in the GitHub UI.

## npm test

```
$ npm test
...
ℹ tests 52
ℹ suites 7
ℹ pass 52
ℹ fail 0
```
Exit 0.

## Opus critic check

```
$ grep -c "Opus critic" README.md
0
```
