### PR TITLE
feat: honest batch-closure next steps in /tm-advisor reports

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrai",
   "displayName": "OrchestrAI",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Orchestrator team: 5 role agents, the tm- operational skills, and the review workflows.",
   "author": {
     "name": "Thomas Mueller"

--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -54,6 +54,7 @@ Present the batch in chat, per package:
 
 End every proposal with this sign-off block:
 
+```
 ## Sign-off
 
 Reply with one of:
@@ -64,6 +65,7 @@ Reply with one of:
    issue numbers and how to dispatch later, then stop. No batch issue,
    no run.
 3. **revise** - say what to change; the proposal comes back adjusted.
+```
 
 Then stop and wait. Nothing lands on GitHub before outcome 1 or 2. This
 is the only confirmation in the loop: dispatch runs unattended after it;
@@ -152,9 +154,12 @@ report and the chat digest with:
 - #NN parked (needs-human): <the open question>
 
 ## Next steps
-1. Review & merge: #NN, #NN
+1. Review & merge: #NN, #NN (merging closes each package issue via its
+   Closes #N)
 2. Decide on #NN (retry or close)
-3. Run /tm-advisor to close this batch and propose the next
+3. Close this batch issue by hand once everything is merged (it is the
+   run record), or run /tm-advisor to confirm the merges, close it, and
+   propose the next batch
 ```
 
 After posting, the advisor is done for this session.
@@ -184,7 +189,9 @@ With no arguments, `/tm-advisor` enters the resume path:
 
    ## Next steps
    1. Resolve or close: #NN, #NN
-   2. Run /tm-advisor to continue
+   2. Close this batch issue by hand once the PRs are merged, or run
+      /tm-advisor to confirm the merges, close it, and propose the next
+      batch
    ```
 
    Do not close the batch issue until every package either has a merged PR or
@@ -201,8 +208,10 @@ With no arguments, `/tm-advisor` enters the resume path:
    - PR #NN ready  - <package title>
 
    ## Next steps
-   1. Merge the outstanding PRs: #NN, #NN
-   2. Run /tm-advisor to continue
+   1. Merge the outstanding PRs: #NN, #NN (merging closes the package
+      issues via Closes #N)
+   2. Close this batch issue by hand, or run /tm-advisor to confirm the
+      merges, close it, and propose the next batch
    ```
 
    When all PRs are confirmed merged, close the batch issue and propose the
@@ -219,10 +228,13 @@ With no arguments, `/tm-advisor` enters the resume path:
 gh issue list --state open --search "NOT Batch: in:title"
 ```
 
-Then filter out any issue whose body still contains a `Part of batch #` line
-(those belong to an active batch and must not be re-proposed). Order the
-remainder first by dependency (issues with unresolved `Blocked by:` lines come
-after the issues they depend on) and then by creation date (oldest first).
+Then check every issue whose body contains a `Part of batch #N` line: if
+batch issue #N is open, filter the issue out (it belongs to an active
+batch and must not be re-proposed); if #N is closed, keep it as backlog.
+Closing a batch by hand therefore releases its remaining issues to this
+scan. Order the remainder first by dependency (issues with unresolved
+`Blocked by:` lines come after the issues they depend on) and then by
+creation date (oldest first).
 Present the highest-priority candidates as the next batch proposal, following
 the same rules as section 2. Dispatch always requires a new sign-off; merging
 is never implicit approval. End the proposal with:

--- a/docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md
+++ b/docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md
@@ -72,7 +72,7 @@ It parks a package (`needs-human`) only for:
 
 ### 4. Batch tracking issue
 
-Each sign-off creates one GitHub issue for the batch holding: the approved
+Each dispatch creates one GitHub issue for the batch holding: the approved
 proposal (the contract), links to the package issues, every advisor decision
 with reasoning, parked questions, and the final report. A dropped session
 resumes from it. Closed when all batch PRs are merged. Package-level detail
@@ -95,6 +95,15 @@ no `Part of batch #` line and no `Batch:` title prefix - ordered by dependency
 then creation date). Dispatch still requires sign-off;
 merging is never implicit approval. A new session reconstructs state from
 the open batch issue.
+
+**Amendment (2026-07-04, batch #160).** Manual closure of the batch
+issue is valid. The batch issue is a run record; the user may close it
+by hand once every PR is merged. Re-running /tm-advisor is optional
+bookkeeping (confirm merges, close the batch issue, release parked
+issues) plus the next-batch proposal, not a required step. To make the
+hand-close safe, the backlog scan treats an issue whose
+`Part of batch #N` line points at a closed batch as backlog; only
+membership in an open batch excludes an issue.
 
 ### 7. Parking pings: hold for the report
 


### PR DESCRIPTION
## Why

Every "Next steps" template in the /tm-advisor skill told the user to
re-run /tm-advisor to close a batch, as if that were the only valid
path. The batch issue is just a run record, so closing it by hand once
every PR is merged is safe and simpler. This PR rewords the templates
so hand closure is the primary option and re-running the skill reads
as optional bookkeeping, fixes the backlog scan so a closed batch
releases its remaining issues to the next-batch proposal, and fences
the section 2 sign-off block to match the other templates in the
skill. The design spec gets a dated amendment mirroring the same rule.

Closes #161

## Verification

- `npm test` passes (52 tests, docs-only change)
- `grep -n "Run /tm-advisor" .claude/skills/tm-advisor/SKILL.md` shows
  one hit, the untouched section 3 file-only template
- Read-through confirms the new filter sentence and the decision 6
  amendment state the same rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EErqgsrrgfQ2gYE3FqxqP4