### PR TITLE
feat: plan-status block parser and renderer

### DIFF
--- a/.claude/workflows/__tests__/plan-status.test.mjs
+++ b/.claude/workflows/__tests__/plan-status.test.mjs
@@ -1,0 +1,179 @@
+/**
+ * Tests for the plan-status block parser/renderer (issue #256).
+ *
+ * The block grammar is defined in .claude/team-guide.md under "Plan-status
+ * block before dispatch". These tests parse the two examples from that doc
+ * verbatim, round-trip a block through render/parse, and exercise each of
+ * the 7 validation rules with one failing case apiece.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { parsePlanStatus, renderPlanStatus } from '../lib/plan-status.mjs'
+
+// The fenced 5-step example from team-guide.md, verbatim (including the
+// alignment padding before "<- dispatching tester").
+const FENCED_BLOCK = [
+  'Plan status (issue #42):',
+  '  [x] 1. sub-plan',
+  '  [x] 2. develop',
+  '  [>] 3. test   <- dispatching tester',
+  '  [ ] 4. review',
+  '  [ ] 5. PR ready',
+].join('\n')
+
+// The canonical (single-space) form of the same block.
+const FENCED_BLOCK_CANONICAL = [
+  'Plan status (issue #42):',
+  '  [x] 1. sub-plan',
+  '  [x] 2. develop',
+  '  [>] 3. test <- dispatching tester',
+  '  [ ] 4. review',
+  '  [ ] 5. PR ready',
+].join('\n')
+
+// A minimal valid block whose current-step line is the verbatim fix-round
+// example from team-guide.md: "[>] 3. test (fix round 2/3)".
+const FIX_ROUND_BLOCK = [
+  'Plan status (issue #7):',
+  '  [x] 1. sub-plan',
+  '  [x] 2. develop',
+  '  [>] 3. test (fix round 2/3)',
+].join('\n')
+
+describe('parsePlanStatus: team-guide examples', () => {
+  test('parses the fenced 5-step block verbatim', () => {
+    const result = parsePlanStatus(FENCED_BLOCK)
+    assert.deepEqual(result, {
+      subject: 'issue #42',
+      steps: [
+        { number: 1, title: 'sub-plan', state: 'done', dispatching: null, fixRound: null },
+        { number: 2, title: 'develop', state: 'done', dispatching: null, fixRound: null },
+        { number: 3, title: 'test', state: 'current', dispatching: 'tester', fixRound: null },
+        { number: 4, title: 'review', state: 'todo', dispatching: null, fixRound: null },
+        { number: 5, title: 'PR ready', state: 'todo', dispatching: null, fixRound: null },
+      ],
+    })
+  })
+
+  test('parses the minimal fix-round block verbatim', () => {
+    const result = parsePlanStatus(FIX_ROUND_BLOCK)
+    assert.deepEqual(result, {
+      subject: 'issue #7',
+      steps: [
+        { number: 1, title: 'sub-plan', state: 'done', dispatching: null, fixRound: null },
+        { number: 2, title: 'develop', state: 'done', dispatching: null, fixRound: null },
+        {
+          number: 3,
+          title: 'test',
+          state: 'current',
+          dispatching: null,
+          fixRound: { round: 2, cap: 3 },
+        },
+      ],
+    })
+  })
+})
+
+describe('renderPlanStatus: canonical output', () => {
+  test('normalizes alignment padding to single spaces', () => {
+    const parsed = parsePlanStatus(FENCED_BLOCK)
+    assert.equal(renderPlanStatus(parsed), FENCED_BLOCK_CANONICAL)
+  })
+})
+
+describe('round trip', () => {
+  test('parsePlanStatus(renderPlanStatus(block)) deep-equals block', () => {
+    const block = {
+      subject: 'issue #99',
+      steps: [
+        { number: 1, title: 'sub-plan', state: 'done', dispatching: null, fixRound: null },
+        { number: 2, title: 'develop', state: 'done', dispatching: null, fixRound: null },
+        {
+          number: 3,
+          title: 'test',
+          state: 'current',
+          dispatching: 'tester',
+          fixRound: { round: 2, cap: 3 },
+        },
+        { number: 4, title: 'review', state: 'todo', dispatching: null, fixRound: null },
+      ],
+    }
+
+    const rendered = renderPlanStatus(block)
+    const parsed = parsePlanStatus(rendered)
+    assert.deepEqual(parsed, block)
+  })
+})
+
+describe('validation rules', () => {
+  test('rule 1: header must match "Plan status (<subject>):" with a non-empty subject', () => {
+    const text = ['Plan status issue #1', '  [x] 1. sub-plan'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /Plan status issue #1/)
+  })
+
+  test('rule 2: every step marker must be [x], [>], or [ ]', () => {
+    const text = ['Plan status (issue #1):', '  [y] 1. sub-plan'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /\[y\] 1\. sub-plan/)
+  })
+
+  test('rule 3: step numbers run 1..N in order, no gaps, no duplicates', () => {
+    const text = ['Plan status (issue #1):', '  [x] 1. sub-plan', '  [x] 3. develop'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /\[x\] 3\. develop/)
+  })
+
+  test('rule 4: at most one [>] step per block', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [x] 1. sub-plan',
+      '  [>] 2. develop',
+      '  [>] 3. test',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /\[>\] 3\. test/)
+  })
+
+  test('rule 5: state order is monotonic (done, then current, then todo)', () => {
+    const text = ['Plan status (issue #1):', '  [ ] 1. sub-plan', '  [x] 2. develop'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /\[x\] 2\. develop/)
+  })
+
+  test('rule 6: a dispatching suffix is only valid on the current step', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [x] 1. sub-plan <- dispatching tester',
+      '  [ ] 2. develop',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /\[x\] 1\. sub-plan <- dispatching tester/)
+  })
+
+  test('rule 7: a fix round annotation is only valid on the current step', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [x] 1. sub-plan (fix round 2/3)',
+      '  [ ] 2. develop',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /\[x\] 1\. sub-plan \(fix round 2\/3\)/)
+  })
+})
+
+describe('error messages', () => {
+  test('the error message names the offending line', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [x] 1. sub-plan <- dispatching tester',
+      '  [ ] 2. develop',
+    ].join('\n')
+
+    assert.throws(
+      () => parsePlanStatus(text),
+      (err) => {
+        assert.ok(err instanceof Error)
+        assert.ok(
+          err.message.includes('[x] 1. sub-plan <- dispatching tester'),
+          `expected message to include the offending line, got: ${err.message}`
+        )
+        return true
+      }
+    )
+  })
+})

--- a/.claude/workflows/lib/plan-status.mjs
+++ b/.claude/workflows/lib/plan-status.mjs
@@ -1,0 +1,171 @@
+/**
+ * Parser and renderer for the plan-status block convention defined in
+ * .claude/team-guide.md ("Plan-status block before dispatch").
+ *
+ * A block looks like:
+ *
+ *   Plan status (issue #42):
+ *     [x] 1. sub-plan
+ *     [x] 2. develop
+ *     [>] 3. test   <- dispatching tester
+ *     [ ] 4. review
+ *     [ ] 5. PR ready
+ *
+ * parsePlanStatus() and renderPlanStatus() are exact inverses on the block
+ * structure: parsing tolerates run-of-whitespace between fields (matching
+ * hand-typed alignment padding), rendering always emits single spaces. Both
+ * directions run the same 7 validation rules through the shared validate()
+ * below, so a value that renders is guaranteed to parse back to itself.
+ */
+
+const HEADER_RE = /^Plan status \((.+)\):$/
+const STEP_LINE_RE = /^\s+\[([x> ])\]\s+(\d+)\.\s+(.*)$/
+const DISPATCHING_RE = /^(.*?)\s+<-\s*dispatching\s+(\S+)\s*$/
+const FIX_ROUND_RE = /^(.*?)\s+\(fix round (\d+)\/(\d+)\)\s*$/
+
+const STATE_BY_MARKER = { x: 'done', '>': 'current', ' ': 'todo' }
+const MARKER_BY_STATE = { done: 'x', current: '>', todo: ' ' }
+
+/**
+ * Parse a plan-status block into { subject, steps }.
+ * Throws Error naming the offending line for any malformed or
+ * rule-violating input.
+ */
+export function parsePlanStatus(text) {
+  if (typeof text !== 'string') throw new Error('plan-status input must be a string')
+
+  const rawLines = text.split('\n')
+  const lines = rawLines[rawLines.length - 1] === '' ? rawLines.slice(0, -1) : rawLines
+  if (lines.length === 0) throw new Error('plan-status block is empty')
+
+  const headerLine = lines[0]
+  const headerMatch = headerLine.match(HEADER_RE)
+  if (!headerMatch || !headerMatch[1].trim()) {
+    throw new Error(`invalid plan-status header: "${headerLine}"`)
+  }
+  const subject = headerMatch[1].trim()
+
+  const steps = lines.slice(1).map(parseStepLine)
+
+  return validate({ subject, steps })
+}
+
+/**
+ * Render a { subject, steps } block back into canonical plan-status text.
+ * Runs the same validate() as parsePlanStatus, so an invalid block throws
+ * before anything is emitted.
+ */
+export function renderPlanStatus(block) {
+  validate(block)
+
+  const lines = [`Plan status (${block.subject}):`, ...block.steps.map(renderStepLine)]
+  return lines.join('\n')
+}
+
+function parseStepLine(line) {
+  const match = line.match(STEP_LINE_RE)
+  if (!match) throw new Error(`invalid step line: "${line}"`)
+
+  const [, marker, numberText, remainder] = match
+  const state = STATE_BY_MARKER[marker]
+  const number = parseInt(numberText, 10)
+
+  let rest = remainder
+  let dispatching = null
+  const dispatchMatch = rest.match(DISPATCHING_RE)
+  if (dispatchMatch) {
+    rest = dispatchMatch[1]
+    dispatching = dispatchMatch[2]
+  }
+
+  let fixRound = null
+  const fixRoundMatch = rest.match(FIX_ROUND_RE)
+  if (fixRoundMatch) {
+    rest = fixRoundMatch[1]
+    fixRound = { round: parseInt(fixRoundMatch[2], 10), cap: parseInt(fixRoundMatch[3], 10) }
+  }
+
+  const title = rest.trim()
+  if (!title) throw new Error(`step line missing title: "${line}"`)
+
+  return { number, title, state, dispatching, fixRound }
+}
+
+function renderStepLine(step) {
+  const marker = MARKER_BY_STATE[step.state]
+  let line = `  [${marker}] ${step.number}. ${step.title}`
+  if (step.fixRound) line += ` (fix round ${step.fixRound.round}/${step.fixRound.cap})`
+  if (step.dispatching) line += ` <- dispatching ${step.dispatching}`
+  return line
+}
+
+/**
+ * Enforce the 7 validation rules from team-guide.md against a structured
+ * block. Shared by both parsePlanStatus (after building the structure) and
+ * renderPlanStatus (before emitting), so both directions agree on what a
+ * valid block is. Error messages reconstruct the offending line canonically
+ * from the step's fields, which is exact for well-formed input and only
+ * normalizes whitespace for padded input.
+ */
+function validate(block) {
+  const subject = block && block.subject
+  if (!subject || !String(subject).trim()) {
+    throw new Error(`invalid plan-status header: "Plan status (${subject ?? ''}):"`)
+  }
+
+  const steps = block.steps
+  if (!Array.isArray(steps)) throw new Error('plan-status block has no steps')
+
+  let currentCount = 0
+  let seenCurrent = false
+  let seenTodo = false
+
+  steps.forEach((step, index) => {
+    const line = renderStepLine(step)
+
+    if (!MARKER_BY_STATE[step.state]) {
+      throw new Error(`invalid step marker: "${line}"`)
+    }
+
+    const expectedNumber = index + 1
+    if (step.number !== expectedNumber) {
+      throw new Error(`step numbers must run 1..N in order, no gaps, no duplicates: "${line}"`)
+    }
+
+    if (step.state === 'current') {
+      currentCount++
+      if (currentCount > 1) {
+        throw new Error(`at most one current step ([>]) is allowed per block: "${line}"`)
+      }
+    }
+
+    if (step.state === 'done') {
+      if (seenCurrent || seenTodo) {
+        throw new Error(`step order must be done, then current, then todo: "${line}"`)
+      }
+    } else if (step.state === 'current') {
+      if (seenTodo) {
+        throw new Error(`step order must be done, then current, then todo: "${line}"`)
+      }
+      seenCurrent = true
+    } else if (step.state === 'todo') {
+      seenTodo = true
+    }
+
+    if (step.dispatching && step.state !== 'current') {
+      throw new Error(`a dispatching suffix is only valid on the current step: "${line}"`)
+    }
+
+    if (step.fixRound) {
+      if (step.state !== 'current') {
+        throw new Error(`a fix round annotation is only valid on the current step: "${line}"`)
+      }
+      const { round, cap } = step.fixRound
+      if (!Number.isInteger(round) || !Number.isInteger(cap) || round < 1 || cap < 1 || round > cap) {
+        throw new Error(`fix round annotation must have positive N <= M: "${line}"`)
+      }
+    }
+  })
+
+  return block
+}


### PR DESCRIPTION
## Summary

- Adds `parsePlanStatus`/`renderPlanStatus` as named exports of a real ES
  module (`.claude/workflows/lib/plan-status.mjs`), parsing and rendering
  the plan-status dispatch block defined in `.claude/team-guide.md`.
- One shared `validate(block)` enforces all 7 rules from the issue, called
  by both `parsePlanStatus` (after building the structure) and
  `renderPlanStatus` (before emitting), so the round-trip property
  (`parsePlanStatus(renderPlanStatus(b))` deep-equals `b`) holds by
  construction.
- Parsing tolerates run-of-whitespace alignment padding (matching the
  team-guide example's `<- dispatching tester` padding); rendering always
  normalizes to single spaces.

## Test plan

- [x] `npm test` green (77 tests, including the new
      `plan-status.test.mjs`).
- [x] Tests cover both team-guide.md block examples parsed verbatim, a
      round-trip case exercising all three states plus both annotations
      together, one failing case per validation rule (1-7), and an
      error-message assertion.
- [x] `git status` before commit showed exactly the two new files.

Closes #256