### PR TITLE
docs: align identity docs to the retire-template decision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,10 @@ Orientation for Claude Code sessions in this repo. Read this first.
 
 ## What this repo is
 
-Describe in 2-3 sentences what this project does, who uses it, and its current
-status (pre-implementation, MVP 1.0, in production). Point to the README for the
-user-facing pitch and to the current implementation plan under `docs/plans/`.
-
-Keep the status honest. If nothing is scaffolded yet, say so, so future sessions
-do not assume a toolchain or test suite that does not exist.
+orchestrai is a personal AI-team-orchestrator plugin, applied across the
+user's own repos. It is not a template for spinning up new, unrelated
+projects; see `docs/architecture/operating-model.md` for that identity
+decision and the README for the user-facing pitch.
 
 ## Working principles
 
@@ -22,9 +20,9 @@ repeat them; it adds only what is specific to this project.
 Read these before proposing changes that touch their area:
 
 - `docs/architecture/` - stack and policy decisions, the data model, the domain
-  math. Locked unless explicitly revisited. (see NEW-PROJECT-SETUP)
+  math. Locked unless explicitly revisited.
 - `docs/operations/` - how to run, deploy, and operate the system: environments,
-  CI/CD, runbooks, secrets policy. (see NEW-PROJECT-SETUP)
+  CI/CD, runbooks, secrets policy.
 - `docs/plans/` - implementation plans, one per task as `<issue-number>-<slug>.md`.
 - `docs/superpowers/specs/` - approved designs from brainstorming, as
   `YYYY-MM-DD-<topic>-design.md`.
@@ -39,20 +37,22 @@ The generic team process guidance lives in `.claude/team-guide.md` and loads via
 
 ## Code style
 
-Add project-specific style rules here and remove this line before the first implementation session.
+Follow the "Writing style" section in `.claude/team-guide.md` for commits,
+PRs, docs, and comments. The JS in this repo follows the zero-dependency test
+style (see "Useful commands").
 
 ## Repo layout
 
 ```
 docs/
-  architecture/      stack and policy decisions, data model, domain math (see NEW-PROJECT-SETUP);
+  architecture/      stack and policy decisions, data model, domain math;
                        also dated codebase maps from /tm-map-codebase
-  operations/        run/deploy/operate: environments, CI/CD, runbooks (see NEW-PROJECT-SETUP)
+  operations/        run/deploy/operate: environments, CI/CD, runbooks
   plans/             implementation plans, <issue-number>-<slug>.md
   reviews/           dated codebase-review reports from /tm-review-codebase
   superpowers/specs/ approved designs, YYYY-MM-DD-<topic>-design.md
   team-architecture.md  flat-star agent-team diagrams and rationale
-e2e/                 end-to-end tests; structure depends on the app (see NEW-PROJECT-SETUP)
+e2e/                 end-to-end tests; structure depends on the app
 ```
 
 `e2e/` holds the tests that exercise the deployed system end to end. Its shape
@@ -64,16 +64,11 @@ branch can be unit-green and still break the full stack.
 
 ## Useful commands
 
-Record the exact commands once the project is scaffolded, so future sessions do
-not rediscover them.
-
 ```bash
-# install
-# dev / run
-# typecheck
-# lint
 npm test          # unit tests (node:vm, zero deps); run before commit
-# e2e             (run before pushing full-stack changes)
 # gh issue create
 # gh pr create --draft
 ```
+
+There is no application runtime, so install, dev, typecheck, and lint are N/A;
+there is no `e2e/` suite yet.

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -18,10 +18,13 @@ The plugin exists for five purposes:
    achievable result.
 5. Offer a portable structure the user can apply across any of their repos.
 
-The plugin is the primary identity. Template-scaffolding is demoted to a
-secondary capability, and its leftover framing (in CLAUDE.md,
-`NEW-PROJECT-SETUP.md`, and `tm-new-project`) still exists in the tree and is
-reconciled in Batch 2, not by this doc. See section 3.
+The plugin is the primary identity. The template-copy path is retired, not
+merely demoted: CLAUDE.md no longer frames it as a fallback identity, and its
+own leftover framing (placeholder sentinels, `(see NEW-PROJECT-SETUP)`
+pointers) is corrected by this change. The scaffolding files that implement
+that path (`NEW-PROJECT-SETUP.md`, `.claude/skills/tm-new-project/`) still
+exist in the tree; their physical retirement is deferred to the usability
+batch. See section 3.
 
 ## 2. How it operates (the loop, summary altitude)
 
@@ -55,15 +58,16 @@ side effect. Owned by `.claude/workflows/` (`tm-map-codebase.js`,
 `tm-review-changes.js`, `tm-review-codebase.js`) and the `docs/` layout in
 `CLAUDE.md`.
 
-## 3. Reconciliation: leftover template framing (Batch 2)
+## 3. Transition state: identity retired, scaffolding not yet removed
 
-This doc records the identity decision. It makes no edits to the files
-below; reconciling them is explicit, deferred follow-up for Batch 2:
+This doc records the identity decision and, alongside it, CLAUDE.md now
+carries that decision through. What's done as of this change:
 
-- `CLAUDE.md`'s three placeholder sentinels (the project-description
-  paragraph, the "Code style" placeholder line, and the "(see
-  NEW-PROJECT-SETUP)" pointers in the repo-layout section).
-- `NEW-PROJECT-SETUP.md`.
-- `.claude/skills/tm-new-project/SKILL.md`.
+- The identity above is recorded as retire, not demote.
+- CLAUDE.md's three placeholder sentinels ("What this repo is", "Code
+  style", "Useful commands") are filled with real content.
+- The `(see NEW-PROJECT-SETUP)` pointers are removed from CLAUDE.md.
 
-None of these files are touched by this change.
+What's still open: `NEW-PROJECT-SETUP.md` and
+`.claude/skills/tm-new-project/` remain physically present in the tree.
+Removing them is deferred to the usability batch, not this change.


### PR DESCRIPTION
## Summary
- Records the template-copy path in the operating model as retired, not demoted, and repurposes section 3 into a transition-state note (done now / still open).
- Fills CLAUDE.md's three placeholder sentinels ("What this repo is", "Code style", "Useful commands") with real content and drops the stale `(see NEW-PROJECT-SETUP)` pointers.

Closes #183

## Test plan
- [x] `npm test` passes
- [x] `grep "see NEW-PROJECT-SETUP" CLAUDE.md` returns nothing
- [x] the three sentinel strings are absent from CLAUDE.md
- [x] `grep -i "demoted, not gone" docs/architecture/operating-model.md` returns nothing
- [x] `git diff --stat` shows exactly CLAUDE.md and docs/architecture/operating-model.md