### PR TITLE
Reference CI workflow with cost controls, wired into tm-new-project

### DIFF
--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -103,9 +103,12 @@ These need a browser or a human decision; print them, do not run them.
 direct pushes, require a PR, require status checks to pass before merge.
 
 **Tests and CI/CD.** Decide the e2e approach for this app and scaffold
-`e2e/`. Add a CI workflow that runs typecheck, lint, unit tests, build, and
-e2e. Make the relevant CI jobs required status checks on `main` (the setting
-above). If you deploy, make e2e a pre-deploy gate.
+`e2e/`. Copy `templates/ci.yml` (in this skill's directory) to
+`.github/workflows/ci.yml` and fill in the real commands. Keep its cost
+controls: pinned `timeout-minutes` on every job, a `concurrency` group with
+`cancel-in-progress: true`, and e2e/build skipped on draft PRs. Make the
+relevant CI jobs required status checks on `main` (the setting above). If
+you deploy, make e2e a pre-deploy gate.
 
 **Claude Code plugins.** Accept the superpowers plugin prompt that
 `.claude/settings.json` triggers. If no prompt appears (a known gap,

--- a/.claude/skills/tm-new-project/templates/ci.yml
+++ b/.claude/skills/tm-new-project/templates/ci.yml
@@ -2,10 +2,10 @@
 #
 # Copy this file to `.github/workflows/ci.yml`, then replace every
 # placeholder `run:` command with this repo's real install, typecheck,
-# lint, unit test, build, and e2e commands. The structure encodes the cost
-# policy decided in issue #153: staged jobs, pinned timeouts, concurrency
-# cancellation, and a draft-PR skip for build/e2e. See team-guide.md's CI
-# cost policy section for the reasoning.
+# lint, unit test, build, and e2e commands. The structure encodes the CI
+# cost policy: staged jobs, pinned timeouts, concurrency cancellation, and
+# a draft-PR skip for build/e2e. See team-guide.md's CI cost policy section
+# for the reasoning.
 
 name: CI
 

--- a/.claude/skills/tm-new-project/templates/ci.yml
+++ b/.claude/skills/tm-new-project/templates/ci.yml
@@ -1,0 +1,71 @@
+# Reference CI workflow for repos generated from this template.
+#
+# Copy this file to `.github/workflows/ci.yml`, then replace every
+# placeholder `run:` command with this repo's real install, typecheck,
+# lint, unit test, build, and e2e commands. The structure encodes the cost
+# policy decided in issue #153: staged jobs, pinned timeouts, concurrency
+# cancellation, and a draft-PR skip for build/e2e. See team-guide.md's CI
+# cost policy section for the reasoning.
+
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+# Known GitHub interaction: a required check that paths-ignore skips reports
+# "Expected" and never completes, which can block a docs-only PR from
+# merging. Fixing this needs a no-op mirror workflow; that is out of scope
+# for this template.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Typecheck, lint, unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: echo "replace with this repo's real install command"
+      - name: Typecheck
+        run: echo "replace with this repo's real typecheck command"
+      - name: Lint
+        run: echo "replace with this repo's real lint command"
+      - name: Unit tests
+        run: echo "replace with this repo's real unit test command"
+
+  build:
+    name: Build
+    needs: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # build exists only to serve e2e, so it shares e2e's draft-PR skip.
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: echo "replace with this repo's real build command"
+
+  e2e:
+    name: End-to-end tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Skip on draft PRs; run on ready-for-review PRs and pushes to main.
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+    steps:
+      - uses: actions/checkout@v4
+      - name: e2e
+        run: echo "replace with this repo's real e2e command"

--- a/.claude/workflows/__tests__/ci-template-policy.test.mjs
+++ b/.claude/workflows/__tests__/ci-template-policy.test.mjs
@@ -1,0 +1,76 @@
+/**
+ * Policy-lock test for the tm-new-project CI template (issue #155).
+ *
+ * The template is the worked example for the cost policy decided in #153:
+ * staged jobs, pinned timeouts, concurrency cancellation, and a draft-PR
+ * skip for the build/e2e jobs. This test reads the template's raw text, so
+ * a future edit that drops one of these controls fails here instead of
+ * shipping a template that silently regresses the policy.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const templatePath = join(
+  __dir,
+  '..',
+  '..',
+  'skills',
+  'tm-new-project',
+  'templates',
+  'ci.yml'
+)
+
+describe('tm-new-project CI template', () => {
+  test('the template file exists', () => {
+    assert.ok(existsSync(templatePath), `expected a template at ${templatePath}`)
+  })
+
+  const src = existsSync(templatePath) ? readFileSync(templatePath, 'utf8') : ''
+  // Split into per-job blocks by top-level `  <name>:` lines under `jobs:`.
+  const jobsBlock = src.split(/\njobs:\n/)[1] ?? ''
+  const jobNames = [...jobsBlock.matchAll(/^  (\w+):\n/gm)].map((m) => m[1])
+
+  test('the template defines the checks, build, and e2e jobs', () => {
+    assert.deepEqual(jobNames.sort(), ['build', 'checks', 'e2e'])
+  })
+
+  test('every job pins timeout-minutes', () => {
+    for (const name of jobNames) {
+      const jobSrc = jobsBlock.split(new RegExp(`^  ${name}:\\n`, 'm'))[1] ?? ''
+      const nextJobIdx = jobSrc.search(/^  \w+:\n/m)
+      const body = nextJobIdx === -1 ? jobSrc : jobSrc.slice(0, nextJobIdx)
+      assert.match(
+        body,
+        /timeout-minutes:\s*\d+/,
+        `job "${name}" must pin timeout-minutes`
+      )
+    }
+  })
+
+  test('has a concurrency group with cancel-in-progress true', () => {
+    assert.match(src, /concurrency:/)
+    assert.match(src, /cancel-in-progress:\s*true/)
+  })
+
+  test('the build and e2e jobs are gated off draft PRs', () => {
+    for (const name of ['build', 'e2e']) {
+      const jobSrc = jobsBlock.split(new RegExp(`^  ${name}:\\n`, 'm'))[1] ?? ''
+      const nextJobIdx = jobSrc.search(/^  \w+:\n/m)
+      const body = nextJobIdx === -1 ? jobSrc : jobSrc.slice(0, nextJobIdx)
+      assert.match(
+        body,
+        /if:\s*github\.event_name == 'push' \|\| !github\.event\.pull_request\.draft/,
+        `job "${name}" must skip on draft PRs`
+      )
+    }
+  })
+
+  test('the pull_request trigger includes ready_for_review', () => {
+    assert.match(src, /types:\s*\[opened, synchronize, reopened, ready_for_review\]/)
+  })
+})

--- a/.claude/workflows/__tests__/ci-template-policy.test.mjs
+++ b/.claude/workflows/__tests__/ci-template-policy.test.mjs
@@ -71,6 +71,6 @@ describe('tm-new-project CI template', () => {
   })
 
   test('the pull_request trigger includes ready_for_review', () => {
-    assert.match(src, /types:\s*\[opened, synchronize, reopened, ready_for_review\]/)
+    assert.match(src, /types:\s*\[[^\]]*\bready_for_review\b[^\]]*\]/)
   })
 })

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -66,7 +66,10 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 ## 4. Tests and CI/CD
 
 - [ ] Decide the e2e approach for this app and scaffold `e2e/`.
-- [ ] Add a CI workflow that runs typecheck, lint, unit tests, build, and e2e.
+- [ ] Copy `.claude/skills/tm-new-project/templates/ci.yml` to
+      `.github/workflows/ci.yml` and fill in the real commands. Keep its cost
+      controls: pinned `timeout-minutes` on every job, a `concurrency` group
+      with `cancel-in-progress: true`, and e2e/build skipped on draft PRs.
 - [ ] Make the relevant CI jobs required status checks on `main`.
 - [ ] If you deploy, make e2e a pre-deploy gate.
 


### PR DESCRIPTION
Closes #155

Adds a copyable CI workflow template (`.claude/skills/tm-new-project/templates/ci.yml`) encoding the cost policy from #153: staged jobs, pinned `timeout-minutes`, concurrency cancellation, and a draft-PR skip for build/e2e. Locks the invariants with a policy test (`.claude/workflows/__tests__/ci-template-policy.test.mjs`), same pattern as `effort-policy.test.mjs`.

Also updates NEW-PROJECT-SETUP.md section 4 and tm-new-project SKILL.md section 5 to reference the template and its required controls.

Merge note: merge together with or after #157, which adds the team-guide.md CI cost policy section this template's header comment points to.
