### PR TITLE
chore: stale seat-list cleanup deferred from batch 201

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -271,7 +271,8 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
 
 ```
 .claude/
-  agents/            role agents: architect, developer, tester, reviewer
+  agents/            role agents: architect, developer, tester, reviewer,
+                       fact-checker, docs-writer, perf-investigator
   skills/            project skills: /tm-advisor, /tm-grill-me, /tm-kickoff, /tm-new-project, /tm-to-issues
   workflows/         bounded orchestration scripts (tm-review-changes, tm-review-codebase, tm-map-codebase)
   settings.json      project settings; enables the superpowers plugin

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -29,8 +29,8 @@ describe('agent frontmatter effort pins', () => {
 
   test('the role agents are present', () => {
     assert.ok(
-      agentFiles.length >= 5,
-      `expected at least the 5 role agents in ${agentsDir}, found ${agentFiles.length}`
+      agentFiles.length >= 7,
+      `expected at least the 7 role agents in ${agentsDir}, found ${agentFiles.length}`
     )
   })
 


### PR DESCRIPTION
Closes #217

Seat additions in batch #201 and #210 (fact-checker, docs-writer,
perf-investigator) outpaced two annotations that were deferred for
cleanup:

1. `.claude/team-guide.md` repo-layout line listed only four agents;
   now lists all seven.
2. `.claude/workflows/__tests__/effort-policy.test.mjs` floored the
   role-agent presence check at 5 with a matching stale message; now
   floors at 7.

Pure cleanup, no new seats or policy changes. Diff touches only the
two spots above.

## Test plan

- `npm test`: 65 tests, 65 pass, 0 fail, exit code 0.