### PR TITLE
docs: document per-call Opus override for a single Fable-blocked seat

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -168,7 +168,12 @@ Rationale: docs/team-guide-rationale.md.
   refuses the workload, switch the lead with `/model claude-opus-4-8`; for a
   longer outage flip the `fable` pins to `opus` in the `architect` and
   `reviewer` frontmatters and the Fable-critic stage of every `tm-` workflow
-  (`.claude/workflows/`). Flip back when Fable returns.
+  (`.claude/workflows/`). Flip back when Fable returns. For a single
+  role-agent dispatch hitting Fable quota mid-batch, dispatch that one agent
+  with a per-call Opus override (the Agent tool's `model` param) instead of
+  flipping every pin. The ladder is Fable -> Opus; Sonnet is never a fallback
+  for a judgment seat, and only steps in, flagged, if Opus is also down, with
+  the review re-run on a judgment model afterward.
 - Cost-based fallback trigger: if Fable 5 stops being included under the
   Max-plan subscription and shifts to metered API billing, do not switch to
   Opus automatically. Measure the lead's actual $/session cost at API rates


### PR DESCRIPTION
## Why

The Fallback bullet in `.claude/team-guide.md` only documented two remedies
for Fable exhaustion: the lead switching model with `/model claude-opus-4-8`,
and a longer-outage flip of the `fable` pins across `architect.md`,
`reviewer.md`, and the workflow critic stages. It missed the lightweight
middle case: a single role-agent dispatch (reviewer, architect) hitting
Fable quota mid-batch, where flipping every pin is overkill. That gap led to
a reviewer-to-Sonnet misstep, since nothing documented the per-call override
or stated plainly that Sonnet is never a judgment-seat fallback.

## What changed

Added two sentences to the Fallback bullet:
- Dispatch just the blocked agent with a per-call Opus override (the Agent
  tool's `model` param overrides the agent's `model: fable` frontmatter)
  instead of flipping every pin.
- The ladder is Fable -> Opus; Sonnet is never a fallback for a judgment
  seat, and only steps in, flagged, if Opus is also down, with the review
  re-run on a judgment model afterward.

No change to agent frontmatter, workflow critic pins, or the Model policy
section otherwise; the policy itself (Fable -> Opus) is unchanged, this only
documents the missing lightweight branch.

Closes #227