### PR TITLE
feat: add docs-writer agent seat (survey candidate 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "orchestrai",
       "source": "./.claude",
-      "description": "Orchestrator team: 5 role agents, the tm- operational skills, and the review workflows."
+      "description": "Orchestrator team: the role agents, the tm- operational skills, and the review workflows."
     }
   ]
 }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "orchestrai",
   "displayName": "OrchestrAI",
   "version": "2.0.1",
-  "description": "Orchestrator team: 5 role agents, the tm- operational skills, and the review workflows.",
+  "description": "Orchestrator team: the role agents, the tm- operational skills, and the review workflows.",
   "author": {
     "name": "Thomas Mueller"
   }

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -1,0 +1,48 @@
+---
+name: docs-writer
+description: Authors or updates user-facing documentation (README, guides, API docs) from a gap analysis of what is missing or stale. Dispatch on demand, for example after a tm-map-codebase run, when user-facing docs are missing or stale. Never part of the per-package kickoff pipeline; one dispatch, no fan-out.
+tools: Read, Grep, Glob, Write, Edit
+model: sonnet
+effort: high
+---
+
+You author user-facing documentation; you never touch application code, tests,
+or workflow scripts. You have no Bash, so you cannot commit, push, or open a
+PR: you write into the lead's current checkout, and the lead owns branch,
+commit, and PR for what you write.
+
+Input: the lead's dispatch, naming which docs to look at or produce (for
+example, the output of a `tm-map-codebase` run, or a specific doc the lead
+already knows is stale). You do not decide what to write on your own beyond
+that scope.
+
+## The job
+
+Two phases, in order.
+
+1. **Gap analysis.** Read the repo (and any map or review doc the lead passed
+   in) and list which user-facing docs are missing or stale: a README section
+   that no longer matches the code, a guide that omits a feature, API docs
+   that drifted from the actual interface. Do not fix anything yet.
+2. **Author.** Write or edit only the docs the lead's dispatch actually asked
+   for. Do not expand scope to every gap found in phase 1; note the rest in
+   your report instead (see below).
+
+Your prose follows the "Writing style" section of `.claude/team-guide.md`
+(no em dashes, no AI-cliche phrases, plain direct English, short sentences):
+you are the one seat whose entire output is user-facing prose, so that section
+binds you more than it binds any other seat.
+
+## Report contract
+
+End with exactly this structure:
+
+```
+FILES:
+  1. <path> - <created | updated> - <one-line purpose>
+GAPS_NOT_FILLED: <gap found in phase 1 but out of the dispatch's scope, and why; "none" if the dispatch scope covered every gap found>
+ASSUMPTIONS: <anything you had to guess rather than find in the repo, labeled as such; "none" if none>
+```
+
+The lead decides what happens next (dispatch you again for a gap, fold a gap
+into a future issue, or drop it); you do not make that call.

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -202,13 +202,12 @@ else. The lever is where each model runs, not raw effort everywhere.
   fallback); `developer`, `tester`, `fact-checker`, and `docs-writer` run
   `sonnet`, which resolves to Sonnet 5 (code generation, verification, claim
   auditing, and doc authoring are execution roles, not decision roles). The
-  `fact-checker` stays on
-  Sonnet rather than Haiku because claim extraction is the step that fails
-  silently: a model that misses an unsupported claim defeats the role's
-  purpose, and the agent runs rarely enough that the cost difference does
-  not matter. Each agent also pins its own effort in frontmatter (`sonnet`
-  seats `high`, `fable` seats `xhigh`), so seat effort never depends on the
-  session's `/effort` setting.
+  `fact-checker` stays on Sonnet rather than Haiku because claim extraction is
+  the step that fails silently: a model that misses an unsupported claim
+  defeats the role's purpose, and the agent runs rarely enough that the cost
+  difference does not matter. Each agent also pins its own effort in
+  frontmatter (`sonnet` seats `high`, `fable` seats `xhigh`), so seat effort
+  never depends on the session's `/effort` setting.
 - Effort ceiling: `xhigh`. Nothing runs at `max`. Evidence (DeepSWE v1.1
   leaderboard, July 2026): Fable 5 at max scores the same as at high for
   roughly 1.8x the cost, and Sonnet 5 at max is dominated by Fable 5 at every

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -95,7 +95,7 @@ Standing preferences for this project:
 
 ## Agent team
 
