### PR TITLE
docs: write down the CI cost policy for agents

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -55,6 +55,20 @@ later (see "How to pick up a task").
   locally before pushing any change that touches the full stack. Unit-green is not
   e2e-green.
 
+### CI cost policy
+
+- Agents verify locally first; CI is the final gate, not the first check.
+  Developer and tester already run the full suite locally, so CI confirms
+  results, it does not discover problems.
+- e2e in CI runs on ready-for-review PRs and on pushes to `main` only. Draft
+  PRs run cheaper checks instead (typecheck, lint, unit).
+- Every CI job pins `timeout-minutes`. A `concurrency` group with
+  `cancel-in-progress: true` is mandatory on every workflow.
+- Making a repo public to escape the free-minutes limit is forbidden. Fix the
+  workflow instead.
+- See the CI template under `.claude/skills/tm-new-project/` for the worked
+  example.
+
 ### Writing style (commits, PRs, docs, comments)
 
 - No em dashes. Use regular hyphens, commas, or parentheses.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,10 @@ e2e/                 end-to-end tests; structure depends on the app (see NEW-PRO
 
 `e2e/` holds the tests that exercise the deployed system end to end. Its shape
 depends on the application: a web app uses Playwright specs plus fixtures and
-helpers; a CLI or service uses its own driver. Wire it into CI as a required job
-and as a pre-deploy gate. It is the safety net unit tests cannot be: a branch can
-be unit-green and still break the full stack.
+helpers; a CLI or service uses its own driver. In CI, e2e runs on ready-for-review
+PRs and on pushes to main; draft PRs run cheaper checks instead (see the CI cost
+policy in `.claude/team-guide.md`). It is the safety net unit tests cannot be: a
+branch can be unit-green and still break the full stack.
 
 ## Useful commands
 


### PR DESCRIPTION
## Summary

Writes down the CI cost policy signed off in #153: local-first verification, e2e trigger scope (ready-for-review PRs and pushes to main only), mandatory `timeout-minutes` and `concurrency`/`cancel-in-progress`, and the ban on making a repo public to dodge the free-minutes limit. Adds a new `### CI cost policy` subsection to `.claude/team-guide.md` and rewrites the e2e paragraph in `CLAUDE.md` to point at it instead of the old blanket "wire into CI" wording.

Docs only. The CI template itself is sibling package #155; this PR references its output directory (`.claude/skills/tm-new-project/`) as a pointer, not its filename, so merge order does not matter.

## Test plan

- [x] `npm test` passes (52/52, no regression)
- [x] `grep -n '—' CLAUDE.md .claude/team-guide.md` returns nothing
- [x] Diff reviewed against team-guide.md writing-style rules (no em dashes, no cliche words)

Closes #156