### PR TITLE
docs: add pre-dispatch plan-status block convention

### DIFF
--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -155,8 +155,9 @@ user only if every package parks at once.
 Run the packages through the kickoff per-package pipeline
 (`.claude/skills/tm-kickoff/SKILL.md`): at most 3 concurrent, starting the next
 queued package as one finishes. Skip kickoff's wave-plan confirmation; the
-sign-off already covered it. The advisor differs from a plain `/tm-kickoff` run
-in three ways:
+sign-off already covered it. Kickoff's pre-dispatch plan-status block applies
+unchanged: print it before every agent dispatch, one block per package. The
+advisor differs from a plain `/tm-kickoff` run in three ways:
 
 - **In-scope decisions are yours.** When a question stays within the signed-off
   scope and acceptance criteria (a NEEDS_DECISION, an arbitration outcome,

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -70,6 +70,13 @@ The run does not stop to ask the user. In-scope questions are decided and
 logged; everything else parks-and-continues. Interrupt the user only if every
 package parks at once.
 
+Before every agent dispatch in this pipeline, including fix-round
+re-dispatches and arbitration or fact-checker dispatches, print the
+plan-status block described in team-guide.md. The items are fixed to the
+five pipeline stages below (sub-plan, develop, test, review, PR ready);
+annotate fix rounds on the current item. When dispatching agents for several
+packages in one message, print one block per package.
+
 Run up to 3 packages concurrently; dispatch their agents in parallel. When
 the queue is larger (up to 6 in an /tm-advisor batch), start the next queued
 package as one finishes. Worktree isolation keeps packages apart. Within a

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -126,6 +126,33 @@ Merging stays human and gates the next wave. Caps, routing,
 and report contracts live in `.claude/skills/tm-kickoff/SKILL.md` and the agent
 files; they are not repeated here.
 
+### Plan-status block before dispatch
+
+Before the lead spawns any subagent that works a plan or sub-plan, it prints
+a short status block: which steps are done, which step the new subagent is
+about to work on, which steps remain. This covers every tm-kickoff and
+tm-advisor pipeline stage, plus ad-hoc dispatches when a plan exists.
+
+```
+Plan status (issue #42):
+  [x] 1. sub-plan
+  [x] 2. develop
+  [>] 3. test   <- dispatching tester
+  [ ] 4. review
+  [ ] 5. PR ready
+```
+
+`[x]` marks a done step, `[>]` the current step (suffixed
+`<- dispatching <agent>`), `[ ]` a remaining step. A fix round annotates the
+current item, for example `[>] 3. test (fix round 2/3)`.
+
+An ad-hoc dispatch with no plan behind it prints one fixed line instead:
+`Dispatching <agent>: <purpose>`. Agents spawned inside workflow scripts are
+excluded; the workflow progress tree already covers them.
+
+When one message dispatches agents for several packages, print one block per
+package, consecutively, in the same shape. No combined-table variant.
+
 Labels: `in-progress` (package dispatched; resume, do not restart) and
 `needs-human` (parked: question, blocker, or exhausted fix loop), on top of
 the sizing set.


### PR DESCRIPTION
## Summary

- Adds the plan-status block convention: a short, fixed-shape status block the lead prints before every subagent dispatch that works a plan or sub-plan (done / current / remaining steps).
- Canonical format lives in `.claude/team-guide.md` (fenced example, markers, no-plan fallback line, workflow-script exclusion, one-block-per-package rule).
- `.claude/skills/tm-kickoff/SKILL.md` requires the block before every pipeline dispatch, with items fixed to the five pipeline stages.
- `.claude/skills/tm-advisor/SKILL.md` notes the block applies unchanged during the batch run.

Documentation-only change; no test additions per the issue's enforcement decision (prose convention, not machinery).

Closes #249

## Test plan

- [x] `npm test` passes (65/65, unaffected by these doc changes)
- [x] Manual style pass: no em dashes, no cliche words, example block matches issue format exactly