### PR TITLE
chore: bump plugin version to 2.1.0

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrai",
   "displayName": "OrchestrAI",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Orchestrator team: the role agents, the tm- operational skills, and the review workflows.",
   "author": {
     "name": "Thomas Mueller"


### PR DESCRIPTION
Bumps the plugin version from 2.0.1 to 2.1.0 in `.claude/.claude-plugin/plugin.json`.

Closes #211