### PR TITLE
feat: plan-status block parser and renderer

### DIFF
--- a/.claude/workflows/__tests__/plan-status.test.mjs
+++ b/.claude/workflows/__tests__/plan-status.test.mjs
@@ -1,0 +1,22 @@
+/**
+ * Tests for the plan-status block parser/renderer (issue #257).
+ *
+ * The block format is defined in .claude/team-guide.md, "Plan-status block
+ * before dispatch". These tests parse the two examples from that section
+ * verbatim, check the round trip, and cover one failing case per
+ * validation rule listed in the issue.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { parsePlanStatus, renderPlanStatus } from '../lib/plan-status.mjs'
+
+// ===========================================================================
+// 1. Header parsing
+// ===========================================================================
+describe('parsePlanStatus: header', () => {
+  test('parses the subject out of the header line', () => {
+    const block = parsePlanStatus('Plan status (issue #42):\n  [x] 1. sub-plan')
+    assert.equal(block.subject, 'issue #42')
+  })
+})

--- a/.claude/workflows/__tests__/plan-status.test.mjs
+++ b/.claude/workflows/__tests__/plan-status.test.mjs
@@ -11,6 +11,29 @@ import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
 import { parsePlanStatus, renderPlanStatus } from '../lib/plan-status.mjs'
 
+// The dispatching example from team-guide.md, "Plan-status block before
+// dispatch", parsed verbatim.
+const DISPATCH_EXAMPLE = [
+  'Plan status (issue #42):',
+  '  [x] 1. sub-plan',
+  '  [x] 2. develop',
+  '  [>] 3. test   <- dispatching tester',
+  '  [ ] 4. review',
+  '  [ ] 5. PR ready',
+].join('\n')
+
+// The fix-round example from the same section:
+// "A fix round annotates the current item, for example
+// `[>] 3. test (fix round 2/3)`."
+const FIX_ROUND_EXAMPLE = [
+  'Plan status (issue #42):',
+  '  [x] 1. sub-plan',
+  '  [x] 2. develop',
+  '  [>] 3. test (fix round 2/3)',
+  '  [ ] 4. review',
+  '  [ ] 5. PR ready',
+].join('\n')
+
 // ===========================================================================
 // 1. Header parsing
 // ===========================================================================
@@ -18,5 +41,271 @@ describe('parsePlanStatus: header', () => {
   test('parses the subject out of the header line', () => {
     const block = parsePlanStatus('Plan status (issue #42):\n  [x] 1. sub-plan')
     assert.equal(block.subject, 'issue #42')
+  })
+})
+
+// ===========================================================================
+// 2. The two team-guide.md examples, parsed verbatim
+// ===========================================================================
+describe('parsePlanStatus: team-guide.md examples', () => {
+  test('parses the dispatching example', () => {
+    const block = parsePlanStatus(DISPATCH_EXAMPLE)
+    assert.equal(block.subject, 'issue #42')
+    assert.deepEqual(block.steps, [
+      { number: 1, title: 'sub-plan', state: 'done', dispatching: null, fixRound: null },
+      { number: 2, title: 'develop', state: 'done', dispatching: null, fixRound: null },
+      { number: 3, title: 'test', state: 'current', dispatching: 'tester', fixRound: null },
+      { number: 4, title: 'review', state: 'todo', dispatching: null, fixRound: null },
+      { number: 5, title: 'PR ready', state: 'todo', dispatching: null, fixRound: null },
+    ])
+  })
+
+  test('parses the fix-round example', () => {
+    const block = parsePlanStatus(FIX_ROUND_EXAMPLE)
+    assert.equal(block.subject, 'issue #42')
+    assert.deepEqual(block.steps[2], {
+      number: 3,
+      title: 'test',
+      state: 'current',
+      dispatching: null,
+      fixRound: { round: 2, cap: 3 },
+    })
+  })
+})
+
+// ===========================================================================
+// 3. renderPlanStatus renders the canonical text
+// ===========================================================================
+describe('renderPlanStatus', () => {
+  test('renders the dispatching example with single spaces (source has 3 before "<-")', () => {
+    const block = parsePlanStatus(DISPATCH_EXAMPLE)
+    const canonical = DISPATCH_EXAMPLE.replace('test   <- dispatching', 'test <- dispatching')
+    assert.equal(renderPlanStatus(block), canonical)
+  })
+
+  test('renders the fix-round example back to its canonical text', () => {
+    const block = parsePlanStatus(FIX_ROUND_EXAMPLE)
+    assert.equal(renderPlanStatus(block), FIX_ROUND_EXAMPLE)
+  })
+
+  test('collapses multiple spaces between fields to single spaces', () => {
+    // The dispatching example uses 3 spaces before "<-"; the canonical
+    // render uses exactly 1.
+    const block = parsePlanStatus(DISPATCH_EXAMPLE)
+    const rendered = renderPlanStatus(block)
+    assert.ok(rendered.includes('[>] 3. test <- dispatching tester'))
+  })
+})
+
+// ===========================================================================
+// 4. Round trip: parsePlanStatus(renderPlanStatus(b)) deep-equals b
+// ===========================================================================
+describe('round trip', () => {
+  test('parse(render(b)) deep-equals b for a block with a plain current step', () => {
+    const block = {
+      subject: 'issue #7',
+      steps: [
+        { number: 1, title: 'plan', state: 'done', dispatching: null, fixRound: null },
+        { number: 2, title: 'build', state: 'current', dispatching: 'developer', fixRound: null },
+        { number: 3, title: 'ship', state: 'todo', dispatching: null, fixRound: null },
+      ],
+    }
+    assert.deepEqual(parsePlanStatus(renderPlanStatus(block)), block)
+  })
+
+  test('parse(render(b)) deep-equals b for a block with a fix-round current step', () => {
+    const block = {
+      subject: 'issue #7',
+      steps: [
+        { number: 1, title: 'plan', state: 'done', dispatching: null, fixRound: null },
+        { number: 2, title: 'build', state: 'current', dispatching: null, fixRound: { round: 1, cap: 2 } },
+        { number: 3, title: 'ship', state: 'todo', dispatching: null, fixRound: null },
+      ],
+    }
+    assert.deepEqual(parsePlanStatus(renderPlanStatus(block)), block)
+  })
+
+  test('parse(render(b)) deep-equals b for a block with no current step', () => {
+    const block = {
+      subject: 'issue #7',
+      steps: [
+        { number: 1, title: 'plan', state: 'done', dispatching: null, fixRound: null },
+        { number: 2, title: 'build', state: 'todo', dispatching: null, fixRound: null },
+      ],
+    }
+    assert.deepEqual(parsePlanStatus(renderPlanStatus(block)), block)
+  })
+})
+
+// ===========================================================================
+// 5. Validation rule 1: header must match "Plan status (<subject>):" with a
+// non-empty subject
+// ===========================================================================
+describe('validation rule 1: header', () => {
+  test('rejects a missing header', () => {
+    assert.throws(() => parsePlanStatus('  [x] 1. sub-plan'), /header/)
+  })
+
+  test('rejects an empty subject', () => {
+    assert.throws(() => parsePlanStatus('Plan status ():\n  [x] 1. sub-plan'), /header/)
+  })
+
+  test('rejects a header missing the trailing colon', () => {
+    assert.throws(() => parsePlanStatus('Plan status (issue #42)\n  [x] 1. sub-plan'), /header/)
+  })
+})
+
+// ===========================================================================
+// 6. Validation rule 2: every step marker must be [x], [>], or [ ]
+// ===========================================================================
+describe('validation rule 2: step marker', () => {
+  test('rejects an invalid marker', () => {
+    assert.throws(
+      () => parsePlanStatus('Plan status (issue #1):\n  [y] 1. sub-plan'),
+      /invalid step marker/
+    )
+  })
+})
+
+// ===========================================================================
+// 7. Validation rule 3: step numbers run 1..N in order, no gaps, no dupes
+// ===========================================================================
+describe('validation rule 3: sequential numbering', () => {
+  test('rejects a gap in step numbers', () => {
+    const text = ['Plan status (issue #1):', '  [x] 1. sub-plan', '  [ ] 3. review'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /1\.\.N/)
+  })
+
+  test('rejects a duplicate step number', () => {
+    const text = ['Plan status (issue #1):', '  [x] 1. sub-plan', '  [ ] 1. review'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /1\.\.N/)
+  })
+
+  test('renderPlanStatus rejects a gap in step numbers', () => {
+    const block = {
+      subject: 'issue #1',
+      steps: [
+        { number: 1, title: 'sub-plan', state: 'done', dispatching: null, fixRound: null },
+        { number: 3, title: 'review', state: 'todo', dispatching: null, fixRound: null },
+      ],
+    }
+    assert.throws(() => renderPlanStatus(block), /1\.\.N/)
+  })
+})
+
+// ===========================================================================
+// 8. Validation rule 4: at most one [>] step per block
+// ===========================================================================
+describe('validation rule 4: at most one current step', () => {
+  test('rejects two [>] steps', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [>] 1. sub-plan',
+      '  [>] 2. develop',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /at most one/)
+  })
+})
+
+// ===========================================================================
+// 9. Validation rule 5: state order is monotonic (done*, current?, todo*)
+// ===========================================================================
+describe('validation rule 5: monotonic state order', () => {
+  test('rejects a [x] step after a [ ] step', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [ ] 1. sub-plan',
+      '  [x] 2. develop',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /state order/)
+  })
+
+  test('rejects a [>] step after a [ ] step', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [ ] 1. sub-plan',
+      '  [>] 2. develop',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /state order/)
+  })
+})
+
+// ===========================================================================
+// 10. Validation rule 6: "<- dispatching <agent>" is only valid on [>]
+// ===========================================================================
+describe('validation rule 6: dispatching suffix only on current step', () => {
+  test('rejects a dispatching suffix on a [ ] step', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [x] 1. sub-plan',
+      '  [ ] 2. develop <- dispatching developer',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /dispatching/)
+  })
+
+  test('rejects a dispatching suffix on a [x] step', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [x] 1. sub-plan <- dispatching developer',
+      '  [ ] 2. develop',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /dispatching/)
+  })
+
+  test('renderPlanStatus rejects a dispatching value on a non-current step', () => {
+    const block = {
+      subject: 'issue #1',
+      steps: [
+        { number: 1, title: 'sub-plan', state: 'done', dispatching: 'developer', fixRound: null },
+      ],
+    }
+    assert.throws(() => renderPlanStatus(block), /dispatching/)
+  })
+})
+
+// ===========================================================================
+// 11. Validation rule 7: "(fix round N/M)" is only valid on [>], N and M
+// are positive integers, N <= M
+// ===========================================================================
+describe('validation rule 7: fix round annotation', () => {
+  test('rejects a fix-round annotation on a [ ] step', () => {
+    const text = [
+      'Plan status (issue #1):',
+      '  [x] 1. sub-plan',
+      '  [ ] 2. develop (fix round 1/2)',
+    ].join('\n')
+    assert.throws(() => parsePlanStatus(text), /fix round/)
+  })
+
+  test('rejects round 0', () => {
+    const text = ['Plan status (issue #1):', '  [>] 1. sub-plan (fix round 0/2)'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /fix round/)
+  })
+
+  test('rejects round greater than cap', () => {
+    const text = ['Plan status (issue #1):', '  [>] 1. sub-plan (fix round 3/2)'].join('\n')
+    assert.throws(() => parsePlanStatus(text), /fix round/)
+  })
+
+  test('renderPlanStatus rejects a fix round with round > cap', () => {
+    const block = {
+      subject: 'issue #1',
+      steps: [
+        { number: 1, title: 'sub-plan', state: 'current', dispatching: null, fixRound: { round: 3, cap: 2 } },
+      ],
+    }
+    assert.throws(() => renderPlanStatus(block), /fix round/)
+  })
+})
+
+// ===========================================================================
+// 12. Error messages name the offending line for invalid input
+// ===========================================================================
+describe('error messages name the offending line', () => {
+  test('invalid marker error includes the offending line text', () => {
+    assert.throws(
+      () => parsePlanStatus('Plan status (issue #1):\n  [y] 1. sub-plan'),
+      /\[y\] 1\. sub-plan/
+    )
   })
 })

--- a/.claude/workflows/lib/plan-status.mjs
+++ b/.claude/workflows/lib/plan-status.mjs
@@ -1,0 +1,206 @@
+/**
+ * Parser and renderer for the plan-status block defined in
+ * .claude/team-guide.md ("Plan-status block before dispatch").
+ *
+ * Example:
+ *
+ *   Plan status (issue #42):
+ *     [x] 1. sub-plan
+ *     [x] 2. develop
+ *     [>] 3. test   <- dispatching tester
+ *     [ ] 4. review
+ *     [ ] 5. PR ready
+ *
+ * A fix round annotates the current step instead of a dispatching suffix,
+ * for example `[>] 3. test (fix round 2/3)`.
+ */
+
+const HEADER_RE = /^Plan status \((.+)\):$/
+const STEP_LINE_RE = /^\s*\[(.)\]\s+(\d+)\.\s+(.*)$/
+const DISPATCH_RE = /^(.*?)\s*<-\s*dispatching\s+(\S+)\s*$/
+const FIX_ROUND_RE = /^(.*?)\s*\(fix round\s+(\d+)\s*\/\s*(\d+)\)\s*$/
+
+const MARKER_TO_STATE = { x: 'done', '>': 'current', ' ': 'todo' }
+const STATE_TO_MARKER = { done: 'x', current: '>', todo: ' ' }
+
+// ===========================================================================
+// parsePlanStatus
+// ===========================================================================
+
+export function parsePlanStatus(text) {
+  if (typeof text !== 'string') {
+    throw new Error('parsePlanStatus: text must be a string')
+  }
+
+  const lines = text.split('\n')
+  while (lines.length && lines[0].trim() === '') lines.shift()
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop()
+
+  if (lines.length === 0) {
+    throw new Error('parsePlanStatus: empty plan-status block')
+  }
+
+  const headerLine = lines[0].trim()
+  const headerMatch = headerLine.match(HEADER_RE)
+  if (!headerMatch || !headerMatch[1].trim()) {
+    throw new Error(`parsePlanStatus: invalid header line: "${lines[0]}"`)
+  }
+  const subject = headerMatch[1].trim()
+
+  const stepLines = lines.slice(1)
+  if (stepLines.length === 0) {
+    throw new Error('parsePlanStatus: plan-status block has no step lines')
+  }
+
+  const steps = stepLines.map((line) => parseStepLine(line))
+
+  validateStepSequence(steps, (step) => describeParsedStep(step, stepLines))
+
+  return { subject, steps }
+}
+
+function parseStepLine(line) {
+  const match = line.match(STEP_LINE_RE)
+  if (!match) {
+    throw new Error(`parsePlanStatus: invalid step line: "${line}"`)
+  }
+  const [, markerChar, numberStr, rest] = match
+
+  const state = MARKER_TO_STATE[markerChar]
+  if (!state) {
+    throw new Error(`parsePlanStatus: invalid step marker (must be [x], [>], or [ ]): "${line}"`)
+  }
+
+  const number = Number(numberStr)
+
+  let remainder = rest
+  let dispatching = null
+  const dispatchMatch = remainder.match(DISPATCH_RE)
+  if (dispatchMatch) {
+    remainder = dispatchMatch[1]
+    dispatching = dispatchMatch[2]
+  }
+
+  let fixRound = null
+  const fixRoundMatch = remainder.match(FIX_ROUND_RE)
+  if (fixRoundMatch) {
+    remainder = fixRoundMatch[1]
+    fixRound = { round: Number(fixRoundMatch[2]), cap: Number(fixRoundMatch[3]) }
+  }
+
+  const title = remainder.trim()
+  if (!title) {
+    throw new Error(`parsePlanStatus: step line is missing a title: "${line}"`)
+  }
+
+  const step = { number, title, state, dispatching, fixRound }
+  validateStepFields(step, () => `invalid step line: "${line}"`)
+  return step
+}
+
+function describeParsedStep(step, stepLines) {
+  return `invalid step line: "${stepLines[step.number - 1] ?? step.title}"`
+}
+
+// ===========================================================================
+// renderPlanStatus
+// ===========================================================================
+
+export function renderPlanStatus(block) {
+  if (!block || typeof block !== 'object') {
+    throw new Error('renderPlanStatus: block must be an object')
+  }
+  const { subject, steps } = block
+
+  if (typeof subject !== 'string' || !subject.trim()) {
+    throw new Error('renderPlanStatus: subject must be a non-empty string')
+  }
+  if (!Array.isArray(steps) || steps.length === 0) {
+    throw new Error('renderPlanStatus: steps must be a non-empty array')
+  }
+
+  steps.forEach((step) => validateStepFields(step, () => describeRenderedStep(step)))
+  validateStepSequence(steps, (step) => describeRenderedStep(step))
+
+  const lines = [`Plan status (${subject}):`]
+  for (const step of steps) {
+    let line = `  [${STATE_TO_MARKER[step.state]}] ${step.number}. ${step.title}`
+    if (step.fixRound) {
+      line += ` (fix round ${step.fixRound.round}/${step.fixRound.cap})`
+    }
+    if (step.dispatching) {
+      line += ` <- dispatching ${step.dispatching}`
+    }
+    lines.push(line)
+  }
+  return lines.join('\n')
+}
+
+function describeRenderedStep(step) {
+  return `invalid step ${step?.number ?? '?'} ("${step?.title ?? ''}")`
+}
+
+// ===========================================================================
+// Shared validators
+// ===========================================================================
+
+// Per-step field checks: state set, dispatching/fixRound only on the
+// current step, fix round bounds (rules 2, 6, 7).
+function validateStepFields(step, describe) {
+  if (!Number.isInteger(step.number) || step.number < 1) {
+    throw new Error(`${describe(step)}: step number must be a positive integer`)
+  }
+  if (typeof step.title !== 'string' || !step.title.trim()) {
+    throw new Error(`${describe(step)}: step title must be a non-empty string`)
+  }
+  if (!(step.state in STATE_TO_MARKER)) {
+    throw new Error(`${describe(step)}: invalid state "${step.state}" (must be done, current, or todo)`)
+  }
+  if (step.dispatching != null && step.state !== 'current') {
+    throw new Error(`${describe(step)}: "<- dispatching" is only valid on the [>] (current) step`)
+  }
+  if (step.fixRound != null) {
+    if (step.state !== 'current') {
+      throw new Error(`${describe(step)}: "(fix round N/M)" is only valid on the [>] (current) step`)
+    }
+    const { round, cap } = step.fixRound
+    if (!Number.isInteger(round) || !Number.isInteger(cap) || round < 1 || cap < 1 || round > cap) {
+      throw new Error(`${describe(step)}: fix round must be positive integers with round <= cap`)
+    }
+  }
+}
+
+// Cross-step checks: sequential numbering, at most one current step,
+// monotonic done -> current -> todo order (rules 3, 4, 5).
+function validateStepSequence(steps, describe) {
+  steps.forEach((step, i) => {
+    if (step.number !== i + 1) {
+      throw new Error(
+        `${describe(step)}: step numbers must run 1..N in order with no gaps or duplicates ` +
+          `(found ${step.number}, expected ${i + 1})`
+      )
+    }
+  })
+
+  const currentCount = steps.filter((s) => s.state === 'current').length
+  if (currentCount > 1) {
+    throw new Error(`at most one [>] (current) step is allowed per block, found ${currentCount}`)
+  }
+
+  let seenCurrent = false
+  let seenTodo = false
+  for (const step of steps) {
+    if (step.state === 'done') {
+      if (seenCurrent || seenTodo) {
+        throw new Error(`${describe(step)}: state order must be done, then current, then todo`)
+      }
+    } else if (step.state === 'current') {
+      if (seenTodo) {
+        throw new Error(`${describe(step)}: state order must be done, then current, then todo`)
+      }
+      seenCurrent = true
+    } else {
+      seenTodo = true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a zero-dependency ESM module, `.claude/workflows/lib/plan-status.mjs`, that parses and renders the plan-status block defined in `.claude/team-guide.md` ("Plan-status block before dispatch"), so future tooling can lint dispatch logs.
- `parsePlanStatus(text)` / `renderPlanStatus(block)` round-trip, and both validate against the 7 rules from the issue (marker set, sequential numbering, single current step, monotonic state order, dispatching/fix-round restricted to the current step, fix round bounds).

Closes #257

## Test plan
- [ ] `npm test` green, including `.claude/workflows/__tests__/plan-status.test.mjs`
- [ ] Both team-guide.md examples parsed verbatim
- [ ] Round-trip case: `parsePlanStatus(renderPlanStatus(b))` deep-equals `b`
- [ ] One failing case per validation rule (1-7)