### PR TITLE
docs: reframe tm-new-project + NEW-PROJECT-SETUP.md as plugin adoption

### DIFF
--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -1,45 +1,33 @@
 ---
 name: tm-new-project
-description: "Run the once-per-repo new-project setup as a guided flow: create the workflow labels, the docs tree, and fill the CLAUDE.md placeholders by interview; print the human-only steps (branch protection, CI, design-plugin vetting); and retire NEW-PROJECT-SETUP.md once its checklist is done. User-invocable only."
+description: "Run the once-per-repo plugin-adoption setup as a guided flow: create the workflow labels and the docs tree, then print the human-only steps (branch protection, CI, plugin install, design-plugin vetting). User-invocable only."
 disable-model-invocation: true
 ---
 
 Run the setup in `NEW-PROJECT-SETUP.md` against the current repo (the cwd):
-automate what can be automated, print exact commands for what cannot, and
-retire the checklist file once it is done. Idempotent: each section below
-checks its own precondition and skips what is already done, so re-running
-after a partial setup only finishes what is left.
+automate what can be automated, print exact commands for what cannot.
+Idempotent: each section below checks its own precondition and skips what is
+already done, so re-running after a partial setup only finishes what is
+left.
 
 ## 1. Detect state
 
 Check, in this repo:
 
-- The three CLAUDE.md placeholder sentinels (exact-string match against
-  `CLAUDE.md`):
-  - `Describe in 2-3 sentences what this project does`
-  - `Add project-specific style rules here`
-  - `Record the exact commands once the project is scaffolded`
+- The six canonical labels (`gh label list`): `size:S`, `size:M`, `size:L`,
+  `size:XL`, `in-progress`, `needs-human`. Skip this check, with a note, if
+  there is no GitHub remote or `gh` auth.
 - The five docs dirs: `docs/architecture`, `docs/operations`, `docs/plans`,
   `docs/reviews`, `docs/superpowers/specs`.
-- `NEW-PROJECT-SETUP.md` at the repo root.
 
-**Already set up:** all three sentinels absent, all five dirs present, and no
-`NEW-PROJECT-SETUP.md`. Stop here; do not run sections 2-7. Also check
-whether the six canonical labels exist (`gh label list`), skipping that check
-with a note if there is no GitHub remote or `gh` auth. Missing labels are
-noted in the report but do not block the exit or get created. Report:
+**Already set up:** all six labels present (or not checked, for lack of a
+remote or `gh` auth) and all five dirs present. Stop here; do not run
+sections 2-4. Report:
 
-    Already set up: no CLAUDE.md placeholders, docs tree present, no
-    NEW-PROJECT-SETUP.md. Nothing to do.
-    Labels: <all present | missing: <names> | not checked: <reason>>
+    Already set up: labels present, docs tree present. Nothing to do.
+    Labels: <all present | not checked: <reason>>
 
-**No CLAUDE.md** (a config-dir or plugin install into a repo this template
-never seeded): skip section 4 (interview), with a note; this skill does not
-author a CLAUDE.md from scratch. Sections 2, 3, and 5 do not depend on
-CLAUDE.md and still run. Section 6 (clean up) depends only on
-`NEW-PROJECT-SETUP.md`'s presence, not on CLAUDE.md; see section 6.
-
-Otherwise, continue through sections 2-7 below. Each checks its own
+Otherwise, continue through sections 2-4 below. Each checks its own
 precondition and skips what is already done, so a mixed (partially set up)
 state only finishes what is left.
 
@@ -77,28 +65,7 @@ Git does not track empty directories, so a newly created dir will not show up
 in `git status` until a file lands inside it. That is expected; do not add
 placeholder files just to force tracking.
 
-## 4. CLAUDE.md interview
-
-Skip this section, with a note, if there is no `CLAUDE.md` (see section 1) or
-if none of the three sentinels are present (already filled in). Otherwise,
-for each sentinel still present, ask the user and replace only that
-placeholder text, leaving the rest of the file untouched:
-
-- **"What this repo is"** (`Describe in 2-3 sentences...` sentinel): ask what
-  the project does, who uses it, and its current status (pre-implementation,
-  MVP, in production). Write 2-3 sentences.
-- **"Useful commands"** (`Record the exact commands...` sentinel): ask for
-  the real install, dev, typecheck, lint, test, and e2e commands, delete the
-  caption sentence (both wrapped lines), and fill the `bash` block with
-  them.
-- **"Code style"** (`Add project-specific style rules here` sentinel): first
-  ask for the project's tech stack (languages, frameworks, key libraries),
-  recorded from the answer, not detected by scanning any manifest. Then ask
-  for any project-specific style rules. Replace the placeholder with style
-  rules appropriate to that stack, plus any the user gave; if there is
-  neither a stack nor rules, delete the placeholder as before.
-
-## 5. Print human-only steps
+## 4. Print human-only steps
 
 These need a browser or a human decision; print them, do not run them.
 
