### PR TITLE
feat: fold a tech-stack question into the Code style interview step

### DIFF
--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -91,9 +91,12 @@ placeholder text, leaving the rest of the file untouched:
   the real install, dev, typecheck, lint, test, and e2e commands, delete the
   caption sentence (both wrapped lines), and fill the `bash` block with
   them.
-- **"Code style"** (`Add project-specific style rules here` sentinel): ask
-  for any project-specific style rules, then delete the placeholder line
-  whether or not the user has rules to add.
+- **"Code style"** (`Add project-specific style rules here` sentinel): first
+  ask for the project's tech stack (languages, frameworks, key libraries),
+  recorded from the answer, not detected by scanning any manifest. Then ask
+  for any project-specific style rules. Replace the placeholder with style
+  rules appropriate to that stack, plus any the user gave; if there is
+  neither a stack nor rules, delete the placeholder as before.
 
 ## 5. Print human-only steps
 


### PR DESCRIPTION
## Summary
- Folds an explicit tech-stack question (languages, frameworks, key libraries, recorded from the user's answer, not detected by scanning any manifest) into the "Code style" bullet of section 4 (the CLAUDE.md interview) in `.claude/skills/tm-new-project/SKILL.md`.
- The stack answer seeds the Code style fill so it starts stack-informed instead of blank.
- No new section, no new sentinel, no other file touched (section 7's existing "Code style" report line already covers this).

Closes #175

## Test plan
- [x] `git diff` confirms the change is confined to the single "Code style" bullet in section 4 of one file.
- [x] Grep the diff for `package.json`, `requirements.txt`, `scan`, `detect`, `agent`: only hits the sentence explicitly ruling out manifest scanning, confirming no manifest scanning or new agent is introduced.
- [x] `npm test` -> 0 (63 tests passing).