### PR TITLE
docs: align Model policy with token-burn findings

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -92,6 +92,20 @@ Standing preferences for this project:
   verification-before-completion).
 - Parallel work: fan out subagents for independent research or implementation
   streams. Default to parallel over serial.
+- Session hygiene: bound lead-session context growth before it reaches the
+  hundreds of thousands of tokens (compact, `/clear`, or restart), and prefer
+  fresh short-lived dispatches per issue over one long session across many
+  tasks. Before (measured): the top 15 lead-session peaks per turn all exceed
+  570,000 tokens, the highest is 1,634,150; orchestrai's own top lead session
+  is 583,848, already below those plan-wide peaks because the kickoff
+  pipeline dispatches fresh sessions per issue. After (estimate, not a
+  measurement): assuming a 200,000-token compact-or-clear threshold, the
+  worst measured turn shrinks about 8.2x (about 88% less) and the top-15
+  floor shrinks about 2.9x (about 65% less) per turn. Cache-read volume on
+  those turns drops by roughly the same factors, since the peaks are almost
+  all cache_read (hit ratios 0.9266 to 0.9891). The estimate assumes the
+  threshold holds exactly and ignores compaction's own one-time cost
+  (docs/research/2026-07-06-token-burn-investigation.md).
 
 ## Agent team
 
@@ -170,9 +184,13 @@ else. The lever is where each model runs, not raw effort everywhere.
   model. This is affordable only because the lead stays on the bounded tm-
   machinery: Fable's known failure mode is over-spawning under session-wide
   ultracode, which this policy rules out (next bullet). Fable costs 2x Opus
-  4.8 per token and weighs correspondingly against Max-plan quota; the lead's
-  own token share is small next to the Sonnet-pinned workers, which keeps the
-  premium bounded.
+  4.8 per token and weighs correspondingly against Max-plan quota. Across the
+  14-day, 25-project aggregate, Fable's own token share stays small (5.5% raw,
+  18.7% weighted proxy), but within a single kickoff batch it flips: in batch
+  #201, Fable-priced roles (lead, architect, reviewer) took 57.5% raw and
+  93.3% weighted proxy of that batch's tokens. The premium is bounded in
+  aggregate, not per batch
+  (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
 - Fallback: Opus 4.8 at xhigh effort. Claude Code has no automatic model
   fallback for the lead or for subagents; the fallback is a procedure. When
   Fable 5 is unavailable, rate-limited, quota-exhausted, or refuses the


### PR DESCRIPTION
Closes #216

## Why

`docs/research/2026-07-06-token-burn-investigation.md` found two things the Model policy did not reflect:

1. The "Fable's token share stays small" claim only holds at the 14-day, 25-project aggregate (5.5% raw / 18.7% weighted proxy). Within a single kickoff batch it flips: batch #201 had Fable-priced roles (lead, architect, reviewer) at 57.5% raw / 93.3% weighted proxy.
2. Lead sessions can peak past a million tokens in a single turn (top 15 all exceed 570,000, highest 1,634,150). A session-hygiene note with a labeled before/after projection (assuming a 200,000-token compact-or-clear threshold: about 8.2x / about 2.9x smaller per turn) makes the recommended bound visible in the same place as the other standing preferences.

## Changes

Only `.claude/team-guide.md`, two edit sites:
- Model policy orchestrator bullet: scope-qualified claim with both measured shares, citing the report (driver 3).
- Workflow defaults: new session-hygiene bullet after "Parallel work", with the measured before / labeled-estimate after numbers.

## Verification

- `npm test` -> 65 tests, 0 fail, exit 0
- `git diff --stat origin/main` shows exactly one file: `.claude/team-guide.md` (21 insertions, 3 deletions)
- No em dashes, no AI-cliche phrases in the new text
- Numbers cross-checked against the report: 5.5% / 18.7% (section 4), 57.5% / 93.3% (driver 3), 570,000 / 1,634,150 / 583,848 (section 3), 0.9266 / 0.9891 (section 5); 1,634,150 / 200,000 = 8.17x (about 88% less), 570,000 / 200,000 = 2.85x (about 65% less)