### PR TITLE
fix: reconcile README license with adapted MIT sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,21 @@ and open a PR.
 This source code is published for demonstration and portfolio purposes only. No license is granted to use, copy, modify, merge, publish, distribute, sublicense, or sell any part of this software, in whole or in part, in any other project (public or private) without prior written permission from the copyright holder.
 
 Unauthorized reuse of any portion of this code constitutes copyright infringement and will be pursued accordingly.
+
+### Third-party material
+
+Two skills carry their own MIT attribution because they are adapted from an
+MIT-licensed source: `.claude/skills/tm-grill-me/SKILL.md` (near-verbatim,
+from `mattpocock/skills`) and `.claude/skills/tm-to-issues/SKILL.md`
+(substantially adapted, from the same source). Their attribution footers and
+the source project's full MIT license text are in `THIRD_PARTY_NOTICES.md`.
+This does not change the license of the rest of the repo above; it is a
+normal mixed-license pattern where a small amount of MIT-derived material
+keeps its own attribution inside an otherwise all-rights-reserved codebase.
+
+The research on `vijaythecoder/awesome-claude-agents`
+(`docs/research/2026-07-04-awesome-claude-agents-adoption.md`) and the
+flat-star diagram credit to `owainlewis/youtube-tutorials`
+(`docs/team-architecture.md`) use only ideas and observations from those
+sources, not file copies, so no attribution is required for them beyond the
+credit already given in place.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,52 @@
+# Third-party notices
+
+This repo is otherwise all-rights-reserved (see the License section in
+`README.md`), but two skill files incorporate content from an MIT-licensed
+source. This file carries the notice that license requires; the affected
+files also carry a short attribution footer pointing back here.
+
+## mattpocock/skills
+
+Source: [mattpocock/skills](https://github.com/mattpocock/skills)
+
+- `.claude/skills/tm-grill-me/SKILL.md` is a near-verbatim adaptation of
+  their `skills/productivity/grilling/SKILL.md`.
+- `.claude/skills/tm-to-issues/SKILL.md` is a substantial adaptation of
+  their `skills/engineering/to-issues/SKILL.md`, with the issue-tracker
+  plumbing replaced by `gh`, this template's size labels, and its
+  `Blocked by:` convention.
+
+```
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Other referenced sources (no attribution required)
+
+- `vijaythecoder/awesome-claude-agents`: `docs/research/2026-07-04-awesome-claude-agents-adoption.md`
+  is our own analysis of their published structure, philosophy, and routing
+  approach. Checked against their file tree and nine representative agent
+  files; no file in this repo copies any of their content verbatim or
+  substantially, so no MIT attribution is required for that source.
+- `owainlewis/youtube-tutorials`: `docs/team-architecture.md` credits a
+  tutorial from this source as the origin of the flat-star diagram idea,
+  adapted to this repo's own model. Idea only, not a file copy.


### PR DESCRIPTION
Closes #184

## Summary

- Verified adaptation status of the two named MIT sources:
  - `mattpocock/skills`: `tm-grill-me` is a near-verbatim adaptation of
    their `skills/productivity/grilling/SKILL.md`; `tm-to-issues` is a
    substantial structural adaptation of `skills/engineering/to-issues/SKILL.md`.
    Both already carry a short MIT source/copyright footer, but not the
    full permission-notice text the license asks to be included.
  - `vijaythecoder/awesome-claude-agents`: confirmed idea-only. Grepped this
    repo for their distinctive phrasing and found no verbatim or substantial
    matches; the research doc's "nothing copies their files verbatim" claim
    holds.
- Added `THIRD_PARTY_NOTICES.md` with the full upstream MIT license text and
  a listing of which files it covers.
- Reconciled `README.md`'s License section: kept the existing all-rights-
  reserved copyright for the repo's own work, added a "Third-party material"
  note pointing at the two adapted skills and the notices file, and stated
  plainly that the awesome-claude-agents and youtube-tutorials references
  are ideas/observations only.

No relicensing decision was needed or made: the repo stays all-rights-
reserved for its own code, with the two MIT-derived skill files carrying
(and now more completely documenting) their existing MIT attribution. This
is a normal mixed-license pattern, not a change to the project's own license.

## Test plan

- [x] `npm test` passes (63/63, unchanged; no code touched)
- [x] Verified upstream MIT sources via `curl`/`gh api` against
      `mattpocock/skills` and `vijaythecoder/awesome-claude-agents`