### PR TITLE
feat: tm-ab-test, a paired A/B comparison harness

### DIFF
--- a/.claude/skills/tm-ab-test/SKILL.md
+++ b/.claude/skills/tm-ab-test/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: tm-ab-test
+description: Run a paired A/B comparison of two orchestration-variant arms on the same task. Forks both from one base commit, runs them sequentially (headless or human-supervised), records agent count, wall-clock time, token usage, diff size, and an independent review pass per arm, then writes a dated report and appends one ledger row. User-invocable only.
+disable-model-invocation: true
+argument-hint: <task-issue-number> <arm-A-name>:headless|supervised <arm-B-name>:headless|supervised
+---
+
+You are the lead, running a paired comparison, not a new pipeline. Every
+step below sequences existing bounded machinery (`/tm-kickoff`, a tm-
+workflow, or a single role-agent dispatch); this skill adds no new agent
+and no new workflow script.
+
+Input: $ARGUMENTS (the task issue number, then one `<name>:<mode>` pair per
+arm; mode is `headless` or `supervised`). With missing or unclear
+arguments, ask for the task issue number and, for each arm, its name, a
+one-line description of what it varies, and its mode.
+
+An arm is a name, a free-form description, and a mode:
+
+- **headless**: you drive it end to end (a kickoff-pipeline run, a tm-
+  workflow, or a single developer dispatch), whichever matches what the arm
+  varies.
+- **supervised**: the arm needs a session-level setting (ultracode, a
+  non-default effort level) that you cannot turn on for yourself. Emit
+  `templates/supervised-arm-runbook.md`, filled with this arm's base
+  commit and worktree, and hand it to the human. Wait for the filled
+  recording checklist before continuing.
+
+## 1. Gate
+
+Ensure the `ab-test` label exists:
+
+```
+gh label create "ab-test" --color "5319E7" --description "Scratch issue driving one arm of a tm-ab-test run." --force
+```
+
+Record the base commit both arms fork from: `git rev-parse origin/main`
+(or `origin/HEAD` if the default branch is not `main`). Every arm forks a
+worktree from this exact commit.
+
+## 2. Arm isolation
+
+For each arm whose work is issue-driven (drives `/tm-kickoff`, or any
+machinery that reads an issue's sub-plan comments and PRs), open its own
+scratch issue so the two arms never share GitHub state:
+
+```
+gh issue create --title "AB #<task-issue>-arm-<a|b>: <task title>" \
+  --body "<task issue body, copied verbatim>" \
+  --label "ab-test" --label "<task's size label>"
+```
+
+Copy the task's size label onto the scratch issue as well as `ab-test`.
+Kickoff's sizing gate parks any issue it cannot size, so an unsized scratch
+issue stalls the arm.
+
+Branches are namespaced automatically: a developer dispatch on a scratch
+issue branches from that issue's own number, so arm A and arm B never
+collide on a branch name even when their task titles match.
+
+An arm that is not issue-driven (a direct workflow invocation, or a
+single-shot developer dispatch you drive by hand) needs no scratch issue;
+just record its base commit and window in the checklist.
+
+The original task issue stays untouched throughout: no label, no comment,
+until a human reads the report and picks a winner.
+
+## 3. Run the arms, sequentially
+
+Run arm A to completion (including its recording, step 4 below) before
+starting arm B. Arms never run concurrently: overlapping arms would
+distort wall-clock and token numbers through quota and CPU contention.
+
+For a headless arm: drive it yourself in that arm's own worktree, forked
+from the base commit. Before every agent dispatch inside the arm (a
+kickoff-pipeline stage, a workflow stage, or a single role-agent dispatch),
+print the pre-dispatch plan-status block per issue #249: which of this
+run's steps are done, which the dispatch is about to start, which remain.
+
+For a supervised arm: hand off per the runbook above and wait.
+
+## 4. Record
+
+Fill one copy of `templates/recording-checklist.md` per arm as it runs
+(for a headless arm, you fill it; for a supervised arm, the human fills it
+and hands it back). The checklist pins the exact commands for base commit,
+window, token usage, agent count, diff size, and the independent review
+pass; run each one, do not estimate.
+
+## 5. Report and ledger
+
+Once both arms are recorded, write the report from `templates/report.md`
+to `docs/reviews/YYYY-MM-DD-ab-<task-slug>.md`. Mark each arm's status as
+run headless, run supervised, or not run. Link both arms' draft-PR diffs.
+Then append one row to `docs/reviews/ab-tests.md`: date, task, arms,
+headline numbers, and a link to the new report. Never edit a past ledger
+row or a past report; the ledger only appends.
+
+## 6. Cleanup
+
+Close each arm's scratch issue and its draft PR once both diffs are linked
+in the report. For worktree and branch cleanup, follow `tm-kickoff`
+SKILL.md's "Worktree cleanup (deterministic)" section; it is not repeated
+here.
+
+## Report to the user
+
+- The report path and its headline-numbers table.
+- The ledger row appended.
+- Any arm that stayed "not run" (a supervised arm still waiting on a
+  human), so the run is clearly incomplete rather than silently dropped.

--- a/.claude/skills/tm-ab-test/SKILL.md
+++ b/.claude/skills/tm-ab-test/SKILL.md
@@ -34,9 +34,11 @@ Ensure the `ab-test` label exists:
 gh label create "ab-test" --color "5319E7" --description "Scratch issue driving one arm of a tm-ab-test run." --force
 ```
 
-Record the base commit both arms fork from: `git rev-parse origin/main`
-(or `origin/HEAD` if the default branch is not `main`). Every arm forks a
-worktree from this exact commit.
+Record the base commit both arms fork from: `git fetch origin`, then
+`git rev-parse origin/main` (or `origin/HEAD` if the default branch is not
+`main`). Every arm forks a worktree from this exact commit, and no merge
+may land on `main` between arms; a merge mid-run moves the base out from
+under the later arm and invalidates the pairing.
 
 ## 2. Arm isolation
 
@@ -58,9 +60,15 @@ Branches are namespaced automatically: a developer dispatch on a scratch
 issue branches from that issue's own number, so arm A and arm B never
 collide on a branch name even when their task titles match.
 
-An arm that is not issue-driven (a direct workflow invocation, or a
-single-shot developer dispatch you drive by hand) needs no scratch issue;
-just record its base commit and window in the checklist.
+Every developer-dispatch arm gets a scratch issue, single-shot included.
+Per `.claude/agents/developer.md`, a developer dispatch always reads an
+issue's sub-plan comment as its spec, derives its branch from that issue's
+number, posts a sub-plan comment if none exists, and opens a PR with
+`Closes #<n>`. A raw developer arm run on the original task issue would do
+all of that on the task issue itself, breaking the "stays untouched"
+invariant below. Only a direct workflow invocation, which takes a base ref
+instead of an issue, needs no scratch issue; just record its base commit
+and window in the checklist.
 
 The original task issue stays untouched throughout: no label, no comment,
 until a human reads the report and picks a winner.

--- a/.claude/skills/tm-ab-test/templates/recording-checklist.md
+++ b/.claude/skills/tm-ab-test/templates/recording-checklist.md
@@ -10,11 +10,18 @@ and 6.
 - [ ] Base commit: `git fetch origin`, then `git rev-parse origin/main`,
       recorded before either arm starts. Both arms fork from this same
       commit.
-- [ ] Drift check: `git merge-base <recorded-base-commit> <arm-branch>`
-      must print the recorded base commit. If it prints something else,
-      the arm drifted from the recorded base (for example, a merge landed
-      on `main` between arms). Record the actual fork point printed by the
-      command and mark this run base-drifted in `templates/report.md`.
+- [ ] Pre-dispatch gate: immediately before starting each arm, run
+      `git fetch origin && git rev-parse origin/main` and compare the
+      result to the recorded base commit. If they differ, `main` has
+      moved since the base was recorded: either stop and restart the
+      pairing from the new base, or proceed and mark this run
+      base-drifted in `templates/report.md`.
+- [ ] Post-run audit: after the arm completes, run
+      `git merge-base origin/main <arm-branch>` to record its actual fork
+      point, and compare that to the recorded base commit. A mismatch
+      also marks this run base-drifted in `templates/report.md`, even if
+      the pre-dispatch gate above found no drift (a merge can land on
+      `main` while the arm is running, not just before it starts).
 
 ## Arm window
 

--- a/.claude/skills/tm-ab-test/templates/recording-checklist.md
+++ b/.claude/skills/tm-ab-test/templates/recording-checklist.md
@@ -1,0 +1,63 @@
+# Recording checklist (per arm)
+
+Fill one copy of this checklist per arm. Every field has an exact command;
+nothing here is re-derived by hand. Covers the recording dimensions from
+`docs/reviews/2026-06-30-orchestration-comparison.md`'s appendix, steps 2, 5,
+and 6.
+
+## Fork point (appendix step 2)
+
+- [ ] Base commit: `git rev-parse HEAD`, recorded before either arm starts.
+      Both arms fork from this same commit.
+
+## Arm window
+
+- [ ] Start: ISO timestamp when the arm begins.
+- [ ] End: ISO timestamp when the arm ends.
+
+Arms run sequentially, so the windows never overlap.
+
+## Token usage and agent count (appendix step 5)
+
+- [ ] Run:
+
+  ```
+  node docs/research/2026-07-06-token-burn-analyze.mjs \
+    --start <arm-start-ISO> --end <arm-end-ISO> \
+    --project <repo-dir-substring> --json
+  ```
+
+  Use the arm window above for `--start`/`--end`, and a substring of this
+  repo's working-directory name for `--project` so the script scopes to this
+  project only.
+
+- [ ] Agent or subagent count: read from the same JSON output. For a headless
+      arm, cross-check it against the lead's own dispatch log for that arm's
+      window; the two should agree.
+
+## Diff size (appendix step 5)
+
+- [ ] Run: `git diff --stat <base-commit>...<arm-branch>`
+
+## Independent review pass (appendix step 5)
+
+- [ ] From a checkout with the arm branch at HEAD, run:
+
+  ```
+  Workflow({ name: 'tm-review-changes', args: { base: '<base-commit>' } })
+  ```
+
+  Use the same base commit recorded above for every arm, so each review is
+  scoped to that arm's own diff from the common fork point.
+
+## Acceptance-criteria drift (appendix step 5)
+
+- [ ] Compare the arm's result against the task's stated acceptance
+      criteria. Note any criterion the arm missed, changed, or exceeded.
+
+## Wall-clock time
+
+- [ ] Arm end minus arm start, from the window above.
+
+Once every field above is filled for both arms, copy them into
+`templates/report.md` and append one row to `docs/reviews/ab-tests.md`.

--- a/.claude/skills/tm-ab-test/templates/recording-checklist.md
+++ b/.claude/skills/tm-ab-test/templates/recording-checklist.md
@@ -7,8 +7,14 @@ and 6.
 
 ## Fork point (appendix step 2)
 
-- [ ] Base commit: `git rev-parse HEAD`, recorded before either arm starts.
-      Both arms fork from this same commit.
+- [ ] Base commit: `git fetch origin`, then `git rev-parse origin/main`,
+      recorded before either arm starts. Both arms fork from this same
+      commit.
+- [ ] Drift check: `git merge-base <recorded-base-commit> <arm-branch>`
+      must print the recorded base commit. If it prints something else,
+      the arm drifted from the recorded base (for example, a merge landed
+      on `main` between arms). Record the actual fork point printed by the
+      command and mark this run base-drifted in `templates/report.md`.
 
 ## Arm window
 

--- a/.claude/skills/tm-ab-test/templates/report.md
+++ b/.claude/skills/tm-ab-test/templates/report.md
@@ -1,0 +1,67 @@
+# A/B test: <task title> - YYYY-MM-DD
+
+Save as `docs/reviews/YYYY-MM-DD-ab-<task-slug>.md`. Reports are immutable
+once written; append the summary row to `docs/reviews/ab-tests.md` instead
+of editing this file later.
+
+Task: #<task-issue-number>, `<task title>`.
+
+Base commit: `<base-commit>` (both arms forked from here).
+
+## Arm A: <name>
+
+Status: run headless | run supervised | not run.
+
+- Description: <what this arm varied>
+- Scratch issue: #<n> (if issue-driving)
+- Branch: `<arm-branch>`
+- Draft PR: <url>
+- Window: `<start-ISO>` to `<end-ISO>`
+- Wall-clock: <duration>
+- Agent/subagent count: <n>
+- Token usage: <from the token-burn script's JSON output>
+- Diff size: <files changed, lines added/removed>
+- Independent review (tm-review-changes, base `<base-commit>`): <verdict and summary>
+- Acceptance-criteria drift: <none, or what drifted>
+
+## Arm B: <name>
+
+Status: run headless | run supervised | not run.
+
+- Description: <what this arm varied>
+- Scratch issue: #<n> (if issue-driving)
+- Branch: `<arm-branch>`
+- Draft PR: <url>
+- Window: `<start-ISO>` to `<end-ISO>`
+- Wall-clock: <duration>
+- Agent/subagent count: <n>
+- Token usage: <from the token-burn script's JSON output>
+- Diff size: <files changed, lines added/removed>
+- Independent review (tm-review-changes, base `<base-commit>`): <verdict and summary>
+- Acceptance-criteria drift: <none, or what drifted>
+
+## Headline numbers
+
+| | Arm A | Arm B |
+| --- | --- | --- |
+| Status | run headless / run supervised / not run | run headless / run supervised / not run |
+| Wall-clock | | |
+| Agents | | |
+| Tokens | | |
+| Diff size | | |
+| Independent review | | |
+
+## Reading this result
+
+One paired run is illustrative, not conclusive. Treat any directional
+difference between the arms as a hypothesis for a follow-up run, not a
+settled outcome, per the appendix in
+`docs/reviews/2026-06-30-orchestration-comparison.md`.
+
+## Cleanup
+
+- [ ] Scratch issues closed.
+- [ ] Draft PRs closed (after both diffs are linked above).
+- [ ] Branches and worktrees cleaned up.
+- [ ] Original task issue left untouched; a human picks a winner from this
+      writeup.

--- a/.claude/skills/tm-ab-test/templates/report.md
+++ b/.claude/skills/tm-ab-test/templates/report.md
@@ -8,6 +8,9 @@ Task: #<task-issue-number>, `<task title>`.
 
 Base commit: `<base-commit>` (both arms forked from here).
 
+Base drift: none | base-drifted (arm <name>, actual fork point
+`<actual-fork-point-commit>`, per the checklist's drift check).
+
 ## Arm A: <name>
 
 Status: run headless | run supervised | not run.

--- a/.claude/skills/tm-ab-test/templates/supervised-arm-runbook.md
+++ b/.claude/skills/tm-ab-test/templates/supervised-arm-runbook.md
@@ -8,8 +8,9 @@ appendix step 4 of `docs/reviews/2026-06-30-orchestration-comparison.md`.
 ## Before you start
 
 - [ ] Confirm the base commit recorded for this A/B run:
-      `<base-commit>` (`git rev-parse HEAD` at fork time). This arm must
-      fork from the same commit as every other arm.
+      `<base-commit>` (`git fetch origin`, then `git rev-parse origin/main`
+      at fork time). This arm must fork from the same commit as every
+      other arm.
 - [ ] Open a fresh session. Do not reuse the session that ran (or will run)
       any other arm; a shared session carries context across arms and
       contaminates the comparison.

--- a/.claude/skills/tm-ab-test/templates/supervised-arm-runbook.md
+++ b/.claude/skills/tm-ab-test/templates/supervised-arm-runbook.md
@@ -1,0 +1,37 @@
+# Supervised-arm runbook
+
+For any arm whose mode is `supervised` (a session-level setting the skill
+cannot turn on for itself, for example ultracode or a non-default effort
+level). The skill emits this runbook and stops; a human runs the arm, per
+appendix step 4 of `docs/reviews/2026-06-30-orchestration-comparison.md`.
+
+## Before you start
+
+- [ ] Confirm the base commit recorded for this A/B run:
+      `<base-commit>` (`git rev-parse HEAD` at fork time). This arm must
+      fork from the same commit as every other arm.
+- [ ] Open a fresh session. Do not reuse the session that ran (or will run)
+      any other arm; a shared session carries context across arms and
+      contaminates the comparison.
+- [ ] Work in this arm's own worktree, forked from the base commit above.
+      Do not reuse another arm's worktree.
+- [ ] Turn on the session-level setting this arm tests (for example
+      `ultracode`, or a specific `/effort` level) before doing any task
+      work. Confirm it is active before proceeding.
+
+## During the run
+
+- [ ] Record the start timestamp (ISO) the moment you begin task work.
+- [ ] Work the task to completion in this session, using the setting from
+      the previous step throughout. Do not switch it off mid-run.
+- [ ] Record the end timestamp (ISO) when the task is done (PR opened,
+      or the arm's stopping point reached).
+
+## After the run
+
+- [ ] Fill in `templates/recording-checklist.md` for this arm: base commit,
+      window, token usage, agent/subagent count, diff size, the
+      `tm-review-changes` pass, and any acceptance-criteria drift.
+- [ ] Report status as "run supervised" in `templates/report.md`.
+- [ ] Hand the filled checklist back to the lead session for the report and
+      ledger entry.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ below).
   ready PR per issue.
 - `.claude/skills/tm-grill-me/` - `/tm-grill-me`: stress-tests a plan one question
   at a time before kickoff (from mattpocock/skills, MIT).
+- `.claude/skills/tm-ab-test/` - `/tm-ab-test`: runs a paired A/B comparison of
+  two orchestration-variant arms on one task, forked from the same base
+  commit and run sequentially (headless or human-supervised). Records agent
+  count, wall-clock time, token usage, diff size, and an independent review
+  per arm, then writes a dated report and appends a row to
+  `docs/reviews/ab-tests.md`. Sequences existing machinery only; no new
+  agent, no new workflow script.
 - `.claude/skills/tm-new-project/` - `/tm-new-project`: runs the
   `NEW-PROJECT-SETUP.md` checklist as a guided flow. Creates the workflow
   labels and docs tree, then prints the human-only steps (branch protection,

--- a/docs/reviews/ab-tests.md
+++ b/docs/reviews/ab-tests.md
@@ -1,0 +1,8 @@
+# A/B test ledger
+
+Accumulation point for `/tm-ab-test` runs. Each report under
+`docs/reviews/YYYY-MM-DD-ab-<task-slug>.md` is immutable once written; this
+ledger appends one row per run and never edits a past one.
+
+| Date | Task | Arms | Headline numbers | Report |
+| --- | --- | --- | --- | --- |


### PR DESCRIPTION
Closes #248

Adds the `tm-ab-test` skill: a SKILL.md plus reference templates that
sequence existing bounded machinery (kickoff pipeline, tm-review-changes,
the token-burn analyzer) into a paired A/B run, per the methodology in
`docs/reviews/2026-06-30-orchestration-comparison.md`'s appendix. No new
agents, no new workflow script.

## Files
- `.claude/skills/tm-ab-test/SKILL.md`
- `.claude/skills/tm-ab-test/templates/report.md`
- `.claude/skills/tm-ab-test/templates/supervised-arm-runbook.md`
- `.claude/skills/tm-ab-test/templates/recording-checklist.md`
- `docs/reviews/ab-tests.md` (ledger, header only)
- `README.md` (skill-list entry)