### PR TITLE
docs: note tm-install-team is superseded in its plan and spec

### DIFF
--- a/docs/plans/98-tm-install-team.md
+++ b/docs/plans/98-tm-install-team.md
@@ -1,5 +1,12 @@
 # tm-install-team Implementation Plan
 
+> **Superseded:** the `tm-install-team` skill this plan built was later retired
+> in favor of installing the team via the plugin marketplace, with
+> `team-guide.md` imported into the config dir's `CLAUDE.md` from the
+> marketplace clone. See commit 6dd9c69 (PR #144, "rebrand plugin to
+> orchestrai and retire tm-install-team", closes #143). This plan is kept as a
+> historical record and is not a description of a shipping skill.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a `/tm-install-team` skill that copies/updates the orchestrator team (agents, `tm-*` skills, review workflows) into one or more user config dirs, so the team works in repos it must not be committed to.

--- a/docs/superpowers/specs/2026-06-15-tm-install-team-design.md
+++ b/docs/superpowers/specs/2026-06-15-tm-install-team-design.md
@@ -3,6 +3,13 @@
 Status: approved design, 2026-06-15. Brainstormed and signed off decision by
 decision in session. Issue #98. Not yet implemented.
 
+> **Superseded:** the skill designed here was built (issue #98) and later
+> retired in favor of installing the team via the plugin marketplace, with
+> `team-guide.md` imported into the config dir's `CLAUDE.md` from the
+> marketplace clone. See commit 6dd9c69 (PR #144, "rebrand plugin to
+> orchestrai and retire tm-install-team", closes #143). This design is kept as
+> a historical record and does not describe a shipping skill.
+
 ## Goal
 
 Make the orchestrator team (agents, `tm-*` skills, review workflows) available


### PR DESCRIPTION
Closes #185

## Summary

- Determined the disposition of `tm-install-team`: it was built (issue #98) and later retired in commit 6dd9c69 (PR #144, "rebrand plugin to orchestrai and retire tm-install-team", closes #143), in favor of installing the team via the plugin marketplace with `team-guide.md` imported into the config dir's `CLAUDE.md`. It was not folded into `tm-new-project` (an unrelated per-repo setup skill).
- Added a short "Superseded" note to the top of `docs/plans/98-tm-install-team.md` and near the status line of `docs/superpowers/specs/2026-06-15-tm-install-team-design.md`, each pointing to commit 6dd9c69 / PR #144. No other content in either historical doc was rewritten.

## Verification

```
$ npm test
tests 63
pass 63
fail 0
```

## Test plan

- [x] `npm test` (63 pass, 0 fail)
- [x] `git diff --stat` shows only the two referencing docs changed