@@ -119,9 +86,9 @@ https://github.com/anthropics/claude-code/issues/32606), run
 `/plugin install superpowers@claude-plugins-official`.
 
 (Optional, UI projects only) Enable the design plugins. They are not on by
-default, so the template stays generic. Vet the two third-party plugins
-before enabling them in a project others build on; their install steps live
-in their repos and may change.
+default, so adoption stays generic and free of third-party defaults. Vet the
+two third-party plugins before enabling them in a project others build on;
+their install steps live in their repos and may change.
 
 - `frontend-design@claude-plugins-official` (official marketplace, like
   superpowers): `/plugin install frontend-design@claude-plugins-official`.
@@ -141,33 +108,14 @@ a single issue: post a short sub-plan, branch, open a draft PR (`Closes #N`),
 then expand it to a full plan in `docs/plans/`. For a batch of refined
 issues: run `/tm-kickoff` (see team-guide.md "Agent team").
 
-## 6. Clean up
-
-Only when `NEW-PROJECT-SETUP.md` exists at the repo root (if it is already
-gone, skip this section, nothing to do). The human-only steps in section 5
-are still open at this point, so confirm with the user before touching
-anything: tell them branch protection, CI, and first-slice-of-work are
-manual and still outstanding, and ask whether to clean up anyway. On
-confirmation, mirroring `NEW-PROJECT-SETUP.md` section 7's order:
-
-1. Remove every `(see NEW-PROJECT-SETUP)` pointer from `CLAUDE.md`, in
-   "Where decisions live" and "Repo layout" (there is no fixed count; remove
-   every occurrence, not a specific number). If `CLAUDE.md` does not exist,
-   there is nothing to remove; go straight to step 2.
-2. Delete `NEW-PROJECT-SETUP.md`.
-
-## 7. Report
+## 5. Report
 
 Report, in this order:
 
 - Labels: created, already present, or skipped (and why).
 - Docs dirs: created, already present.
-- CLAUDE.md: sections filled, sections already filled (skipped), or skipped
-  entirely (no CLAUDE.md).
-- The human-only steps from section 5, so the user has them without
+- The human-only steps from section 4, so the user has them without
   re-reading this file.
-- Clean up: pointers removed and file deleted, or skipped (why: no
-  `NEW-PROJECT-SETUP.md`, or the user declined).
 
 All changes are left uncommitted for the user to review and commit. This
 skill never runs `git commit`.

