### PR TITLE
fix: correct unbounded-arm agent count in team-guide.md (287 -> 288)

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -187,7 +187,7 @@ else. The lever is where each model runs, not raw effort everywhere.
   workflow for every substantive task; those invented workflows carry no
   per-stage model pinning, so every stage would run at Fable rates, and Fable
   over-spawns under exactly this shape. The measured trial behind this rule
-  (287 agents attempted by an unbounded dynamic workflow against the bounded
+  (288 agents attempted by an unbounded dynamic workflow against the bounded
   `tm-review-codebase` script's 9, spend cap exhausted) is in
   `docs/reviews/2026-06-30-orchestration-comparison.md`. Keep `/effort` at
   `xhigh` and use the tm- scripts; reach for the `ultracode` keyword only for a


### PR DESCRIPTION
## Summary
- Corrects a transcription error on `.claude/team-guide.md:190`: the unbounded-arm agent count in the ultracode measured trial was cited as 287, but the source (`docs/reviews/2026-06-30-orchestration-comparison.md`) puts the two arms at 297 agents combined with the bounded arm at 9, making the unbounded arm 288.

## Verification
- `grep -n "287" .claude/team-guide.md` -> no output
- `grep -n "288 agents attempted" .claude/team-guide.md` -> line 190
- `git diff --stat origin/main HEAD` -> only `.claude/team-guide.md`, 1 insertion, 1 deletion
- `npm test` -> 0 (63 tests passing)

Closes #172