-The template ships six role agents in `.claude/agents/` and a set of skills.
+The template ships the role agents in `.claude/agents/` and a set of skills.
 The lead is the main session: subagents cannot call each other, so the
 session running `/tm-kickoff` routes every handoff, and GitHub (sub-plan and
 verdict comments, draft PRs, labels) holds the state that makes a dropped

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -95,7 +95,7 @@ Standing preferences for this project:
 
 ## Agent team
 
-The template ships five role agents in `.claude/agents/` and a set of skills.
+The template ships six role agents in `.claude/agents/` and a set of skills.
 The lead is the main session: subagents cannot call each other, so the
 session running `/tm-kickoff` routes every handoff, and GitHub (sub-plan and
 verdict comments, draft PRs, labels) holds the state that makes a dropped
@@ -112,6 +112,9 @@ pipeline lives in `docs/team-architecture.md`.
   marked it as an assumption). Dispatch it when a report's claims matter but
   carry no evidence; a CONTRADICTED claim is never dropped, it goes back to
   the agent that made it.
+- `docs-writer` - authors or updates user-facing docs (README, guides, API
+  docs) from a gap analysis. Dispatch it on demand, for example after a
+  `tm-map-codebase` run, when user-facing docs are missing or stale.
 
 Refine and size issues in discussion first (`/tm-grill-me` stress-tests the
 plan, `/tm-to-issues` turns it into sized issues); mark dependencies with a
@@ -196,9 +199,10 @@ else. The lever is where each model runs, not raw effort everywhere.
   "Adjust effort level".)
 - Role agents (set in each agent's frontmatter `model:`): `architect` and
   `reviewer` run `fable` (the plan/decision roles; `opus` is the documented
-  fallback); `developer`, `tester`, and `fact-checker` run `sonnet`, which
-  resolves to Sonnet 5 (code generation, verification, and claim auditing
-  are execution roles, not decision roles). The `fact-checker` stays on
+  fallback); `developer`, `tester`, `fact-checker`, and `docs-writer` run
+  `sonnet`, which resolves to Sonnet 5 (code generation, verification, claim
+  auditing, and doc authoring are execution roles, not decision roles). The
+  `fact-checker` stays on
   Sonnet rather than Haiku because claim extraction is the step that fails
   silently: a model that misses an unsupported claim defeats the role's
   purpose, and the agent runs rarely enough that the cost difference does

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ below).
   protection, installing the plugin, docs structure, CI/CD and e2e wiring,
   and the first slice of work. Stays in the repo as a living checklist; it
   is not deleted once checked off.
-- `.claude/agents/` - six role agents: architect (approach, read-only),
+- `.claude/agents/` - the role agents: architect (approach, read-only),
   developer (one issue end to end, worktree-isolated), tester (independent
   verification, read-only), reviewer (spec pass then quality pass, read-only),
   fact-checker (audits report and PR claims against evidence, read-only),
@@ -110,7 +110,7 @@ org's private repo):
 /plugin install orchestrai@orchestrai
 ```
 
-This installs the 6 agents and all 7 skills under the `orchestrai` namespace,
+This installs the agents and all 7 skills under the `orchestrai` namespace,
 for example `/orchestrai:tm-advisor` and `/orchestrai:tm-kickoff`. The two
 review workflows (`tm-review-changes`, `tm-review-codebase`) ship as thin
 wrapper skills, since plugin `workflows/` is not an official component type.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ below).
   protection, installing the plugin, docs structure, CI/CD and e2e wiring,
   and the first slice of work. Stays in the repo as a living checklist; it
   is not deleted once checked off.
-- `.claude/agents/` - five role agents: architect (approach, read-only),
+- `.claude/agents/` - six role agents: architect (approach, read-only),
   developer (one issue end to end, worktree-isolated), tester (independent
   verification, read-only), reviewer (spec pass then quality pass, read-only),
-  fact-checker (audits report and PR claims against evidence, read-only).
+  fact-checker (audits report and PR claims against evidence, read-only),
+  docs-writer (authors user-facing docs from a gap analysis, on demand).
 - `.claude/skills/tm-advisor/` - `/tm-advisor`: the operating model on top of the
   team. Refines a raw need into a batch of work packages, takes one sign-off,
   runs the batch uninterrupted through the kickoff pipeline, and reports.
@@ -80,6 +81,8 @@ graph TD
     L -.->|"fix loop"| D
     L -->|"on demand"| F["fact-checker<br/>sonnet, high<br/>read-only - audits claims"]
     F -.->|"grounded / ungrounded"| L
+    L -->|"on demand"| DW["docs-writer<br/>sonnet, high<br/>gap analysis + author docs"]
+    DW -.->|"files written"| L
 
     L -->|"5 ready PR"| G[("GitHub<br/>sub-plans, verdicts, labels")]
     G -->|"6 human merges"| H
@@ -107,7 +110,7 @@ org's private repo):
 /plugin install orchestrai@orchestrai
 ```
 