--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -83,6 +83,7 @@ you deploy, make e2e a pre-deploy gate.
 **Claude Code plugins.** Accept the superpowers plugin prompt that
 `.claude/settings.json` triggers. If no prompt appears (a known gap,
 https://github.com/anthropics/claude-code/issues/32606), run
+`/plugin marketplace add anthropics/claude-plugins-official`, then
 `/plugin install superpowers@claude-plugins-official`.
 
 (Optional, UI projects only) Enable the design plugins. They are not on by

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -3,13 +3,10 @@
 Prefer a guided flow? Run `/tm-new-project` to automate what it can here and
 print exact commands for the rest.
 
-Run once when starting a new repo from this template. Create the repo from the
-GitHub template (or copy the whole tree, including `.claude/`) and fill in the
-`CLAUDE.md` placeholders as you go.
+Run once when adopting the orchestrai plugin into an existing repo.
 
-## 1. Repository and protection
+## 1. Branch protection
 
-- [ ] Create the repo (`gh repo create <name> --template sv-tmueller/orchestrai --clone`).
 - [ ] Protect `main`: block direct pushes, require a PR, require status checks to
       pass before merge.
 - [ ] (Optional) Create the labels the workflow uses: the sizing set `size:S`,
@@ -23,16 +20,21 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 
 ## 2. Claude Code
 
-- [ ] Open the repo in Claude Code and trust the folder. Accept the superpowers
-      plugin prompt that `.claude/settings.json` triggers. If no prompt appears
-      (a known gap, https://github.com/anthropics/claude-code/issues/32606), run
+- [ ] Install the orchestrai plugin via the marketplace (see the README's
+      "Getting the team into your repos"):
+      `/plugin marketplace add sv-tmueller/orchestrai`, then
+      `/plugin install orchestrai@orchestrai`. It depends on the superpowers
+      plugin: accept the prompt that `.claude/settings.json` triggers, or if
+      no prompt appears (a known gap,
+      https://github.com/anthropics/claude-code/issues/32606), run
+      `/plugin marketplace add anthropics/claude-plugins-official`, then
       `/plugin install superpowers@claude-plugins-official`.
 - [ ] Check the agent team is loaded: `/agents` should list architect,
       developer, tester, and reviewer.
 - [ ] Check the skills are registered: `/skills` should list tm-advisor,
       tm-kickoff, tm-grill-me, tm-to-issues, and tm-new-project.
 - [ ] (Optional) If this project builds UI, enable the design plugins. They are
-      not on by default, so the template stays generic and free of third-party
+      not on by default, so adoption stays generic and free of third-party
       defaults. Add each to `.claude/settings.json` under `enabledPlugins` and
       install it:
       - `frontend-design@claude-plugins-official` (distinctive frontend UI;
@@ -73,13 +75,7 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 - [ ] Make the relevant CI jobs required status checks on `main`.
 - [ ] If you deploy, make e2e a pre-deploy gate.
 
-## 5. CLAUDE.md
-
-- [ ] Fill "What this repo is" (what, who, status).
-- [ ] Fill "Useful commands" with the real install/dev/test/lint/e2e commands.
-- [ ] Tailor "Code style" to this project; delete the placeholder line.
-
-## 6. First slice of work
+## 5. First slice of work
 
 - [ ] Brainstorm the first design via `superpowers:brainstorming`; save the spec to
       `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`.
@@ -88,10 +84,3 @@ GitHub template (or copy the whole tree, including `.claude/`) and fill in the
 - [ ] For a single issue: post a short sub-plan on the issue, branch, open a
       draft PR (`Closes #N`), then expand it to a full plan in `docs/plans/`.
 - [ ] For a batch of refined issues: run `/tm-kickoff` (see team-guide.md "Agent team").
-
-## 7. Clean up
-
-- [ ] Remove all `(see NEW-PROJECT-SETUP)` pointers from `CLAUDE.md`, in
-      "Where decisions live" and "Repo layout".
-- [ ] Delete this file, `NEW-PROJECT-SETUP.md`, once every box above is
-      checked.


### PR DESCRIPTION
## Summary

- Reframes both `.claude/skills/tm-new-project/SKILL.md` and `NEW-PROJECT-SETUP.md` from "start a new repo from this template" to "adopt the orchestrai plugin into an existing repo," per the sub-plan on #190.
- Keeps the bootstrap that still applies: create the 6 workflow labels, create the 5 docs dirs, and print the human-only steps (branch protection, CI, plugin install, design-plugin vetting).
- Drops the `gh repo create --template` step, the CLAUDE.md-interview section, and the "delete NEW-PROJECT-SETUP.md" / "remove pointers" cleanup steps (adopting repos already own their CLAUDE.md; this file stays as a living reference, not a one-time checklist to retire).
- Redesigns SKILL.md's state-detection (section 1) to key on labels-present + docs-dirs-present instead of CLAUDE.md placeholder sentinels.
- Replaces "open the repo and trust the folder" in NEW-PROJECT-SETUP.md section 2 with installing the orchestrai plugin via the marketplace, reusing the exact commands and wording from README's "Getting the team into your repos" section and the `orchestrai` plugin identity in `.claude-plugin/marketplace.json`.
- Both files now describe the same 5-section bootstrap and the same human-only steps, kept mutually consistent.

## Scope flag (not fixed here)

After this reframe, `README.md` will contradict these two files: it still says "a starting point for new projects," describes `tm-new-project` as interviewing to fill CLAUDE.md placeholders, and has the `gh repo create --template` line. That reconciliation is a separate, already-filed follow-up: #195. This PR intentionally does not touch `README.md`.

Closes #190

## Test plan

- [x] `git diff --stat` shows only the two intended files changed
- [x] `grep -n -i "template\|placeholder\|sentinel\|delete this file\|repo create"` on both files returns only intentional survivors (`templates/ci.yml`, and "placeholder files" in the git-tracking note, unrelated to CLAUDE.md placeholders)
- [x] No em dashes or AI-cliche phrases
- [x] `npm test` passes (63/63)