### PR TITLE
fix: correct tm-grill-me footer upstream path to grilling

### DIFF
--- a/.claude/skills/tm-grill-me/SKILL.md
+++ b/.claude/skills/tm-grill-me/SKILL.md
@@ -12,4 +12,4 @@ If a question can be answered by exploring the codebase, explore the codebase in
 ---
 
 Source: [mattpocock/skills](https://github.com/mattpocock/skills)
-(`skills/productivity/grill-me`), MIT License, Copyright (c) 2026 Matt Pocock.
+(`skills/productivity/grilling`), MIT License, Copyright (c) 2026 Matt Pocock.


### PR DESCRIPTION
## Summary
The MIT-attribution footer in `.claude/skills/tm-grill-me/SKILL.md` cited the upstream source path as `skills/productivity/grill-me`. The near-verbatim content actually lives in the upstream `grilling` skill; `grill-me` is a thin wrapper. This corrects the footer to `skills/productivity/grilling`, matching `THIRD_PARTY_NOTICES.md`.

Closes #191

## Test plan
- [x] `npm test` passes (63/63, exit 0)
- [x] `git diff` shows only the one footer line changed in `.claude/skills/tm-grill-me/SKILL.md`