### PR TITLE
chore: address review nits from #248 and #249

### DIFF
--- a/.claude/skills/tm-ab-test/templates/recording-checklist.md
+++ b/.claude/skills/tm-ab-test/templates/recording-checklist.md
@@ -1,9 +1,15 @@
 # Recording checklist (per arm)
 
-Fill one copy of this checklist per arm. Every field has an exact command;
-nothing here is re-derived by hand. Covers the recording dimensions from
+Fill one copy of this checklist per arm. Every field has an exact command or
+derives from two fields that do; nothing here is re-derived by hand. Covers
+the recording dimensions from
 `docs/reviews/2026-06-30-orchestration-comparison.md`'s appendix, steps 2, 5,
 and 6.
+
+## Arm status
+
+- [ ] How this arm ran: headless or supervised. The lead copies this into
+      the report's per-arm status field.
 
 ## Fork point (appendix step 2)
 
@@ -15,18 +21,19 @@ and 6.
       result to the recorded base commit. If they differ, `main` has
       moved since the base was recorded: either stop and restart the
       pairing from the new base, or proceed and mark this run
-      base-drifted in `templates/report.md`.
+      base-drifted in the report written from `templates/report.md`.
 - [ ] Post-run audit: after the arm completes, run
-      `git merge-base origin/main <arm-branch>` to record its actual fork
-      point, and compare that to the recorded base commit. A mismatch
-      also marks this run base-drifted in `templates/report.md`, even if
-      the pre-dispatch gate above found no drift (a merge can land on
-      `main` while the arm is running, not just before it starts).
+      `git fetch origin && git merge-base origin/main <arm-branch>` to
+      record its actual fork point, and compare that to the recorded base
+      commit. A mismatch also marks this run base-drifted in the report
+      written from `templates/report.md`, even if the pre-dispatch gate
+      above found no drift (a merge can land on `main` while the arm is
+      running, not just before it starts).
 
 ## Arm window
 
-- [ ] Start: ISO timestamp when the arm begins.
-- [ ] End: ISO timestamp when the arm ends.
+- [ ] Start: `date -u +%Y-%m-%dT%H:%M:%SZ` when the arm begins.
+- [ ] End: `date -u +%Y-%m-%dT%H:%M:%SZ` when the arm ends.
 
 Arms run sequentially, so the windows never overlap.
 
@@ -72,5 +79,6 @@ Arms run sequentially, so the windows never overlap.
 
 - [ ] Arm end minus arm start, from the window above.
 
-Once every field above is filled for both arms, copy them into
-`templates/report.md` and append one row to `docs/reviews/ab-tests.md`.
+Once every field above is filled for both arms, copy them into the report
+written from `templates/report.md` and append one row to
+`docs/reviews/ab-tests.md`.

--- a/.claude/skills/tm-ab-test/templates/supervised-arm-runbook.md
+++ b/.claude/skills/tm-ab-test/templates/supervised-arm-runbook.md
@@ -30,9 +30,9 @@ appendix step 4 of `docs/reviews/2026-06-30-orchestration-comparison.md`.
 
 ## After the run
 
-- [ ] Fill in `templates/recording-checklist.md` for this arm: base commit,
-      window, token usage, agent/subagent count, diff size, the
-      `tm-review-changes` pass, and any acceptance-criteria drift.
-- [ ] Report status as "run supervised" in `templates/report.md`.
-- [ ] Hand the filled checklist back to the lead session for the report and
-      ledger entry.
+- [ ] Fill in `templates/recording-checklist.md` for this arm: arm status
+      ("supervised"), base commit, window, token usage, agent/subagent
+      count, diff size, the `tm-review-changes` pass, and any
+      acceptance-criteria drift.
+- [ ] Hand the filled checklist back to the lead session; the lead writes
+      the report and the ledger entry.

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -71,7 +71,7 @@ logged; everything else parks-and-continues. Interrupt the user only if every
 package parks at once.
 
 Before every agent dispatch in this pipeline, including fix-round
-re-dispatches and arbitration or fact-checker dispatches, print the
+re-dispatches and arbitration dispatches, print the
 plan-status block described in team-guide.md. The items are fixed to the
 five pipeline stages below (sub-plan, develop, test, review, PR ready);
 annotate fix rounds on the current item. When dispatching agents for several

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -144,7 +144,9 @@ Plan status (issue #42):
 
 `[x]` marks a done step, `[>]` the current step (suffixed
 `<- dispatching <agent>`), `[ ]` a remaining step. A fix round annotates the
-current item, for example `[>] 3. test (fix round 2/3)`.
+current item, for example `[>] 3. test (fix round 2/3)`. In the tm- flows
+the items are the pipeline stages (the skills pin them); an ad-hoc
+plan-backed dispatch uses the active plan's own steps as items.
 
 An ad-hoc dispatch with no plan behind it prints one fixed line instead:
 `Dispatching <agent>: <purpose>`. Agents spawned inside workflow scripts are


### PR DESCRIPTION
Closes #253

One tiny follow-up collecting the non-blocking findings from the #248/#249 reviews (PRs #251, #252). Nit numbering from the PR comments.

- #252 should-fix: kickoff's dispatch-block rule no longer names fact-checker; the per-package pipeline never dispatches one.
- #252 nit: team-guide now states the items rule explicitly: pipeline stages in the tm- flows, the active plan's own steps for ad-hoc plan-backed dispatches.
- #251 nit 4: Start/End pin `date -u +%Y-%m-%dT%H:%M:%SZ`; the checklist intro now says every field has an exact command or derives from two that do (wall-clock is end minus start).
- #251 nit 5: the runbook human marks arm status on the hand-back checklist (new Arm status field); the lead writes the report.
- #251 nit 7: base-drift marks (and the closing copy step) point at the written report, not `templates/report.md`.
- #251 nit 8: the post-run audit is self-contained: `git fetch origin && git merge-base origin/main <arm-branch>`.

Checks: npm test 65/65; style scan on the diff clean (no em dashes, no cliche words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)