-This installs the 5 agents and all 7 skills under the `orchestrai` namespace,
+This installs the 6 agents and all 7 skills under the `orchestrai` namespace,
 for example `/orchestrai:tm-advisor` and `/orchestrai:tm-kickoff`. The two
 review workflows (`tm-review-changes`, `tm-review-codebase`) ship as thin
 wrapper skills, since plugin `workflows/` is not an official component type.

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -49,7 +49,7 @@ graph TD
     L <-->|"sub-plans, PR verdicts, labels = resumable state"| G[("GitHub")]
 ```
 
-Six peers under one lead, no third level. Evidence flows back to the lead, which
+Peers under one lead, no third level. Evidence flows back to the lead, which
 routes it into the next agent. GitHub holds the state that makes a dropped
 session resumable. The `fact-checker` and `docs-writer` sit outside the
 per-package pipeline: the lead dispatches `fact-checker` on demand when a

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -37,22 +37,26 @@ graph TD
     L -->|"branch + issue"| T["tester (sonnet)<br/>read-only - re-runs suite, attacks change"]
     L -->|"PR + issue + untested claims"| R["reviewer (fable)<br/>read-only - spec pass then quality pass"]
     L -->|"report text + branch or PR"| F["fact-checker (sonnet)<br/>read-only - audits claims against evidence"]
+    L -->|"dispatch: docs to write"| DW["docs-writer (sonnet)<br/>gap analysis, then author user-facing docs"]
 
     A -.->|"SUB_PLAN / NEEDS_DECISION"| L
     D -.->|"STATUS / BRANCH / PR / CHECKS"| L
     T -.->|"VERDICT / FINDINGS"| L
     R -.->|"VERDICT / FINDINGS"| L
     F -.->|"GROUNDED / UNGROUNDED per claim"| L
+    DW -.->|"FILES / GAPS_NOT_FILLED / ASSUMPTIONS"| L
 
     L <-->|"sub-plans, PR verdicts, labels = resumable state"| G[("GitHub")]
 ```
 
-Five peers under one lead, no third level. Evidence flows back to the lead, which
+Six peers under one lead, no third level. Evidence flows back to the lead, which
 routes it into the next agent. GitHub holds the state that makes a dropped
-session resumable. The `fact-checker` sits outside the per-package pipeline:
-the lead dispatches it on demand when a report's claims are load-bearing but
-carry no evidence, and routes any CONTRADICTED claim back to the agent that
-made it.
+session resumable. The `fact-checker` and `docs-writer` sit outside the
+per-package pipeline: the lead dispatches `fact-checker` on demand when a
+report's claims are load-bearing but carry no evidence, and routes any
+CONTRADICTED claim back to the agent that made it; it dispatches `docs-writer`
+on demand, for example after a `tm-map-codebase` run, when user-facing docs
+are missing or stale.
 
 ## The per-package pipeline
 


### PR DESCRIPTION
## Summary
- Add `.claude/agents/docs-writer.md`, an on-demand execution seat that authors user-facing docs (README, guides, API docs) from a gap analysis. Never part of the per-package kickoff pipeline.
- Update the seat lists in `.claude/team-guide.md` (Agent team + Model policy), `README.md`, and `docs/team-architecture.md`.

Closes #202