### PR TITLE
feat: add docs-drift and perf review dimensions to tm-review-changes

### DIFF
--- a/.claude/skills/tm-review-changes/SKILL.md
+++ b/.claude/skills/tm-review-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tm-review-changes
-description: Token-bounded code review of the current diff, run as a workflow (fixed Sonnet reviewers plus one Fable critic). Plugin-only wrapper; the committed-repo root invokes the tm-review-changes workflow directly by name. User-invocable only.
+description: Token-bounded code review of the current diff, run as a workflow (fixed Sonnet reviewers, one per dimension including docs drift and performance, plus one Fable critic). Plugin-only wrapper; the committed-repo root invokes the tm-review-changes workflow directly by name. User-invocable only.
 disable-model-invocation: true
 argument-hint: "[base ref, default origin/main]"
 ---

--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -241,7 +241,8 @@ describe('MAX_AREAS coercion logic', () => {
 })
 
 // ===========================================================================
-// 4a. covered/dropped partition (tm-review-changes.js lines 120-121)
+// 4a. covered/dropped partition (the covered/dropped partition after the
+// Review phase, tm-review-changes.js)
 //
 // Logic kernel:
 //   const covered = DIMENSIONS.filter((_, i) => reviews[i])
@@ -254,7 +255,7 @@ describe('covered/dropped partition', () => {
   const DIMS = ['bugs', 'security', 'scope', 'tests', 'style']
 
   function partition(reviews) {
-    // Logic kernel of: tm-review-changes.js lines 120-121
+    // Logic kernel of the covered/dropped partition after the Review phase, tm-review-changes.js
     const covered = DIMS.filter((_, i) => reviews[i])
     const dropped = DIMS.filter((_, i) => !reviews[i])
     return { covered, dropped }

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -27,6 +27,11 @@ function safeRef(value, fallback) {
 }
 const base = safeRef(args && args.base, 'origin/main')
 
+// This list is diff-scoped and intentionally longer than tm-review-codebase's
+// per-area dimension list: docs and perf need diff context (what changed, and
+// whether the matching doc or hot path moved with it) that a whole-repo area
+// pass does not have. tm-review-codebase covers doc drift repo-wide through
+// its architecture worker instead; see that file's `dimensions` comment.
 const DIMENSIONS = [
   {
     key: 'bugs',
@@ -52,6 +57,16 @@ const DIMENSIONS = [
     key: 'style',
     brief:
       'Project style (CLAUDE.md code style and writing style). Em dashes, AI-cliche phrases, hard-coded user-facing strings, raw primitives where dedicated types exist, comments that restate code, escape hatches with no // reason: comment.',
+  },
+  {
+    key: 'docs',
+    brief:
+      'Doc drift introduced by this diff. Behavior, commands, or config that changed with no matching update to README, CLAUDE.md, or the relevant spec under docs/. Enforces the CLAUDE.md rule that when code and a doc disagree, the doc is corrected in the same PR. Flag only drift this diff introduces, not pre-existing gaps.',
+  },
+  {
+    key: 'perf',
+    brief:
+      'Performance regressions introduced by this diff. Algorithmic complexity regressions, N+1 query patterns, unnecessary work in hot paths, unbounded memory growth.',
   },
 ]
 

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -145,6 +145,10 @@ const REPORT_SCHEMA = {
 
 const scope = `Work from the repo root scoped to "${root}". List source files with \`git ls-files -- ${root}\` (it already respects .gitignore); ignore vendored and generated trees (node_modules, dist, build, vendor, .git, coverage) and lockfiles.`
 
+// This list stays at five and does not track tm-review-changes.js's dimension
+// list: docs and perf there are diff-scoped (they need to know what changed).
+// Here, doc drift is covered repo-wide by the architecture worker below, and
+// there is no repo-wide perf dimension.
 const dimensions = `Review across these dimensions:
 - bugs: adversarial correctness. Logic errors, wrong or missing edge-case handling, broken error paths, races and ordering bugs, off-by-one, misused or wrongly-assumed APIs, null and boundary handling, resource leaks.
 - security: untrusted input reaching a sink (injection, path traversal, SSRF, unsafe deserialization), missing authn or authz, secrets or credentials in code or logs, unsafe defaults, weak crypto, risky dependencies.
@@ -187,7 +191,7 @@ const reviewThunks = areas.map((a) => () =>
 
 reviewThunks.push(() =>
   agent(
-    `You audit a repository's structure and report findings only. You never edit. Use dimension "architecture".\n\n${scope}\n\nRead the directory layout, module boundaries, imports, and dependency manifests. Read signatures and imports rather than full file bodies, so you can hold the whole tree in view. The area map is:\n${repoMap}\n\nFlag: module boundaries and layering that have drifted, the same logic duplicated across modules, dead or orphaned code, dependency health (unused, outdated, risky), and test-coverage gaps at the suite level. Report each finding with area (the module name or "repo"), dimension ("architecture"), file, line or "n/a", severity, the problem, and the fix.`,
+    `You audit a repository's structure and report findings only. You never edit. Use dimension "architecture".\n\n${scope}\n\nRead the directory layout, module boundaries, imports, and dependency manifests. Read signatures and imports rather than full file bodies, so you can hold the whole tree in view. The area map is:\n${repoMap}\n\nFlag: module boundaries and layering that have drifted, the same logic duplicated across modules, dead or orphaned code, dependency health (unused, outdated, risky), test-coverage gaps at the suite level, and doc drift between README/CLAUDE.md claims and the actual repo state (commands that no longer exist, a described layout that does not match the real one, stale status claims). Report each finding with area (the module name or "repo"), dimension ("architecture"), file, line or "n/a", severity, the problem, and the fix.`,
     { label: 'architecture', phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA }
   )
 )

--- a/docs/superpowers/specs/2026-06-13-review-codebase-design.md
+++ b/docs/superpowers/specs/2026-06-13-review-codebase-design.md
@@ -118,7 +118,7 @@ tm-review-changes coverage fix.
 
 ## What each reviewer looks for
 
-Area workers reuse the five tm-review-changes dimensions, worded for whole files
+Area workers reuse five of the tm-review-changes dimensions, worded for whole files
 rather than a diff, reusing the existing briefs where possible for consistency:
 
 - bugs (adversarial correctness, edge cases, error paths, races, resource leaks)


### PR DESCRIPTION
Extends tm-review-changes with two new diff-scoped dimension workers:
- docs: behavior, commands, or config changed in the diff with no matching
  update to README, CLAUDE.md, or the relevant spec (enforces the "doc
  corrected in the same PR" rule).
- perf: algorithmic complexity regressions, N+1 queries, unnecessary work in
  hot paths, unbounded memory growth introduced by the diff.

tm-review-changes now runs 7 dimension workers plus 1 critic. The
tm-review-codebase area workers stay at 5 dimensions; instead, its
architecture worker's brief now names repo-wide doc drift explicitly
(README/CLAUDE.md claims vs. actual repo state), since a per-area worker has
no diff to scope docs/perf checks against. Also updated the
tm-review-changes SKILL.md description and made two stale line-number
references in helpers.test.mjs line-agnostic.

No changes to the critic stage, schemas, or README (which is already
count-agnostic).

Part of batch #164.

Closes #166

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtWpxzMZaw6Mu5fJcLykCR)_