### PR TITLE
chore: bump plugin version to 2.2.0

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrai",
   "displayName": "OrchestrAI",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Orchestrator team: the role agents, the tm- operational skills, and the review workflows.",
   "author": {
     "name": "Thomas Mueller"


### PR DESCRIPTION
## Summary
- Bumps `.claude/.claude-plugin/plugin.json` version from 2.1.0 to 2.2.0
- 2.2.0 covers feat #240 (grill-me sign-off option), refactors #236 (tm-to-issues consolidation) and #225 (team-guide trim)

Closes #242

## Test plan
- [x] `git diff origin/main --stat` shows exactly one file, one changed line
- [x] File parses as valid JSON
- [x] `npm test` (node --test) passes: 65/65 tests