### PR TITLE
docs: refresh stale model references and assess Opus 5 for the judgment seats

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,8 @@
 name: architect
 description: Advisory lead for approach decisions. Use when an issue needs a sub-plan before implementation, when an issue looks mis-sized or needs splitting (size:L or size:XL), or when developer and reviewer disagree. Read-only; decides approach, never writes code.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Fable 5. Fallback is opus (see team-guide, Model policy).
+# Judgment role: Fable 5. Fallback is opus = Opus 5, same xhigh effort
+# (see team-guide, Model policy).
 model: fable
 effort: xhigh
 ---

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,8 @@
 name: reviewer
 description: Reviews a work package diff against its issue and sub-plan, in two passes, spec compliance then code quality. Read-only; outputs APPROVE or CHANGES_REQUESTED with numbered file:line findings. Never edits files.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Fable 5. Fallback is opus (see team-guide, Model policy).
+# Judgment role: Fable 5. Fallback is opus = Opus 5, same xhigh effort
+# (see team-guide, Model policy).
 model: fable
 effort: xhigh
 ---

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -189,12 +189,12 @@ Rationale: docs/team-guide-rationale.md.
 
 - Orchestrator (the lead session, including `/tm-advisor` and `/tm-kickoff`):
   Fable 5 (`claude-fable-5`) at xhigh effort. Affordable only because the
-  lead stays on the bounded tm- machinery. Fable costs 2x Opus 4.8 per
+  lead stays on the bounded tm- machinery. Fable costs 2x Opus 5 per
   token. The premium is bounded in aggregate, not per batch
   (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
-- Fallback: Opus 4.8 at xhigh effort (a procedure, not automatic). When
+- Fallback: Opus 5 at xhigh effort (a procedure, not automatic). When
   Fable 5 is unavailable, rate-limited, quota-exhausted, or
-  refuses the workload, switch the lead with `/model claude-opus-4-8`; for a
+  refuses the workload, switch the lead with `/model claude-opus-5`; for a
   longer outage flip the `fable` pins to `opus` in the `architect` and
   `reviewer` frontmatters and the Fable-critic stage of every `tm-` workflow
   (`.claude/workflows/`). Flip back when Fable returns. For a single
@@ -206,7 +206,7 @@ Rationale: docs/team-guide-rationale.md.
 - Cost-based fallback trigger: if Fable 5 stops being included under the
   Max-plan subscription and shifts to metered API billing, do not switch to
   Opus automatically. Measure the lead's actual $/session cost at API rates
-  first, then decide whether to keep Fable or move to Opus 4.8 permanently,
+  first, then decide whether to keep Fable or move to Opus 5 permanently,
   logging the decision and cost here.
 - No session-wide `ultracode` under this policy (a prompt keyword or
   `/effort` menu option, not a slash command). Measured trial:
@@ -230,7 +230,7 @@ Rationale: docs/team-guide-rationale.md.
   never pays Fable rates for worker stages.
 - Do not set `CLAUDE_CODE_SUBAGENT_MODEL`. It flattens every subagent to one
   model, defeating the split above. Use only as a temporary seatbelt (e.g.
-  `claude-sonnet-4-6` before one heavy ad-hoc run); it downgrades the
+  `claude-sonnet-5` before one heavy ad-hoc run); it downgrades the
   architect and reviewer too.
 
 ## How to pick up a task

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -6,6 +6,11 @@
  * The test reads the real agent frontmatters and workflow sources, so a new
  * agent or workflow stage that omits its pin (and would silently inherit the
  * session effort) fails here instead of shipping.
+ *
+ * `opus` carries fable's xhigh so the documented Fable-outage fallback is
+ * usable: flipping a judgment seat's pin from fable to opus keeps its effort
+ * unchanged and still passes. Without that entry the fallback the Model policy
+ * prescribes fails this suite the moment anyone follows it.
  */
 
 import { test, describe } from 'node:test'
@@ -18,7 +23,7 @@ const __dir = dirname(fileURLToPath(import.meta.url))
 const workflowsDir = join(__dir, '..')
 const agentsDir = join(__dir, '..', '..', 'agents')
 
-const EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh' }
+const EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh', opus: 'xhigh' }
 const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
 
 // ===========================================================================

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -16,7 +16,7 @@ export const meta = {
 // areas the scout proposes. There is no per-file fan-out and no loop. Models and
 // effort are pinned per stage, so the session model and effort never leak into
 // the scout or the workers; the single critic runs Fable 5 at xhigh effort (flip
-// its model pin to 'opus' under the Opus 4.8 fallback, see team-guide).
+// its model pin to 'opus' under the Opus 5 fallback, see team-guide).
 //
 // When the repo is too big for MAX_AREAS areas to cover, the leftover paths are
 // reported (coverage.areasDropped, coverage.ceilingReached, and a suggested next

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -14,7 +14,7 @@ export const meta = {
 // session-model review produces. Models and effort are pinned per
 // stage, so the session model and effort never leak into the workers; the
 // single critic runs Fable 5 at xhigh effort (flip its model pin to 'opus'
-// under the Opus 4.8 fallback, see team-guide).
+// under the Opus 5 fallback, see team-guide).
 //
 // Invoke with an optional base ref:
 //   Workflow({ name: 'tm-review-changes', args: { base: 'origin/main' } })

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -17,7 +17,7 @@ export const meta = {
 // fan-out and no loop. Models and effort are pinned per stage, so the
 // session model and effort never leak into the scout or the workers; the
 // single critic runs Fable 5 at xhigh effort (flip its model pin to 'opus'
-// under the Opus 4.8 fallback, see team-guide).
+// under the Opus 5 fallback, see team-guide).
 //
 // When the repo is too big for MAX_AREAS areas to cover, the leftover paths are
 // reported (coverage.ceilingReached, coverage.areasDropped, and a suggested next

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -93,13 +93,17 @@ dispatch, no architect/reviewer): $1.80. Ledger row:
 lines 63-77 weight all four scopes above using historical list-price
 tiers: `OPUS_INPUT = 15`, `OPUS_OUTPUT = 75`, Sonnet `3`/`15`, with Fable
 set to 2x that Opus figure (`30`/`150`). Current published pricing (bundled
-`claude-api` skill, `shared/models.md`, cached 2026-06-24): Opus 5
-`claude-opus-5` $5/$25 per MTok, Fable 5 `claude-fable-5` $10/$50, Opus 4.8
-`claude-opus-4-8` $5/$25 (still active), Sonnet 5 `claude-sonnet-5` $3/$15.
-Cross-checked against this repo's own citation in
-`docs/reviews/2026-06-30-orchestration-comparison.md` ("Corollary": Sonnet
-$3/$15 vs Opus 4.8 $5/$25, checked 2026-06-30) - the two sources agree on
-Sonnet and Opus 4.8.
+`claude-api` skill, `shared/models.md`, which self-describes as cached, not
+live, at line 7, with no embedded cache date): Opus 5 `claude-opus-5` $5/$25
+per MTok, Fable 5 `claude-fable-5` $10/$50, Opus 4.8 `claude-opus-4-8` $5/$25
+(still active). That file carries no Sonnet 5 pricing at all
+(`grep -n '\$' shared/models.md` returns only the Fable 5 and Opus 5 lines);
+Sonnet 5's $3/$15 comes from `shared/model-migration.md:1192` ("unchanged at
+the $3/$15 sticker"), `python/claude-api/README.md:502`, and this repo's own
+`docs/reviews/2026-06-30-orchestration-comparison.md:126-129` ("Corollary":
+Sonnet $3/$15 vs Opus 4.8 $5/$25, checked 2026-06-30). Those three sources
+agree with each other on Sonnet, and the last also agrees with
+`shared/models.md` on Opus 4.8's $5/$25.
 
 The Sonnet leg of the proxy table ($3/$15) already matches current
 pricing exactly, but the Opus/Fable leg does not: at the proxy table,
@@ -129,7 +133,7 @@ were never published for that batch. Under that assumption:
 - Opus 5 is exactly half of Fable 5's price in both directions, so
   replacing every Fable-priced seat with Opus 5 halves that slice's dollar
   contribution. Cutting an ~80-85% slice in half cuts total batch-level
-  spend by roughly 35-45%.
+  spend by roughly 40-42.5%.
 
 That range is the ceiling for option (b) (all three seats moved), at
 batch scope, in dollars, not confirmed Max-plan quota. It reuses
@@ -144,7 +148,7 @@ more than half of nearly every bucket across the whole dataset (a
 different scope, not batch #201's role split), so it is directional
 evidence that lead is plausibly the majority of the Fable-priced group,
 not a number to plug into the formula above. Option (c)'s savings are
-therefore real, bounded above by the same 35-45% ceiling, and smaller if
+therefore real, bounded above by the same 40-42.5% ceiling, and smaller if
 architect and reviewer carry a non-trivial share. Pricing it more
 precisely would need a role-scoped re-run of the token-burn script
 against a fresh batch (section 9).
@@ -152,15 +156,18 @@ against a fresh batch (section 9).
 ## 5. Availability and operating cost
 
 During this batch, two judgment-seat dispatches failed with `You've
-reached your Fable 5 limit`, each forcing a per-call Opus override
-(the Agent tool's `model` param, per the documented fallback procedure).
-Cross-referenced against commit `11003f9` ("docs: document per-call Opus
-override for a single Fable-blocked seat", #228, verified with
-`git show 11003f9`): that commit exists specifically because the same
-workaround already had to be written down once before, in a prior batch.
-Two Fable-limit events across two separate occasions is a recurrence, not
-a first; it is not a measured failure rate, and this document does not
-treat it as one.
+reached your Fable 5 limit`, each forcing a per-call Opus override (the
+Agent tool's `model` param, per the documented fallback procedure). Both
+events, with the exact error string, are recorded on batch issue #262
+alongside the decision to use the per-call override; that issue is the
+auditable record, since this document's sandbox has no GitHub access or
+session transcript to re-derive the claim from. Cross-referenced against
+commit `11003f9` ("docs: document per-call Opus override for a single
+Fable-blocked seat", #228, verified with `git show 11003f9`): that commit
+exists because the same workaround already had to be written down once
+before, in a prior batch. Two events across two separate occasions is a
+recurrence, not a first; it is not a measured failure rate, and this
+document does not treat it as one.
 
 Two standing costs from the pricing source (`claude-api` skill,
 `shared/models.md`):
@@ -177,7 +184,7 @@ Two standing costs from the pricing source (`claude-api` skill,
 
 Opus 5's prompt-cache minimum dropped to 512 tokens (from 1024 on
 Opus 4.8), but this repo's own measured bootstrap contexts run
-12k-22k tokens (drivers 1 and 4 of the token-burn investigation), so that
+12k-22k tokens (driver 1 of the token-burn investigation), so that
 change is marginal here and does not support the recommendation below.
 
 ## 6. Capability
@@ -227,8 +234,10 @@ Opus 5 today (section 2 notes the mid-session #263 rename that makes the
 prose track this). Worth reconciling in the same follow-up that adds the
 `opus` effort-policy entry.
 
-Prompt rework specific to any Opus 5 shift, tied to each documented
-behavior change:
+Prompt rework specific to any Opus 5 shift, tied to each documented behavior
+change (`claude-api` bundled skill, `shared/model-migration.md`, "Migrating
+to Claude Opus 5" > "Behavioral shifts (prompt-tunable)", lines 1029-1098; a
+vendor migration guide, the same weakest evidence class as section 6):
 
 - **Longer default output.** `reviewer.md`'s report contract fixes
   structure (`VERDICT`/`STAGE`/`FINDINGS`) but sets no length bound. A
@@ -285,7 +294,7 @@ review or sub-plan quality the pipeline already guarantees through
 Fable-pinned subagents.
 
 What caps this at medium rather than high: the precise dollar/quota
-savings from moving the lead alone are bounded (up to the 35-45%
+savings from moving the lead alone are bounded (up to the 40-42.5%
 batch-level ceiling in section 4) but not pinned, since driver-3 does not
 publish a lead-only breakdown; "affordable" in the current policy is a
 Max-plan quota claim, and nothing here measures whether Opus 5's lower
@@ -322,9 +331,14 @@ the recommended delegation cap in place.
   `docs/reviews/ab-tests.md`.
 - `docs/reviews/2026-06-30-orchestration-comparison.md` (Corollary,
   addendum, and the $3/$15 vs $5/$25 pricing cross-check).
-- `claude-api` bundled skill, `shared/models.md`, cached 2026-06-24. Not
-  a live query; the file itself recommends the Models API for anything
-  capability-related, which this document did not run.
+- `claude-api` bundled skill: `shared/models.md` (self-described as cached,
+  not live, at line 7, no embedded cache date; recommends the Models API for
+  anything capability-related, which this document did not run);
+  `shared/model-migration.md:1192` (Sonnet 5 pricing) and its "Migrating to
+  Claude Opus 5" > "Behavioral shifts (prompt-tunable)" section, lines
+  1029-1098 (section 7's behavior-shift claims, a vendor migration guide,
+  the same weakest evidence class as section 6's capability claims);
+  `python/claude-api/README.md:502` (Sonnet 5 pricing).
 - `.claude/team-guide.md`, `docs/team-guide-rationale.md`,
   `.claude/agents/architect.md`, `.claude/agents/reviewer.md`,
   `.claude/workflows/tm-review-changes.js`,

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -1,0 +1,339 @@
+# Opus 5 vs Fable 5 for the lead, architect, and reviewer seats - 2026-07-24
+
+A recommendation, not a policy change. Related: issue #264. Nothing here
+edits `.claude/team-guide.md`, any agent frontmatter, or any workflow stage.
+
+## 1. Question and scope
+
+With Opus 5 released, should the orchestrator (lead), architect, and
+reviewer seats stay on Fable 5, or move to Opus 5? These three are the
+Model policy's "judgment" seats: the lead session itself, plus the two
+`fable`-pinned role agents (`architect.md`, `reviewer.md`) and, by
+extension, the three workflow critic stages that also pin `fable`
+(`tm-review-changes.js`, `tm-review-codebase.js`, `tm-map-codebase.js`).
+
+In scope: one recommendation with a stated confidence level, grounded in
+this repo's own measured burn data and current published pricing.
+Out of scope: the Sonnet-pinned worker seats, the `xhigh` effort ceiling,
+any live A/B run (no `tm-ab-test` execution), and any actual edit to the
+Model policy, frontmatter, or workflow scripts. A follow-up issue would
+carry out any change this document recommends.
+
+## 2. What the current policy rests on
+
+`.claude/team-guide.md`, Model policy, as of this session:
+
+> Fable 5 (`claude-fable-5`) at xhigh effort. Affordable only because the
+> lead stays on the bounded tm- machinery. Fable costs 2x Opus 5 per
+> token. The premium is bounded in aggregate, not per batch
+> (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
+
+Note on that quote: issue #263 landed on this same branch while this
+document was being written and renamed the fallback model throughout
+`team-guide.md` from Opus 4.8 to Opus 5 (a stale comparison target, not a
+dollar-math error). The line above already reflects that edit; earlier
+drafts said "2x Opus 4.8 per token." Opus 4.8 and Opus 5 are priced
+identically ($5/$25 per MTok, section 4), so the "2x" figure is unchanged
+by the rename.
+
+Two things to hold apart when reading "affordable":
+
+- It is a **Max-plan subscription quota claim**, not a dollar claim. The
+  policy's own "Cost-based fallback trigger" bullet says as much: if
+  Fable 5 ever moves off the Max-plan subscription to metered API
+  billing, "measure the lead's actual $/session cost at API rates first,"
+  rather than assuming the quota reasoning still applies.
+- "Bounded in aggregate, not per batch" is a scope claim, backed by one
+  finding (section 4): Fable's token share is small across 14 days and 25
+  projects, but not small inside a single kickoff batch.
+
+## 3. Options
+
+Three concrete seat assignments, not general positions.
+
+- **(a) Stay on Fable everywhere.** Lead, architect, reviewer, and all
+  three workflow critics stay `fable`. The status quo.
+- **(b) Move all three seats to Opus 5.** Lead switches its session model;
+  `architect.md`/`reviewer.md` frontmatter and the three critic stages
+  flip `model: fable` to `model: opus`.
+- **(c) Split: lead moves to Opus 5, architect/reviewer/critics stay on
+  Fable 5.** Priced in section 4, justified in section 8.
+
+A fourth combination (architect/reviewer to Opus 5, lead stays Fable) was
+rejected as a candidate: section 7 shows the frontmatter/critic-stage move
+is the one blocked by today's failing effort-policy test, while the
+lead's own model is not test-pinned at all. Leading with the change that
+needs no code fix first is the lower-risk split.
+
+## 4. Cost, from this repo's numbers
+
+Three scopes, in order of how much of the pipeline they cover.
+
+**14-day, 25-project aggregate.** From
+`docs/research/2026-07-06-token-burn-investigation.md` section 4/5:
+Fable's raw token share is 5.5%, its weighted-proxy-dollar share is 18.7%.
+Lead attribution alone (section 3) accounts for 1,105,250 input /
+9,757,736 output / 41,496,802 cache_creation / 1,156,442,742 cache_read
+across 4,535 deduped lines, "more than half of all buckets except
+cache_creation" - the single largest attribution bucket in the dataset.
+
+**Single batch (#201).** Same doc, section 5, driver 3: at batch scope,
+Fable-priced roles (lead + architect + reviewer) flip to 57.5% of raw
+tokens and 93.3% of weighted-proxy dollars, against Sonnet-priced roles
+(developer + tester) at 42.5% raw / 6.7% weighted. This is the finding the
+"bounded in aggregate, not per batch" policy line already cites.
+
+**Single package.** `docs/reviews/2026-07-13-ab-plan-status-parser.md`,
+Arm A (full kickoff pipeline): weighted cost $7.55, of which $6.44 is
+Fable-priced (85.3%) and $1.11 Sonnet-priced. Arm B (developer-only
+dispatch, no architect/reviewer): $1.80. Ledger row:
+`docs/reviews/ab-tests.md`.
+
+**Mandatory price correction.** `docs/research/2026-07-06-token-burn-analyze.mjs`
+lines 63-77 weight all four scopes above using historical list-price
+tiers: `OPUS_INPUT = 15`, `OPUS_OUTPUT = 75`, Sonnet `3`/`15`, with Fable
+set to 2x that Opus figure (`30`/`150`). Current published pricing (bundled
+`claude-api` skill, `shared/models.md`, cached 2026-06-24): Opus 5
+`claude-opus-5` $5/$25 per MTok, Fable 5 `claude-fable-5` $10/$50, Opus 4.8
+`claude-opus-4-8` $5/$25 (still active), Sonnet 5 `claude-sonnet-5` $3/$15.
+Cross-checked against this repo's own citation in
+`docs/reviews/2026-06-30-orchestration-comparison.md` ("Corollary": Sonnet
+$3/$15 vs Opus 4.8 $5/$25, checked 2026-06-30) - the two sources agree on
+Sonnet and Opus 4.8.
+
+The Sonnet leg of the proxy table ($3/$15) already matches current
+pricing exactly, but the Opus/Fable leg does not: at the proxy table,
+Opus is 5x Sonnet's input price ($15 vs $3); at current prices, Opus is
+1.67x ($5 vs $3), i.e. Sonnet is 1/5 of Opus in the proxy and 3/5 of Opus
+now. **Every dollar figure quoted above (18.7%, 93.3%, $7.55, $6.44)
+overstates the Fable/Opus share relative to current pricing.** Naively
+rescaling one of those figures (dividing $6.44 by some factor) is not
+done here: the single-package report only publishes already-weighted
+dollars, not the raw per-model token counts a correct re-derivation
+needs. Batch #201's driver-3 finding is different: it publishes the raw
+split itself (57.5%/42.5%), so it can be re-derived.
+
+**The counterfactual, worked from batch #201's raw split.** Assumption
+named up front: a uniform bucket mix across role classes (input, output,
+cache_creation, cache_read tokens in the same relative proportion for
+Fable-priced and Sonnet-priced roles), since per-role, per-bucket splits
+were never published for that batch. Under that assumption:
+
+- Raw split: 57.5% Fable-priced tokens, 42.5% Sonnet-priced.
+- Fable is 3.33x Sonnet at current prices ($10/$50 vs $3/$15, both
+  directions), against the proxy table's implied 10x.
+- Fable-priced share of weighted spend at current prices:
+  `(0.575 x 3.33) / (0.575 x 3.33 + 0.425)`, roughly 80-85%, down from the
+  proxy's 93.3%. Not stated to two decimals; the uniform-mix assumption
+  does not support that precision.
+- Opus 5 is exactly half of Fable 5's price in both directions, so
+  replacing every Fable-priced seat with Opus 5 halves that slice's dollar
+  contribution. Cutting an ~80-85% slice in half cuts total batch-level
+  spend by roughly 35-45%.
+
+That range is the ceiling for option (b) (all three seats moved), at
+batch scope, in dollars, not confirmed Max-plan quota. It reuses
+`2026-07-06-token-burn-analyze.mjs`'s own published numbers plus the
+price correction above; no new analysis script was written.
+
+**Pricing option (c).** Batch #201's driver-3 finding reports lead +
+architect + reviewer as one combined group; it does not publish how much
+of that 57.5%/93.3% the lead alone accounts for. The best available
+proxy is the 14-day aggregate's attribution table, where lead alone is
+more than half of nearly every bucket across the whole dataset (a
+different scope, not batch #201's role split), so it is directional
+evidence that lead is plausibly the majority of the Fable-priced group,
+not a number to plug into the formula above. Option (c)'s savings are
+therefore real, bounded above by the same 35-45% ceiling, and smaller if
+architect and reviewer carry a non-trivial share. Pricing it more
+precisely would need a role-scoped re-run of the token-burn script
+against a fresh batch (section 9).
+
+## 5. Availability and operating cost
+
+During this batch, two judgment-seat dispatches failed with `You've
+reached your Fable 5 limit`, each forcing a per-call Opus override
+(the Agent tool's `model` param, per the documented fallback procedure).
+Cross-referenced against commit `11003f9` ("docs: document per-call Opus
+override for a single Fable-blocked seat", #228, verified with
+`git show 11003f9`): that commit exists specifically because the same
+workaround already had to be written down once before, in a prior batch.
+Two Fable-limit events across two separate occasions is a recurrence, not
+a first; it is not a measured failure rate, and this document does not
+treat it as one.
+
+Two standing costs from the pricing source (`claude-api` skill,
+`shared/models.md`):
+
+- Fable 5 requires 30-day data retention (not available under
+  zero-data-retention). A policy cost the current assignment already
+  pays, independent of anything measured here.
+- Opus 5 sits in a rate-limit bucket separate from the combined Opus 4.x
+  pool, so an Opus 5 primary with an Opus 4.8 fallback would be two
+  independent capacity pools, not one pool with a within-family fallback.
+  Whether that is a net resilience gain over the current Fable-primary,
+  Opus-4.8-fallback arrangement is not established here; both
+  arrangements already cross model families for their fallback.
+
+Opus 5's prompt-cache minimum dropped to 512 tokens (from 1024 on
+Opus 4.8), but this repo's own measured bootstrap contexts run
+12k-22k tokens (drivers 1 and 4 of the token-burn investigation), so that
+change is marginal here and does not support the recommendation below.
+
+## 6. Capability
+
+No first-party comparison of Opus 5 against Fable 5 on this repo's own
+judgment tasks (sub-plans, PR reviews, codebase-review critiques) exists.
+The only capability signal is vendor positioning, the weakest evidence
+class, quoted and labeled as such: `shared/models.md` describes Opus 5 as
+"a step-change over Claude Opus 4.8... at half the cost of Claude Fable 5
+(Claude Fable 5 remains the highest-capability tier)," and separately
+calls Fable 5 "Anthropic's most capable widely released model." Taken at
+face value, the vendor's own framing puts Fable 5 above Opus 5 on
+capability, arguing against moving the judgment seats for quality
+reasons, not for it. This repo's `docs/team-guide-rationale.md` DeepSWE
+leaderboard note ("Fable 5 at max scores the same as at high... Sonnet 5
+at max is dominated by Fable 5") compares effort levels and Sonnet
+against Fable, not Opus 5 against Fable, so it does not bear here.
+
+## 7. Change surface and prompt rework
+
+Full inventory, `grep -rn "fable\|Fable" .claude/ docs/`: `architect.md`
+and `reviewer.md` frontmatter (`model: fable` plus a fallback comment
+naming Opus), the three workflow critic stages
+(`tm-review-changes.js:146`, `tm-review-codebase.js:248`,
+`tm-map-codebase.js:236`), the three `SKILL.md` files describing the
+critic as Fable, and `team-guide.md`/`team-guide-rationale.md` as the
+policy's own prose (an edit site for any future change, not touched here).
+
+**Flag prominently:** `.claude/workflows/__tests__/effort-policy.test.mjs:21`
+defines `EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh' }` with no
+`opus` key. Read against the test body (lines 37-61): flipping any
+frontmatter or workflow-stage `model:` to `opus` fails with "pins model
+'opus', which has no effort rule." The documented Fable-outage fallback
+(flip the pins to `opus` for a longer outage) is blocked by this repo's
+own test today. This is real rework, not a hypothetical: option (b), and
+the architect/reviewer half of option (c) if ever extended, cannot ship
+until a follow-up issue adds an `opus` entry to `EFFORT_BY_MODEL`. That
+follow-up is not done in this package.
+
+One consequence worth flagging, verified directly: the same
+`shared/models.md` alias table (lines 116-134) maps the bare alias
+"opus" to `claude-opus-5`, not `claude-opus-4-8`. If Claude Code's own
+frontmatter `model: opus` resolves through the same alias table (not
+independently confirmed, but the two systems share Anthropic's model
+naming), the documented Fable-outage fallback would already land on
+Opus 5 today (section 2 notes the mid-session #263 rename that makes the
+prose track this). Worth reconciling in the same follow-up that adds the
+`opus` effort-policy entry.
+
+Prompt rework specific to any Opus 5 shift, tied to each documented
+behavior change:
+
+- **Longer default output.** `reviewer.md`'s report contract fixes
+  structure (`VERDICT`/`STAGE`/`FINDINGS`) but sets no length bound. A
+  longer-by-default reviewer inflates every fix-round input and PR
+  comment; worth a length hint if reviewer moves.
+- **Self-verification without being asked, distinguished carefully.**
+  Self-check scaffolding aimed at a model's own output can become
+  redundant if the model already double-checks itself. That does not
+  apply to the workflow critic's consolidation step: `tm-review-changes.js:145`
+  instructs the critic to "verify it against the actual diff" for the
+  *parallel Sonnet reviewers'* raw findings, not the critic's own work. A
+  doc that told a maintainer to strip that instruction because "the model
+  self-verifies now" would remove a real cross-check on other agents, not
+  redundant scaffolding. Do not remove it.
+- **Readier delegation, priced as a lead-seat risk.** `architect.md`/
+  `reviewer.md` have no Task tool, so those two seats are structurally
+  bounded regardless of model. The lead is not, and the lead is where the
+  one measured over-spawn failure in this repo's history came from
+  (`docs/reviews/2026-06-30-orchestration-comparison.md` addendum: an
+  unpinned, unbounded construction reached 297 agents and about 5.64M
+  subagent tokens over ~51 minutes and died on an organization-wide spend
+  cap, against the bounded arm's 9). That trial ran Sonnet 5, not Opus 5,
+  so it is evidence about unbounded construction risk in general, not a
+  measured Opus 5 spawning rate. If the lead moves to Opus 5, an explicit
+  delegation cap is the mitigation this risk calls for, not a general
+  policy change.
+- **Task-scope expansion.** Hits `architect.md`'s advisory role and
+  collides with `reviewer.md`'s pass-1 rule that "scope creep... [is a]
+  blocking finding, even when the extra code is good." Watch for this
+  before trusting either seat unsupervised on a new model.
+- **Effort ceiling.** No change needed: Opus 5's effort ladder runs
+  through `max`, so `xhigh` (this policy's ceiling) is already available.
+
+## 8. Recommendation and confidence
+
+**Move the lead seat from Fable 5 to Opus 5 now (`/model claude-opus-5`);
+leave architect, reviewer, and the three workflow critic stages on
+Fable 5 until the effort-policy test gains an `opus` tier in a follow-up
+issue. Confidence: medium.**
+
+This is option (c), not (b): a full move is blocked today by a real,
+verified test failure (section 7), and the vendor's own capability claim
+(section 6) argues against moving the two structurally-bounded judgment
+seats for quality reasons alone. The lead-only move is not blocked by
+that test (the lead's model is not frontmatter-pinned or asserted
+anywhere in `npm test`), captures a real and potentially majority share
+of the available savings (lead is the single largest token consumer in
+this repo's own aggregate data, section 4), and its blast radius is
+contained: per `docs/reviews/2026-06-30-orchestration-comparison.md`'s
+Corollary, the pipeline pins architect and reviewer regardless of which
+model leads, so a lead-model change affects only the lead's own direct
+judgment work (scoping, parking decisions, un-delegated writing), not the
+review or sub-plan quality the pipeline already guarantees through
+Fable-pinned subagents.
+
+What caps this at medium rather than high: the precise dollar/quota
+savings from moving the lead alone are bounded (up to the 35-45%
+batch-level ceiling in section 4) but not pinned, since driver-3 does not
+publish a lead-only breakdown; "affordable" in the current policy is a
+Max-plan quota claim, and nothing here measures whether Opus 5's lower
+per-token price actually buys more quota; the two Fable-limit events are
+a recurrence, not a measured rate, so the availability case is real but
+modest; and Opus 5's own spawning tendency as a lead is unmeasured
+(section 7's only data point is a Sonnet 5 trial).
+
+## 9. What would have to be true to revisit
+
+**To extend the move to architect, reviewer, and the critics:** the
+effort-policy test gains an `opus` tier (a follow-up issue, not this
+package); a repo-scoped comparison (a `tm-ab-test` run per role, since
+none has run yet) shows Opus 5's judgment output on this repo's own
+sub-plans or reviews holds up against Fable 5's, not just against vendor
+positioning; or Fable-limit exhaustion events recur often enough to look
+like a rate rather than two isolated incidents.
+
+**To revert the lead-only move:** the lead's own scoping and parking
+decisions visibly degrade on Opus 5, traceable to real batch outcomes
+(missed scope calls, more parked `needs-human` items than before); a
+measured Max-plan quota check (per the existing "Cost-based fallback
+trigger" bullet) shows Opus 5's lower dollar price does not translate
+into lower quota consumption for the lead seat; or Opus 5 shows the same
+unbounded-delegation tendency the addendum measured for Sonnet 5, without
+the recommended delegation cap in place.
+
+## 10. Sources and limitations
+
+- `docs/research/2026-07-06-token-burn-investigation.md` (sections 3, 4,
+  5) and its script, `docs/research/2026-07-06-token-burn-analyze.mjs`
+  (lines 55-87).
+- `docs/reviews/2026-07-13-ab-plan-status-parser.md` and
+  `docs/reviews/ab-tests.md`.
+- `docs/reviews/2026-06-30-orchestration-comparison.md` (Corollary,
+  addendum, and the $3/$15 vs $5/$25 pricing cross-check).
+- `claude-api` bundled skill, `shared/models.md`, cached 2026-06-24. Not
+  a live query; the file itself recommends the Models API for anything
+  capability-related, which this document did not run.
+- `.claude/team-guide.md`, `docs/team-guide-rationale.md`,
+  `.claude/agents/architect.md`, `.claude/agents/reviewer.md`,
+  `.claude/workflows/tm-review-changes.js`,
+  `.claude/workflows/__tests__/effort-policy.test.mjs`, and commit
+  `11003f9`, all read directly for this document.
+
+Limitations: the price correction in section 4 is arithmetic, not a
+re-run against real transcripts (transcripts were not reachable from this
+worktree); the batch #201 and single-package dollar figures both predate
+current pricing and were not independently re-derived beyond the one
+worked example; capability evidence is vendor-only; and the two
+availability events are anecdote, explicitly not a rate.

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -2,12 +2,15 @@
 
 **Summary: move the lead session from Fable 5 to Opus 5 now (`/model
 claude-opus-5`); leave architect, reviewer, and the workflow critics on Fable
-5. Confidence: medium (section 8). One blocker: extending further to
-architect/reviewer/critics is blocked today by the effort-policy test having
-no `opus` tier (section 7); the lead-only move is not. It is a one-command
-model switch and cheap to reverse (section 7's inventory lists the prose that
-goes stale, none of it blocking) - the strongest argument for acting despite
-the unmeasured capability risk in section 6.**
+5. Confidence: medium (section 8), resting on an Opus-class floor claim, real
+but bounded savings, and availability (section 8) - not on cheap
+reversibility, which is a real but secondary point (a one-command model
+switch; section 7's inventory lists the prose that goes stale, none of it
+blocking) that lowers the cost of being wrong rather than driving the
+decision, despite the unmeasured capability risk in section 6. One blocker:
+extending further to architect/reviewer/critics is blocked today by the
+effort-policy test having no `opus` tier (section 7); the lead-only move is
+not.**
 
 A recommendation, not a policy change. Related: issue #264. Nothing here edits
 `.claude/team-guide.md`, any agent frontmatter, or any workflow stage.
@@ -68,9 +71,9 @@ Three concrete seat assignments, not general positions.
 
 A fourth combination (architect/reviewer to Opus 5, lead stays Fable) was
 rejected as a candidate: section 7 shows the frontmatter/critic-stage move is
-the one blocked by today's failing effort-policy test, while the lead's own
-model is not test-pinned at all. Leading with the change that needs no code
-fix first is the lower-risk split.
+the one that would fail the effort-policy test, while the lead's own model is
+not test-pinned at all. Leading with the change that needs no code fix first
+is the lower-risk split.
 
 ## 4. Cost, from this repo's numbers
 
@@ -106,8 +109,8 @@ no embedded cache date): Opus 5 `claude-opus-5` $5/$25 per MTok, Fable 5
 That file carries no Sonnet 5 pricing at all (`grep -n '\$' shared/models.md`
 returns three lines: the Fable 5 and Opus 5 prices plus one unrelated
 `$ANTHROPIC_API_KEY` curl example); Sonnet 5's $3/$15 comes from
-`shared/model-migration.md:1192` ("unchanged at the $3/$15 sticker,
-introductory $2/$10 per MTok applies through 2026-08-31"),
+`shared/model-migration.md:1192` ("unchanged at the $3/$15 sticker
+(introductory $2/$10 per MTok applies through 2026-08-31)"),
 `python/claude-api/README.md:502`, and this repo's own
 `docs/reviews/2026-06-30-orchestration-comparison.md:126-129` ("Corollary":
 Sonnet $3/$15 vs Opus 4.8 $5/$25, checked 2026-06-30). Those three sources
@@ -175,12 +178,18 @@ your Fable 5 limit`, each forcing a per-call Opus override (the Agent tool's
 `model` param, per the documented fallback procedure). Both events, with the
 exact error string, are recorded on batch issue #262 alongside the decision to
 use the per-call override, the auditable record since this document's sandbox
-has no GitHub access or session transcript to re-derive the claim from.
-Cross-referenced against commit `11003f9` ("docs: document per-call Opus
-override for a single Fable-blocked seat", #228): that commit exists because
-the same workaround already had to be written down once before, in a prior
-batch. Two events across two separate occasions is a recurrence, not a first;
-it is not a measured failure rate, and this document does not treat it as one.
+has no GitHub access or session transcript to re-derive the claim from. Two
+prior, separate occurrences exist. Commit `11003f9` ("docs: document per-call
+Opus override for a single Fable-blocked seat", #228) exists because the same
+workaround already had to be written down once before, in a prior batch.
+`docs/architecture/2026-07-05-codebase-map.md:6` records that the older
+2026-07-04 codebase map's synthesis stage "ran on the Opus 4.8 fallback while
+Fable 5 was quota-exhausted" (#179), confirmed by reading that source directly.
+Four events across three separate documented occasions (this batch's two, plus
+#228 and #179) is a recurrence, not a first; it is not a measured failure
+rate, and this document does not treat it as one - these remain individual
+recorded occurrences, not a rate measured over some denominator of total
+dispatches.
 
 Two standing costs from the pricing source (`claude-api` skill,
 `shared/models.md`):
@@ -234,11 +243,13 @@ editing alongside any lead-seat move.
 
 **Flag prominently:** `.claude/workflows/__tests__/effort-policy.test.mjs:21`
 defines `EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh' }` with no `opus`
-key. Read against the test body (lines 37-61): flipping any frontmatter or
-workflow-stage `model:` to `opus` fails with "pins model 'opus', which has no
-effort rule." The documented Fable-outage fallback (flip the pins to `opus`
-for a longer outage) is blocked by this repo's own test today. This is real
-rework, not a hypothetical: option (b), and the architect/reviewer half of
+key. Read against the test body: the frontmatter assertion (lines 37-61) and
+the workflow-stage assertion that consumes the same `EFFORT_BY_MODEL` (lines
+86-105) both fail the same way if `model:` is flipped to `opus`, with "pins
+model 'opus', which has no effort rule." The documented Fable-outage fallback
+(flip the pins to `opus` for a longer outage) is blocked by this repo's own
+test today. This is real rework, not a hypothetical: option (b), and the
+architect/reviewer half of
 option (c) if ever extended, cannot ship until a follow-up issue adds an
 `opus` entry to `EFFORT_BY_MODEL`. That follow-up is not done in this package.
 
@@ -294,79 +305,91 @@ leave architect, reviewer, and the three workflow critic stages on Fable 5
 until the effort-policy test gains an `opus` tier in a follow-up issue.
 Confidence: medium.**
 
-This is option (c), not (b): a full move is blocked today by a real, verified
-test failure (section 7), and the vendor's own capability claim (section 6)
-argues against moving the two structurally-bounded judgment seats for quality
+This is option (c), not (b): a full move would fail the effort-policy test
+today (section 7), and the vendor's own capability claim (section 6) argues
+against moving the two structurally-bounded judgment seats for quality
 reasons alone. The lead-only move is not blocked by that test (the lead's
-model is not frontmatter-pinned or asserted anywhere in `npm test`), captures
-a real and potentially majority share of the available savings (lead is the
-single largest token consumer in this repo's own aggregate data, section 4).
-That dollar range may not translate under this repo's Max-plan subscription,
-where nothing measures whether a lower per-token price buys more quota
-(below); what does bite here is availability - Opus 5 sits in its own
-rate-limit bucket, separate from the combined Opus 4.x pool (section 5), and
-this batch alone hit the Fable-5 limit twice. Moving the lead off the shared
-Fable pool reduces exposure to that already-observed failure mode (it does not
-remove it: architect, reviewer, and the critics stay on Fable and can still
-hit the limit), regardless of whether the dollar saving above translates into
-quota saved. Its blast radius is also contained: per
-`docs/reviews/2026-06-30-orchestration-comparison.md`'s Corollary, the
-pipeline pins architect and reviewer regardless of which model leads, so a
-lead-model change affects only the lead's own direct judgment work (scoping,
-parking decisions, un-delegated writing), not the review or sub-plan quality
-the pipeline already guarantees.
+model is not frontmatter-pinned or asserted anywhere in `npm test`), and it
+captures a real and potentially majority share of the available savings (lead
+is the single largest token consumer in this repo's own aggregate data,
+section 4). Weighed below against the sharpest existing rebuttal on file -
+`docs/reviews/2026-06-30-orchestration-comparison.md`'s Corollary, run on
+Sonnet 5 vs Opus 4.8, which reached the opposite conclusion (keep the
+stronger model in the lead seat, since the lead's own un-delegated judgment
+is the one place model choice isn't backstopped by the pipeline) - the case
+breaks into five parts:
 
-That Corollary section doesn't stop at containment: run on Sonnet 5 vs Opus
-4.8, it reached the opposite conclusion, keep the stronger model in the lead
-seat, since the lead's own un-delegated judgment is the one place model choice
-isn't backstopped by the pipeline. Its cost argument does not distinguish this
-case: the Corollary weighed comparable pressure (1.67x at sticker, 2.5x at the
-intro rate, against this document's 2.0x), said "Cost cuts the other way," and
-rejected the swap anyway, discounting its own case as unverified under the
-Max-plan subscription, the same discount section 8 applies here. What does
-distinguish this case is a floor claim, not a ranking claim: the Corollary's
-own conclusion, "keep Opus 4.8 as the default lead," argues against dropping
-the lead below Opus class, not that only the top-ranked model may hold the
-seat. This repo ran an Opus-class lead by policy until commit 7fd326e (#133)
-replaced it with Fable 5 (`git show 248d672 -- CLAUDE.md`); nothing in the
-record calls that inadequate, and #133 moved up because a stronger model
-appeared, not because Opus failed. Opus 5 is that model's successor at
-identical pricing and is already this repo's documented judgment-seat
-fallback, per commit ec14b7a (#263); this needs only "Opus 5 is at least Opus
-4.8's equal," nothing about the size of the gap to Fable 5.
+- **Cost, conceded rather than claimed.** The dollar range worked out in
+  section 4 may not translate under this repo's Max-plan subscription, where
+  nothing measures whether a lower per-token price buys more quota
+  (confidence cap, below), so this recommendation does not rest its case on
+  it. That mirrors the Corollary's own cost argument, which does not
+  distinguish this case: the Corollary weighed comparable pressure (1.67x at
+  sticker, 2.5x at the intro rate, against this document's 2.0x), said "Cost
+  cuts the other way," and rejected the swap anyway, discounting its own case
+  as unverified under the Max-plan subscription - the same discount this
+  section applies here.
+- **The floor claim.** What distinguishes this case from the Corollary's is a
+  floor claim, not a ranking claim: the Corollary's own conclusion, "the
+  judgment-escalation argument favors keeping Opus 4.8 as the default lead,"
+  argues against dropping the lead below Opus class, not that only the
+  top-ranked model may hold the seat. This repo ran an Opus-class lead by
+  policy until commit 7fd326e (#133) replaced it with Fable 5 (`git show
+  7fd326e -- .claude/team-guide.md`; commit 248d672, #87, three weeks
+  earlier, is cited elsewhere only as evidence of the pre-#133 Opus-4.8 lead
+  bullet, not as the replacing commit). Nothing in the record calls that
+  inadequate, and #133 moved up because a stronger model appeared, not
+  because Opus failed. Opus 5 is that model's successor at identical pricing
+  and is already this repo's documented judgment-seat fallback, per commit
+  ec14b7a (#263); this needs only "Opus 5 is at least Opus 4.8's equal,"
+  nothing about the size of the gap to Fable 5.
+- **Availability, genuinely new.** The Corollary has no availability fact or
+  argument anywhere. Precisely: the recorded events (section 5) span this
+  batch's two subagent judgment-seat dispatches (recovered by a per-call
+  Opus override, not lead-seat blocks), the prior occurrence behind commit
+  `11003f9` (#228), and the 2026-07-04 codebase map's synthesis-stage
+  fallback (#179) - four events across three separate documented occasions,
+  a recurrence, not a rate. Moving the lead off Fable reduces exhaustion
+  pressure on a shared pool the lead plausibly dominates (section 4); it does
+  not remove the failure mode, since architect, reviewer, and the critics
+  stay on Fable and can still hit the limit, regardless of whether the dollar
+  saving above translates into quota saved. The blast radius is also
+  contained: per the Corollary, the pipeline pins architect and reviewer
+  regardless of which model leads, so a lead-model change affects only the
+  lead's own direct judgment work (scoping, parking decisions, un-delegated
+  writing), not the review or sub-plan quality the pipeline already
+  guarantees.
+- **Policy conflict.** This collides with the Model policy's opening line,
+  "the strongest model in every plan/decision seat" (`.claude/team-guide.md`):
+  commit 7fd326e (#133), one day after the Corollary, moved the lead to Fable
+  for that reason, ratifying the Corollary's principle into standing policy
+  rather than superseding it. A lead-only move to Opus 5 is an exception to
+  that line, resolved by the policy's own fallback trigger ("unavailable,
+  rate-limited, quota-exhausted" as grounds to run the lead on Opus), except
+  that the exhaustion recurs rather than being one-off; the follow-up issue
+  implementing this amends the orchestrator bullet, a human sign-off item,
+  not a decision made here.
+- **Capability, conceded against.** The only capability signal still points
+  the other way: vendor positioning ranks Fable 5 above Opus 5 (section 6).
+  That concession stays tied to the confidence cap below, not argued around.
 
-Availability is genuinely new; the Corollary has no availability fact or
-argument anywhere. But precisely: the two recorded events (section 5) were
-subagent judgment-seat dispatches recovered by a per-call Opus override, not
-lead-seat blocks; with the prior occurrence behind commit 11003f9 they are a
-recurrence across three occasions, not a rate; and moving the lead off Fable
-reduces exhaustion pressure on a shared pool the lead plausibly dominates
-(section 4), it does not remove the failure mode noted above. This also
-collides with the Model policy's opening line, "the strongest model in every
-plan/decision seat" (`.claude/team-guide.md`): commit 7fd326e (#133), one day
-after the Corollary, moved the lead to Fable for that reason, ratifying the
-Corollary's principle into standing policy rather than superseding it. A
-lead-only move to Opus 5 is an exception to that line, resolved by the
-policy's own fallback trigger ("unavailable, rate-limited, quota-exhausted" as
-grounds to run the lead on Opus), except that the exhaustion recurs rather
-than being one-off; the follow-up issue implementing this amends the
-orchestrator bullet, a human sign-off item, not a decision made here. The only
-capability signal still points the other way, vendor positioning ranking Fable
-5 above Opus 5 (section 6); that concession stays tied to the confidence cap
-below, not argued around.
+What caps this at medium rather than high:
 
-What caps this at medium rather than high: the precise dollar/quota savings
-from moving the lead alone are bounded (around 40.9% at sticker pricing, 43.6%
-at the live intro rate, section 4) but not pinned, since driver-3 does not
-publish a lead-only breakdown; "affordable" in the current policy is a
-Max-plan quota claim, and nothing here measures whether Opus 5's lower
-per-token price actually buys more quota; the two Fable-limit events are a
-recurrence, not a rate, so the availability case is real but modest; Opus 5's
-own spawning tendency as a lead is unmeasured (section 7's only data point is
-a Sonnet 5 trial); no first-party comparison of Opus 5 against Fable 5 exists,
-and the only capability signal, vendor positioning, ranks Fable 5 above Opus 5
-(section 6); and the pricing here is itself cached, not live, with no embedded
-cache date (section 4).
+- The precise dollar/quota savings from moving the lead alone are bounded
+  (around 40.9% at sticker pricing, 43.6% at the live intro rate, section 4)
+  but not pinned, since driver-3 does not publish a lead-only breakdown.
+- "Affordable" in the current policy is a Max-plan quota claim, and nothing
+  here measures whether Opus 5's lower per-token price actually buys more
+  quota.
+- The four Fable-limit events, across three documented occasions, are a
+  recurrence, not a rate, so the availability case is real but modest.
+- Opus 5's own spawning tendency as a lead is unmeasured (section 7's only
+  data point is a Sonnet 5 trial).
+- No first-party comparison of Opus 5 against Fable 5 exists, and the only
+  capability signal, vendor positioning, ranks Fable 5 above Opus 5
+  (section 6).
+- The pricing here is itself cached, not live, with no embedded cache date
+  (section 4).
 
 ## 9. What would have to be true to revisit
 
@@ -375,8 +398,8 @@ effort-policy test gains an `opus` tier (a follow-up issue, not this package);
 a repo-scoped comparison (a `tm-ab-test` run per role, since none has run yet)
 shows Opus 5's judgment output on this repo's own sub-plans or reviews holds
 up against Fable 5's, not just against vendor positioning; or Fable-limit
-exhaustion events recur often enough to look like a rate rather than two
-isolated incidents.
+exhaustion events recur often enough to look like a rate rather than four
+isolated events across three documented occasions.
 
 **To revert the lead-only move:** the lead's own scoping and parking decisions
 visibly degrade on Opus 5, traceable to real batch outcomes (missed scope
@@ -406,12 +429,14 @@ measured for Sonnet 5, without the recommended delegation cap in place.
 - `.claude/team-guide.md`, `docs/team-guide-rationale.md`,
   `.claude/agents/architect.md`, `.claude/agents/reviewer.md`,
   `.claude/workflows/tm-review-changes.js`,
-  `.claude/workflows/__tests__/effort-policy.test.mjs`, and commit `11003f9`,
-  all read directly for this document.
+  `.claude/workflows/__tests__/effort-policy.test.mjs`,
+  `docs/architecture/2026-07-05-codebase-map.md` (the #179 availability
+  occurrence, section 5), and commit `11003f9`, all read directly for this
+  document.
 
 Limitations: the price correction in section 4 is arithmetic, not a re-run
 against real transcripts (transcripts were not reachable from this worktree);
 the batch #201 and single-package dollar figures both predate current pricing
 and were not independently re-derived beyond the one worked example;
-capability evidence is vendor-only; and the two availability events are
-anecdote, explicitly not a rate.
+capability evidence is vendor-only; and the four availability events across
+three documented occasions are anecdote, explicitly not a rate.

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -1,5 +1,14 @@
 # Opus 5 vs Fable 5 for the lead, architect, and reviewer seats - 2026-07-24
 
+**Summary: move the lead session from Fable 5 to Opus 5 now
+(`/model claude-opus-5`); leave architect, reviewer, and the workflow
+critics on Fable 5. Confidence: medium (section 8). One blocker: extending
+further to architect/reviewer/critics is blocked today by the
+effort-policy test having no `opus` tier (section 7); the lead-only move
+is not. It is a one-command, zero-code change, and instantly reversible -
+the strongest argument for acting despite the unmeasured capability risk
+in section 6.**
+
 A recommendation, not a policy change. Related: issue #264. Nothing here
 edits `.claude/team-guide.md`, any agent frontmatter, or any workflow stage.
 
@@ -31,10 +40,9 @@ carry out any change this document recommends.
 Note on that quote: issue #263 landed on this same branch while this
 document was being written and renamed the fallback model throughout
 `team-guide.md` from Opus 4.8 to Opus 5 (a stale comparison target, not a
-dollar-math error). The line above already reflects that edit; earlier
-drafts said "2x Opus 4.8 per token." Opus 4.8 and Opus 5 are priced
-identically ($5/$25 per MTok, section 4), so the "2x" figure is unchanged
-by the rename.
+dollar-math error). The line above reflects that edit; Opus 4.8 and
+Opus 5 are priced identically ($5/$25 per MTok, section 4), so the "2x"
+figure is unchanged by the rename.
 
 Two things to hold apart when reading "affordable":
 
@@ -96,23 +104,28 @@ set to 2x that Opus figure (`30`/`150`). Current published pricing (bundled
 `claude-api` skill, `shared/models.md`, which self-describes as cached, not
 live, at line 7, with no embedded cache date): Opus 5 `claude-opus-5` $5/$25
 per MTok, Fable 5 `claude-fable-5` $10/$50, Opus 4.8 `claude-opus-4-8` $5/$25
-(still active). That file carries no Sonnet 5 pricing at all
-(`grep -n '\$' shared/models.md` returns only the Fable 5 and Opus 5 lines);
-Sonnet 5's $3/$15 comes from `shared/model-migration.md:1192` ("unchanged at
-the $3/$15 sticker"), `python/claude-api/README.md:502`, and this repo's own
+(still active). That file carries no Sonnet 5 pricing at all (`grep -n '\$' shared/models.md`
+returns three lines: the Fable 5 and Opus 5 prices plus one unrelated
+`$ANTHROPIC_API_KEY` curl example); Sonnet 5's $3/$15 comes from
+`shared/model-migration.md:1192` ("unchanged at the $3/$15 sticker,
+introductory $2/$10 per MTok applies through 2026-08-31"),
+`python/claude-api/README.md:502`, and this repo's own
 `docs/reviews/2026-06-30-orchestration-comparison.md:126-129` ("Corollary":
 Sonnet $3/$15 vs Opus 4.8 $5/$25, checked 2026-06-30). Those three sources
 agree with each other on Sonnet, and the last also agrees with
-`shared/models.md` on Opus 4.8's $5/$25.
+`shared/models.md` on Opus 4.8's $5/$25. Today (2026-07-24) is inside the
+intro window; everything below uses the $3/$15 sticker as the durable
+figure (the window closes in about five weeks) and calls out the intro
+rate's effect separately where it changes the answer.
 
-The Sonnet leg of the proxy table ($3/$15) already matches current
-pricing exactly, but the Opus/Fable leg does not: at the proxy table,
-Opus is 5x Sonnet's input price ($15 vs $3); at current prices, Opus is
-1.67x ($5 vs $3), i.e. Sonnet is 1/5 of Opus in the proxy and 3/5 of Opus
-now. **Every dollar figure quoted above (18.7%, 93.3%, $7.55, $6.44)
-overstates the Fable/Opus share relative to current pricing.** Naively
-rescaling one of those figures (dividing $6.44 by some factor) is not
-done here: the single-package report only publishes already-weighted
+The Sonnet leg of the proxy table ($3/$15 sticker) already matches
+current pricing exactly, but the Opus/Fable leg does not: at the proxy
+table, Opus is 5x Sonnet's input price ($15 vs $3); at current prices,
+Opus is 1.67x ($5 vs $3), i.e. Sonnet is 1/5 of Opus in the proxy and 3/5
+of Opus now. **Every dollar figure quoted above (18.7%, 93.3%, $7.55,
+$6.44) overstates the Fable/Opus share relative to current pricing.**
+Naively rescaling one of those figures (dividing $6.44 by some factor) is
+not done here: the single-package report only publishes already-weighted
 dollars, not the raw per-model token counts a correct re-derivation
 needs. Batch #201's driver-3 finding is different: it publishes the raw
 split itself (57.5%/42.5%), so it can be re-derived.
@@ -121,24 +134,32 @@ split itself (57.5%/42.5%), so it can be re-derived.
 named up front: a uniform bucket mix across role classes (input, output,
 cache_creation, cache_read tokens in the same relative proportion for
 Fable-priced and Sonnet-priced roles), since per-role, per-bucket splits
-were never published for that batch. Under that assumption:
+were never published for that batch. Cross-check: at the proxy table's
+10x Fable/Sonnet ratio, uniform mix predicts a 93.1% weighted
+Fable-priced share (`(0.575 x 10) / (0.575 x 10 + 0.425)`) against the
+93.3% the investigation measured directly - a 0.2-point gap, within
+rounding, so the assumption holds. Under that assumption, at current
+sticker prices:
 
 - Raw split: 57.5% Fable-priced tokens, 42.5% Sonnet-priced.
-- Fable is 3.33x Sonnet at current prices ($10/$50 vs $3/$15, both
+- Fable is 3.33x Sonnet at sticker prices ($10/$50 vs $3/$15, both
   directions), against the proxy table's implied 10x.
-- Fable-priced share of weighted spend at current prices:
-  `(0.575 x 3.33) / (0.575 x 3.33 + 0.425)`, roughly 80-85%, down from the
-  proxy's 93.3%. Not stated to two decimals; the uniform-mix assumption
-  does not support that precision.
+- Fable-priced share of weighted spend: `(0.575 x 3.33) / (0.575 x 3.33 +
+  0.425)` = 81.9%, down from the proxy's 93.3%.
 - Opus 5 is exactly half of Fable 5's price in both directions, so
-  replacing every Fable-priced seat with Opus 5 halves that slice's dollar
-  contribution. Cutting an ~80-85% slice in half cuts total batch-level
-  spend by roughly 40-42.5%.
+  replacing every Fable-priced seat with Opus 5 halves that slice's
+  dollar contribution: cutting an 81.9% slice in half cuts total
+  batch-level spend by 40.9%.
 
-That range is the ceiling for option (b) (all three seats moved), at
-batch scope, in dollars, not confirmed Max-plan quota. It reuses
-`2026-07-06-token-burn-analyze.mjs`'s own published numbers plus the
-price correction above; no new analysis script was written.
+At the live $2/$10 intro Sonnet rate, Fable is 5x Sonnet instead of
+3.33x, giving an 87.1% share and a 43.6% saving - higher than the
+sticker-price figures above, not a ceiling above them. 40.9% is this
+document's durable, sticker-priced estimate for option (b) (all three
+seats moved), at batch scope, in dollars, not confirmed Max-plan quota;
+43.6% is what applies for the roughly five weeks the intro rate still
+runs. Both reuse `2026-07-06-token-burn-analyze.mjs`'s own published
+numbers plus the price correction above; no new analysis script was
+written.
 
 **Pricing option (c).** Batch #201's driver-3 finding reports lead +
 architect + reviewer as one combined group; it does not publish how much
@@ -148,8 +169,9 @@ more than half of nearly every bucket across the whole dataset (a
 different scope, not batch #201's role split), so it is directional
 evidence that lead is plausibly the majority of the Fable-priced group,
 not a number to plug into the formula above. Option (c)'s savings are
-therefore real, bounded above by the same 40-42.5% ceiling, and smaller if
-architect and reviewer carry a non-trivial share. Pricing it more
+therefore real, bounded above by the same 40.9% (sticker) to 43.6%
+(intro-rate) range, and smaller if architect and reviewer carry a
+non-trivial share. Pricing it more
 precisely would need a role-scoped re-run of the token-burn script
 against a fresh batch (section 9).
 
@@ -176,11 +198,10 @@ Two standing costs from the pricing source (`claude-api` skill,
   zero-data-retention). A policy cost the current assignment already
   pays, independent of anything measured here.
 - Opus 5 sits in a rate-limit bucket separate from the combined Opus 4.x
-  pool, so an Opus 5 primary with an Opus 4.8 fallback would be two
-  independent capacity pools, not one pool with a within-family fallback.
-  Whether that is a net resilience gain over the current Fable-primary,
-  Opus-4.8-fallback arrangement is not established here; both
-  arrangements already cross model families for their fallback.
+  pool (reused as the recommendation's availability argument, section 8).
+  Whether an Opus 5 primary with an Opus 4.8 fallback is a net resilience
+  gain over today's Fable-primary, Opus-4.8-fallback arrangement is not
+  established here; both already cross model families for their fallback.
 
 Opus 5's prompt-cache minimum dropped to 512 tokens (from 1024 on
 Opus 4.8), but this repo's own measured bootstrap contexts run
@@ -205,13 +226,23 @@ against Fable, not Opus 5 against Fable, so it does not bear here.
 
 ## 7. Change surface and prompt rework
 
-Full inventory, `grep -rn "fable\|Fable" .claude/ docs/`: `architect.md`
-and `reviewer.md` frontmatter (`model: fable` plus a fallback comment
-naming Opus), the three workflow critic stages
+Scope note: `grep -rn "fable\|Fable" .claude/ docs/` (below) does not
+cover the repo root, so this is a partial inventory, not a full one.
+`architect.md` and `reviewer.md` frontmatter (`model: fable` plus a
+fallback comment naming Opus), the three workflow critic stages
 (`tm-review-changes.js:146`, `tm-review-codebase.js:248`,
 `tm-map-codebase.js:236`), the three `SKILL.md` files describing the
 critic as Fable, and `team-guide.md`/`team-guide-rationale.md` as the
-policy's own prose (an edit site for any future change, not touched here).
+policy's own prose (edit sites for any future change, not touched here).
+
+Re-run from the repo root and two more lead-seat hardcodes surface, both
+stale as soon as the lead moves: `README.md` (7 hits; line 77,
+`fable, xhigh` on the lead node) and `docs/team-architecture.md:33`
+(`LEAD - main session (fable, xhigh effort)`) - the latter was already
+inside the `.claude`/`docs` scope above and simply left off the list.
+Neither is frontmatter or asserted in `npm test`, so neither is blocked
+by the effort-policy failure below, but both need editing alongside any
+lead-seat move.
 
 **Flag prominently:** `.claude/workflows/__tests__/effort-policy.test.mjs:21`
 defines `EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh' }` with no
@@ -225,7 +256,7 @@ until a follow-up issue adds an `opus` entry to `EFFORT_BY_MODEL`. That
 follow-up is not done in this package.
 
 One consequence worth flagging, verified directly: the same
-`shared/models.md` alias table (lines 116-134) maps the bare alias
+`shared/models.md` alias table (lines 114-138) maps the bare alias
 "opus" to `claude-opus-5`, not `claude-opus-4-8`. If Claude Code's own
 frontmatter `model: opus` resolves through the same alias table (not
 independently confirmed, but the two systems share Anthropic's model
@@ -255,13 +286,15 @@ vendor migration guide, the same weakest evidence class as section 6):
 - **Readier delegation, priced as a lead-seat risk.** `architect.md`/
   `reviewer.md` have no Task tool, so those two seats are structurally
   bounded regardless of model. The lead is not, and the lead is where the
-  one measured over-spawn failure in this repo's history came from
-  (`docs/reviews/2026-06-30-orchestration-comparison.md` addendum: an
-  unpinned, unbounded construction reached 297 agents and about 5.64M
-  subagent tokens over ~51 minutes and died on an organization-wide spend
-  cap, against the bounded arm's 9). That trial ran Sonnet 5, not Opus 5,
-  so it is evidence about unbounded construction risk in general, not a
-  measured Opus 5 spawning rate. If the lead moves to Opus 5, an explicit
+  one measured over-spawn failure in this repo's testing came from
+  (`docs/reviews/2026-06-30-orchestration-comparison.md` addendum: the
+  unbounded arm alone reached 288 of a combined 297 agents and about
+  5.64M subagent tokens over ~51 minutes and died on an organization-wide
+  spend cap, against the bounded arm's 9). That trial measured the
+  construction's behavior on Sonnet 5, not a live session's own free-form
+  choice, and not Opus 5 at all, so it is evidence about unbounded
+  construction risk in general, not a measured Opus 5 spawning rate. If
+  the lead moves to Opus 5, an explicit
   delegation cap is the mitigation this risk calls for, not a general
   policy change.
 - **Task-scope expansion.** Hits `architect.md`'s advisory role and
@@ -285,7 +318,14 @@ seats for quality reasons alone. The lead-only move is not blocked by
 that test (the lead's model is not frontmatter-pinned or asserted
 anywhere in `npm test`), captures a real and potentially majority share
 of the available savings (lead is the single largest token consumer in
-this repo's own aggregate data, section 4), and its blast radius is
+this repo's own aggregate data, section 4). That dollar range may not
+translate under this repo's Max-plan subscription, where nothing measures
+whether a lower per-token price buys more quota (below); what does bite
+here is availability - Opus 5 sits in its own rate-limit bucket, separate
+from the combined Opus 4.x pool (section 5), and this batch alone hit the
+Fable-5 limit twice. Moving the lead off the shared Fable pool removes
+that already-observed failure mode regardless of whether the dollar
+saving above translates into quota saved. Its blast radius is also
 contained: per `docs/reviews/2026-06-30-orchestration-comparison.md`'s
 Corollary, the pipeline pins architect and reviewer regardless of which
 model leads, so a lead-model change affects only the lead's own direct
@@ -293,15 +333,39 @@ judgment work (scoping, parking decisions, un-delegated writing), not the
 review or sub-plan quality the pipeline already guarantees through
 Fable-pinned subagents.
 
+That Corollary section doesn't stop at containment: run on Sonnet 5 vs
+Opus 4.8, it reached the opposite conclusion - keep the stronger model in
+the lead seat, since the lead's own un-delegated judgment is the one
+place model choice isn't backstopped by the pipeline. The same logic, run
+on this document's own numbers, would favor keeping Fable 5: section 6's
+only capability signal, vendor positioning, ranks Fable 5 above Opus 5,
+so a lead-only move accepts the same kind of judgment risk that report
+argued against taking. Two things distinguish this case rather than
+defeat it: that report's swap had no offsetting pressure and explicitly
+kept Opus as lead, where sections 4 and 5 here document real pressure
+absent there (a 2x per-token premium, two recorded Fable-limit failures);
+and the vendor positions Opus 5 itself as narrowing that gap ("a
+step-change over Claude Opus 4.8... at half the cost of Claude Fable 5",
+section 6), not a repeat of the older Opus-4.8-vs-Sonnet-5 comparison.
+Neither point is capability evidence; both are why confidence stays
+medium rather than treating containment alone as sufficient, and why
+section 9's revert trigger names exactly the judgment-quality signal the
+Corollary flags.
+
 What caps this at medium rather than high: the precise dollar/quota
-savings from moving the lead alone are bounded (up to the 40-42.5%
-batch-level ceiling in section 4) but not pinned, since driver-3 does not
-publish a lead-only breakdown; "affordable" in the current policy is a
-Max-plan quota claim, and nothing here measures whether Opus 5's lower
-per-token price actually buys more quota; the two Fable-limit events are
-a recurrence, not a measured rate, so the availability case is real but
-modest; and Opus 5's own spawning tendency as a lead is unmeasured
-(section 7's only data point is a Sonnet 5 trial).
+savings from moving the lead alone are bounded (around 40.9% at sticker
+pricing, 43.6% at the live intro rate, section 4) but not pinned, since
+driver-3 does not publish a lead-only breakdown; "affordable" in the
+current policy is a Max-plan quota claim, and nothing here measures
+whether Opus 5's lower per-token price actually buys more quota; the two
+Fable-limit events are a recurrence, not a measured rate, so the
+availability case is real but modest; Opus 5's own spawning tendency as a
+lead is unmeasured (section 7's only data point is a Sonnet 5 trial); no
+first-party comparison of Opus 5 against Fable 5 on this repo's own
+judgment tasks exists, and the only capability signal available, vendor
+positioning, ranks Fable 5 above Opus 5 (section 6); and the pricing this
+recommendation is built on is itself cached, not live, with no embedded
+cache date (section 4).
 
 ## 9. What would have to be true to revisit
 

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -1,56 +1,55 @@
 # Opus 5 vs Fable 5 for the lead, architect, and reviewer seats - 2026-07-24
 
-**Summary: move the lead session from Fable 5 to Opus 5 now
-(`/model claude-opus-5`); leave architect, reviewer, and the workflow
-critics on Fable 5. Confidence: medium (section 8). One blocker: extending
-further to architect/reviewer/critics is blocked today by the
-effort-policy test having no `opus` tier (section 7); the lead-only move
-is not. It is a one-command, zero-code change, and instantly reversible -
-the strongest argument for acting despite the unmeasured capability risk
-in section 6.**
+**Summary: move the lead session from Fable 5 to Opus 5 now (`/model
+claude-opus-5`); leave architect, reviewer, and the workflow critics on Fable
+5. Confidence: medium (section 8). One blocker: extending further to
+architect/reviewer/critics is blocked today by the effort-policy test having
+no `opus` tier (section 7); the lead-only move is not. It is a one-command
+model switch and cheap to reverse (section 7's inventory lists the prose that
+goes stale, none of it blocking) - the strongest argument for acting despite
+the unmeasured capability risk in section 6.**
 
-A recommendation, not a policy change. Related: issue #264. Nothing here
-edits `.claude/team-guide.md`, any agent frontmatter, or any workflow stage.
+A recommendation, not a policy change. Related: issue #264. Nothing here edits
+`.claude/team-guide.md`, any agent frontmatter, or any workflow stage.
 
 ## 1. Question and scope
 
-With Opus 5 released, should the orchestrator (lead), architect, and
-reviewer seats stay on Fable 5, or move to Opus 5? These three are the
-Model policy's "judgment" seats: the lead session itself, plus the two
-`fable`-pinned role agents (`architect.md`, `reviewer.md`) and, by
-extension, the three workflow critic stages that also pin `fable`
-(`tm-review-changes.js`, `tm-review-codebase.js`, `tm-map-codebase.js`).
+With Opus 5 released, should the orchestrator (lead), architect, and reviewer
+seats stay on Fable 5, or move to Opus 5? These three are the Model policy's
+"judgment" seats: the lead session itself, plus the two `fable`-pinned role
+agents (`architect.md`, `reviewer.md`) and, by extension, the three workflow
+critic stages that also pin `fable` (`tm-review-changes.js`,
+`tm-review-codebase.js`, `tm-map-codebase.js`).
 
-In scope: one recommendation with a stated confidence level, grounded in
-this repo's own measured burn data and current published pricing.
-Out of scope: the Sonnet-pinned worker seats, the `xhigh` effort ceiling,
-any live A/B run (no `tm-ab-test` execution), and any actual edit to the
-Model policy, frontmatter, or workflow scripts. A follow-up issue would
-carry out any change this document recommends.
+In scope: one recommendation with a stated confidence level, grounded in this
+repo's own measured burn data and current published pricing. Out of scope: the
+Sonnet-pinned worker seats, the `xhigh` effort ceiling, any live A/B run (no
+`tm-ab-test` execution), and any actual edit to the Model policy, frontmatter,
+or workflow scripts. A follow-up issue would carry out any change this
+document recommends.
 
 ## 2. What the current policy rests on
 
 `.claude/team-guide.md`, Model policy, as of this session:
 
-> Fable 5 (`claude-fable-5`) at xhigh effort. Affordable only because the
-> lead stays on the bounded tm- machinery. Fable costs 2x Opus 5 per
-> token. The premium is bounded in aggregate, not per batch
+> Fable 5 (`claude-fable-5`) at xhigh effort. Affordable only because the lead
+> stays on the bounded tm- machinery. Fable costs 2x Opus 5 per token. The
+> premium is bounded in aggregate, not per batch
 > (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
 
-Note on that quote: issue #263 landed on this same branch while this
-document was being written and renamed the fallback model throughout
-`team-guide.md` from Opus 4.8 to Opus 5 (a stale comparison target, not a
-dollar-math error). The line above reflects that edit; Opus 4.8 and
-Opus 5 are priced identically ($5/$25 per MTok, section 4), so the "2x"
-figure is unchanged by the rename.
+Note on that quote: issue #263 landed on this same branch while this document
+was being written and renamed the fallback model throughout `team-guide.md`
+from Opus 4.8 to Opus 5 (a stale comparison target, not a dollar-math error);
+Opus 4.8 and Opus 5 are priced identically ($5/$25 per MTok, section 4), so
+the "2x" figure is unchanged by the rename.
 
 Two things to hold apart when reading "affordable":
 
 - It is a **Max-plan subscription quota claim**, not a dollar claim. The
-  policy's own "Cost-based fallback trigger" bullet says as much: if
-  Fable 5 ever moves off the Max-plan subscription to metered API
-  billing, "measure the lead's actual $/session cost at API rates first,"
-  rather than assuming the quota reasoning still applies.
+  policy's own "Cost-based fallback trigger" bullet says as much: if Fable 5
+  ever moves off the Max-plan subscription to metered API billing, "measure
+  the lead's actual $/session cost at API rates first," rather than assuming
+  the quota reasoning still applies.
 - "Bounded in aggregate, not per batch" is a scope claim, backed by one
   finding (section 4): Fable's token share is small across 14 days and 25
   projects, but not small inside a single kickoff batch.
@@ -59,52 +58,52 @@ Two things to hold apart when reading "affordable":
 
 Three concrete seat assignments, not general positions.
 
-- **(a) Stay on Fable everywhere.** Lead, architect, reviewer, and all
-  three workflow critics stay `fable`. The status quo.
+- **(a) Stay on Fable everywhere.** Lead, architect, reviewer, and all three
+  workflow critics stay `fable`. The status quo.
 - **(b) Move all three seats to Opus 5.** Lead switches its session model;
-  `architect.md`/`reviewer.md` frontmatter and the three critic stages
-  flip `model: fable` to `model: opus`.
-- **(c) Split: lead moves to Opus 5, architect/reviewer/critics stay on
-  Fable 5.** Priced in section 4, justified in section 8.
+  `architect.md`/`reviewer.md` frontmatter and the three critic stages flip
+  `model: fable` to `model: opus`.
+- **(c) Split: lead moves to Opus 5, architect/reviewer/critics stay on Fable
+  5.** Priced in section 4, justified in section 8.
 
 A fourth combination (architect/reviewer to Opus 5, lead stays Fable) was
-rejected as a candidate: section 7 shows the frontmatter/critic-stage move
-is the one blocked by today's failing effort-policy test, while the
-lead's own model is not test-pinned at all. Leading with the change that
-needs no code fix first is the lower-risk split.
+rejected as a candidate: section 7 shows the frontmatter/critic-stage move is
+the one blocked by today's failing effort-policy test, while the lead's own
+model is not test-pinned at all. Leading with the change that needs no code
+fix first is the lower-risk split.
 
 ## 4. Cost, from this repo's numbers
 
 Three scopes, in order of how much of the pipeline they cover.
 
 **14-day, 25-project aggregate.** From
-`docs/research/2026-07-06-token-burn-investigation.md` section 4/5:
-Fable's raw token share is 5.5%, its weighted-proxy-dollar share is 18.7%.
-Lead attribution alone (section 3) accounts for 1,105,250 input /
-9,757,736 output / 41,496,802 cache_creation / 1,156,442,742 cache_read
-across 4,535 deduped lines, "more than half of all buckets except
-cache_creation" - the single largest attribution bucket in the dataset.
+`docs/research/2026-07-06-token-burn-investigation.md` section 4/5: Fable's
+raw token share is 5.5%, its weighted-proxy-dollar share is 18.7%. Lead
+attribution alone (section 3) accounts for 1,105,250 input / 9,757,736 output
+/ 41,496,802 cache_creation / 1,156,442,742 cache_read across 4,535 deduped
+lines, "more than half of all buckets except cache_creation" - the single
+largest attribution bucket in the dataset.
 
 **Single batch (#201).** Same doc, section 5, driver 3: at batch scope,
-Fable-priced roles (lead + architect + reviewer) flip to 57.5% of raw
-tokens and 93.3% of weighted-proxy dollars, against Sonnet-priced roles
-(developer + tester) at 42.5% raw / 6.7% weighted. This is the finding the
-"bounded in aggregate, not per batch" policy line already cites.
+Fable-priced roles (lead + architect + reviewer) flip to 57.5% of raw tokens
+and 93.3% of weighted-proxy dollars, against Sonnet-priced roles (developer +
+tester) at 42.5% raw / 6.7% weighted. This is the finding the "bounded in
+aggregate, not per batch" policy line already cites.
 
-**Single package.** `docs/reviews/2026-07-13-ab-plan-status-parser.md`,
-Arm A (full kickoff pipeline): weighted cost $7.55, of which $6.44 is
-Fable-priced (85.3%) and $1.11 Sonnet-priced. Arm B (developer-only
-dispatch, no architect/reviewer): $1.80. Ledger row:
-`docs/reviews/ab-tests.md`.
+**Single package.** `docs/reviews/2026-07-13-ab-plan-status-parser.md`, Arm A
+(full kickoff pipeline): weighted cost $7.55, of which $6.44 is Fable-priced
+(85.3%) and $1.11 Sonnet-priced. Arm B (developer-only dispatch, no
+architect/reviewer): $1.80. Ledger row: `docs/reviews/ab-tests.md`.
 
-**Mandatory price correction.** `docs/research/2026-07-06-token-burn-analyze.mjs`
-lines 63-77 weight all four scopes above using historical list-price
-tiers: `OPUS_INPUT = 15`, `OPUS_OUTPUT = 75`, Sonnet `3`/`15`, with Fable
-set to 2x that Opus figure (`30`/`150`). Current published pricing (bundled
-`claude-api` skill, `shared/models.md`, which self-describes as cached, not
-live, at line 7, with no embedded cache date): Opus 5 `claude-opus-5` $5/$25
-per MTok, Fable 5 `claude-fable-5` $10/$50, Opus 4.8 `claude-opus-4-8` $5/$25
-(still active). That file carries no Sonnet 5 pricing at all (`grep -n '\$' shared/models.md`
+**Mandatory price correction.**
+`docs/research/2026-07-06-token-burn-analyze.mjs` lines 63-77 weight all four
+scopes above using historical list-price tiers: `OPUS_INPUT = 15`,
+`OPUS_OUTPUT = 75`, Sonnet `3`/`15`, with Fable set to 2x that Opus figure
+(`30`/`150`). Current published pricing (bundled `claude-api` skill,
+`shared/models.md`, which self-describes as cached, not live, at line 7, with
+no embedded cache date): Opus 5 `claude-opus-5` $5/$25 per MTok, Fable 5
+`claude-fable-5` $10/$50, Opus 4.8 `claude-opus-4-8` $5/$25 (still active).
+That file carries no Sonnet 5 pricing at all (`grep -n '\$' shared/models.md`
 returns three lines: the Fable 5 and Opus 5 prices plus one unrelated
 `$ANTHROPIC_API_KEY` curl example); Sonnet 5's $3/$15 comes from
 `shared/model-migration.md:1192` ("unchanged at the $3/$15 sticker,
@@ -114,304 +113,305 @@ introductory $2/$10 per MTok applies through 2026-08-31"),
 Sonnet $3/$15 vs Opus 4.8 $5/$25, checked 2026-06-30). Those three sources
 agree with each other on Sonnet, and the last also agrees with
 `shared/models.md` on Opus 4.8's $5/$25. Today (2026-07-24) is inside the
-intro window; everything below uses the $3/$15 sticker as the durable
-figure (the window closes in about five weeks) and calls out the intro
-rate's effect separately where it changes the answer.
+intro window; everything below uses the $3/$15 sticker as the durable figure
+(the window closes in about five weeks) and calls out the intro rate's effect
+separately where it changes the answer.
 
-The Sonnet leg of the proxy table ($3/$15 sticker) already matches
-current pricing exactly, but the Opus/Fable leg does not: at the proxy
-table, Opus is 5x Sonnet's input price ($15 vs $3); at current prices,
-Opus is 1.67x ($5 vs $3), i.e. Sonnet is 1/5 of Opus in the proxy and 3/5
-of Opus now. **Every dollar figure quoted above (18.7%, 93.3%, $7.55,
-$6.44) overstates the Fable/Opus share relative to current pricing.**
-Naively rescaling one of those figures (dividing $6.44 by some factor) is
-not done here: the single-package report only publishes already-weighted
-dollars, not the raw per-model token counts a correct re-derivation
-needs. Batch #201's driver-3 finding is different: it publishes the raw
-split itself (57.5%/42.5%), so it can be re-derived.
+The Sonnet leg of the proxy table ($3/$15 sticker) already matches current
+pricing exactly, but the Opus/Fable leg does not: at the proxy table, Opus is
+5x Sonnet's input price ($15 vs $3); at current prices, Opus is 1.67x ($5 vs
+$3), i.e. Sonnet is 1/5 of Opus in the proxy and 3/5 of Opus now. **Every
+dollar figure quoted above (18.7%, 93.3%, $7.55, $6.44) overstates the
+Fable/Opus share relative to current pricing.** Naively rescaling one of those
+figures (dividing $6.44 by some factor) is not done here: the single-package
+report only publishes already-weighted dollars, not the raw per-model token
+counts a correct re-derivation needs. Batch #201's driver-3 finding is
+different: it publishes the raw split itself (57.5%/42.5%), so it can be
+re-derived.
 
-**The counterfactual, worked from batch #201's raw split.** Assumption
-named up front: a uniform bucket mix across role classes (input, output,
+**The counterfactual, worked from batch #201's raw split.** Assumption named
+up front: a uniform bucket mix across role classes (input, output,
 cache_creation, cache_read tokens in the same relative proportion for
-Fable-priced and Sonnet-priced roles), since per-role, per-bucket splits
-were never published for that batch. Cross-check: at the proxy table's
-10x Fable/Sonnet ratio, uniform mix predicts a 93.1% weighted
-Fable-priced share (`(0.575 x 10) / (0.575 x 10 + 0.425)`) against the
-93.3% the investigation measured directly - a 0.2-point gap, within
-rounding, so the assumption holds. Under that assumption, at current
-sticker prices:
+Fable-priced and Sonnet-priced roles), since per-role, per-bucket splits were
+never published for that batch. Cross-check: at the proxy table's 10x
+Fable/Sonnet ratio, uniform mix predicts a 93.1% weighted Fable-priced share
+(`(0.575 x 10) / (0.575 x 10 + 0.425)`) against the 93.3% the investigation
+measured directly - a 0.2-point gap, within rounding, so the assumption holds.
+Under that assumption, at current sticker prices:
 
 - Raw split: 57.5% Fable-priced tokens, 42.5% Sonnet-priced.
 - Fable is 3.33x Sonnet at sticker prices ($10/$50 vs $3/$15, both
   directions), against the proxy table's implied 10x.
 - Fable-priced share of weighted spend: `(0.575 x 3.33) / (0.575 x 3.33 +
   0.425)` = 81.9%, down from the proxy's 93.3%.
-- Opus 5 is exactly half of Fable 5's price in both directions, so
-  replacing every Fable-priced seat with Opus 5 halves that slice's
-  dollar contribution: cutting an 81.9% slice in half cuts total
-  batch-level spend by 40.9%.
+- Opus 5 is exactly half of Fable 5's price in both directions, so replacing
+  every Fable-priced seat with Opus 5 halves that slice's dollar contribution:
+  cutting an 81.9% slice in half cuts total batch-level spend by 40.9%.
 
-At the live $2/$10 intro Sonnet rate, Fable is 5x Sonnet instead of
-3.33x, giving an 87.1% share and a 43.6% saving - higher than the
-sticker-price figures above, not a ceiling above them. 40.9% is this
-document's durable, sticker-priced estimate for option (b) (all three
-seats moved), at batch scope, in dollars, not confirmed Max-plan quota;
-43.6% is what applies for the roughly five weeks the intro rate still
-runs. Both reuse `2026-07-06-token-burn-analyze.mjs`'s own published
-numbers plus the price correction above; no new analysis script was
-written.
+At the live $2/$10 intro Sonnet rate, Fable is 5x Sonnet instead of 3.33x,
+giving an 87.1% share and a 43.6% saving - higher than the sticker-price
+figures above, not a ceiling above them. 40.9% is this document's durable,
+sticker-priced estimate for option (b) (all three seats moved), at batch
+scope, in dollars, not confirmed Max-plan quota; 43.6% is what applies for the
+roughly five weeks the intro rate still runs. Both reuse
+`2026-07-06-token-burn-analyze.mjs`'s own published numbers plus the price
+correction above; no new analysis script was written.
 
-**Pricing option (c).** Batch #201's driver-3 finding reports lead +
-architect + reviewer as one combined group; it does not publish how much
-of that 57.5%/93.3% the lead alone accounts for. The best available
-proxy is the 14-day aggregate's attribution table, where lead alone is
-more than half of nearly every bucket across the whole dataset (a
-different scope, not batch #201's role split), so it is directional
-evidence that lead is plausibly the majority of the Fable-priced group,
-not a number to plug into the formula above. Option (c)'s savings are
-therefore real, bounded above by the same 40.9% (sticker) to 43.6%
-(intro-rate) range, and smaller if architect and reviewer carry a
-non-trivial share. Pricing it more
-precisely would need a role-scoped re-run of the token-burn script
-against a fresh batch (section 9).
+**Pricing option (c).** Batch #201's driver-3 finding reports lead + architect
++ reviewer as one combined group, not a lead-only split. The 14-day
+aggregate's attribution table shows lead alone is more than half of nearly
+every bucket across the whole dataset (a different scope, not batch #201's
+role split) - directional evidence lead is plausibly the majority of the
+Fable-priced group, not a number to plug into the formula above. Option (c)'s
+savings are therefore real, bounded above by the range worked out above, and
+smaller if architect and reviewer carry a non-trivial share; pricing it
+precisely would need a role-scoped re-run of the token-burn script against a
+fresh batch (section 9).
 
 ## 5. Availability and operating cost
 
-During this batch, two judgment-seat dispatches failed with `You've
-reached your Fable 5 limit`, each forcing a per-call Opus override (the
-Agent tool's `model` param, per the documented fallback procedure). Both
-events, with the exact error string, are recorded on batch issue #262
-alongside the decision to use the per-call override; that issue is the
-auditable record, since this document's sandbox has no GitHub access or
-session transcript to re-derive the claim from. Cross-referenced against
-commit `11003f9` ("docs: document per-call Opus override for a single
-Fable-blocked seat", #228, verified with `git show 11003f9`): that commit
-exists because the same workaround already had to be written down once
-before, in a prior batch. Two events across two separate occasions is a
-recurrence, not a first; it is not a measured failure rate, and this
-document does not treat it as one.
+During this batch, two judgment-seat dispatches failed with `You've reached
+your Fable 5 limit`, each forcing a per-call Opus override (the Agent tool's
+`model` param, per the documented fallback procedure). Both events, with the
+exact error string, are recorded on batch issue #262 alongside the decision to
+use the per-call override, the auditable record since this document's sandbox
+has no GitHub access or session transcript to re-derive the claim from.
+Cross-referenced against commit `11003f9` ("docs: document per-call Opus
+override for a single Fable-blocked seat", #228): that commit exists because
+the same workaround already had to be written down once before, in a prior
+batch. Two events across two separate occasions is a recurrence, not a first;
+it is not a measured failure rate, and this document does not treat it as one.
 
 Two standing costs from the pricing source (`claude-api` skill,
 `shared/models.md`):
 
 - Fable 5 requires 30-day data retention (not available under
-  zero-data-retention). A policy cost the current assignment already
-  pays, independent of anything measured here.
-- Opus 5 sits in a rate-limit bucket separate from the combined Opus 4.x
-  pool (reused as the recommendation's availability argument, section 8).
-  Whether an Opus 5 primary with an Opus 4.8 fallback is a net resilience
-  gain over today's Fable-primary, Opus-4.8-fallback arrangement is not
-  established here; both already cross model families for their fallback.
+  zero-data-retention). A policy cost the current assignment already pays,
+  independent of anything measured here.
+- Opus 5 sits in a rate-limit bucket separate from the combined Opus 4.x pool
+  (reused as the recommendation's availability argument, section 8). Whether
+  that is a net resilience gain over today's Fable-primary, Opus-4.8-fallback
+  arrangement is not established here.
 
-Opus 5's prompt-cache minimum dropped to 512 tokens (from 1024 on
-Opus 4.8), but this repo's own measured bootstrap contexts run
-12k-22k tokens (driver 1 of the token-burn investigation), so that
-change is marginal here and does not support the recommendation below.
+Opus 5's prompt-cache minimum dropped to 512 tokens (from 1024 on Opus 4.8),
+but this repo's bootstrap contexts run 12k-22k tokens (driver 1 of the
+token-burn investigation), so the change is marginal here.
 
 ## 6. Capability
 
 No first-party comparison of Opus 5 against Fable 5 on this repo's own
-judgment tasks (sub-plans, PR reviews, codebase-review critiques) exists.
-The only capability signal is vendor positioning, the weakest evidence
-class, quoted and labeled as such: `shared/models.md` describes Opus 5 as
-"a step-change over Claude Opus 4.8... at half the cost of Claude Fable 5
-(Claude Fable 5 remains the highest-capability tier)," and separately
-calls Fable 5 "Anthropic's most capable widely released model." Taken at
-face value, the vendor's own framing puts Fable 5 above Opus 5 on
-capability, arguing against moving the judgment seats for quality
-reasons, not for it. This repo's `docs/team-guide-rationale.md` DeepSWE
-leaderboard note ("Fable 5 at max scores the same as at high... Sonnet 5
-at max is dominated by Fable 5") compares effort levels and Sonnet
-against Fable, not Opus 5 against Fable, so it does not bear here.
+judgment tasks (sub-plans, PR reviews, codebase-review critiques) exists. The
+only capability signal is vendor positioning, the weakest evidence class,
+quoted and labeled as such: `shared/models.md` describes Opus 5 as "a
+step-change over Claude Opus 4.8... at half the cost of Claude Fable 5 (Claude
+Fable 5 remains the highest-capability tier)," and separately calls Fable 5
+"Anthropic's most capable widely released model." Taken at face value, the
+vendor's own framing puts Fable 5 above Opus 5 on capability, arguing against
+moving the judgment seats for quality reasons, not for it. This repo's
+`docs/team-guide-rationale.md` DeepSWE leaderboard note ("Fable 5 at max
+scores the same as at high... Sonnet 5 at max is dominated by Fable 5")
+compares effort levels and Sonnet against Fable, not Opus 5 against Fable, so
+it does not bear here.
 
 ## 7. Change surface and prompt rework
 
-Scope note: `grep -rn "fable\|Fable" .claude/ docs/` (below) does not
-cover the repo root, so this is a partial inventory, not a full one.
-`architect.md` and `reviewer.md` frontmatter (`model: fable` plus a
-fallback comment naming Opus), the three workflow critic stages
-(`tm-review-changes.js:146`, `tm-review-codebase.js:248`,
-`tm-map-codebase.js:236`), the three `SKILL.md` files describing the
-critic as Fable, and `team-guide.md`/`team-guide-rationale.md` as the
-policy's own prose (edit sites for any future change, not touched here).
+Scope note: `grep -rn "fable\|Fable" .claude/ docs/` (below) does not cover
+the repo root, so this is a partial inventory, not a full one. `architect.md`
+and `reviewer.md` frontmatter (`model: fable` plus a fallback comment naming
+Opus), the three workflow critic stages (`tm-review-changes.js:146`,
+`tm-review-codebase.js:248`, `tm-map-codebase.js:236`), the three `SKILL.md`
+files describing the critic as Fable, and
+`team-guide.md`/`team-guide-rationale.md` as the policy's own prose (edit
+sites for any future change, not touched here).
 
-Re-run from the repo root and two more lead-seat hardcodes surface, both
-stale as soon as the lead moves: `README.md` (7 hits; line 77,
-`fable, xhigh` on the lead node) and `docs/team-architecture.md:33`
-(`LEAD - main session (fable, xhigh effort)`) - the latter was already
-inside the `.claude`/`docs` scope above and simply left off the list.
-Neither is frontmatter or asserted in `npm test`, so neither is blocked
-by the effort-policy failure below, but both need editing alongside any
-lead-seat move.
+Re-run from the repo root and two more lead-seat hardcodes surface, both stale
+as soon as the lead moves: `README.md` (7 hits; line 77, `fable, xhigh` on the
+lead node) and `docs/team-architecture.md:33` (`LEAD - main session (fable,
+xhigh effort)`) - the latter was already inside the `.claude`/`docs` scope
+above and simply left off the list. Neither is frontmatter or asserted in `npm
+test`, so neither is blocked by the effort-policy failure below, but both need
+editing alongside any lead-seat move.
 
 **Flag prominently:** `.claude/workflows/__tests__/effort-policy.test.mjs:21`
-defines `EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh' }` with no
-`opus` key. Read against the test body (lines 37-61): flipping any
-frontmatter or workflow-stage `model:` to `opus` fails with "pins model
-'opus', which has no effort rule." The documented Fable-outage fallback
-(flip the pins to `opus` for a longer outage) is blocked by this repo's
-own test today. This is real rework, not a hypothetical: option (b), and
-the architect/reviewer half of option (c) if ever extended, cannot ship
-until a follow-up issue adds an `opus` entry to `EFFORT_BY_MODEL`. That
-follow-up is not done in this package.
+defines `EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh' }` with no `opus`
+key. Read against the test body (lines 37-61): flipping any frontmatter or
+workflow-stage `model:` to `opus` fails with "pins model 'opus', which has no
+effort rule." The documented Fable-outage fallback (flip the pins to `opus`
+for a longer outage) is blocked by this repo's own test today. This is real
+rework, not a hypothetical: option (b), and the architect/reviewer half of
+option (c) if ever extended, cannot ship until a follow-up issue adds an
+`opus` entry to `EFFORT_BY_MODEL`. That follow-up is not done in this package.
 
-One consequence worth flagging, verified directly: the same
-`shared/models.md` alias table (lines 114-138) maps the bare alias
-"opus" to `claude-opus-5`, not `claude-opus-4-8`. If Claude Code's own
-frontmatter `model: opus` resolves through the same alias table (not
-independently confirmed, but the two systems share Anthropic's model
-naming), the documented Fable-outage fallback would already land on
-Opus 5 today (section 2 notes the mid-session #263 rename that makes the
-prose track this). Worth reconciling in the same follow-up that adds the
-`opus` effort-policy entry.
+One consequence worth flagging: the same `shared/models.md` alias table (lines
+114-138) maps the bare alias "opus" to `claude-opus-5`, not `claude-opus-4-8`.
+If Claude Code's frontmatter `model: opus` resolves through that table (not
+independently confirmed, but the two systems share Anthropic's naming), the
+documented Fable-outage fallback already lands on Opus 5 today (section 2
+notes the #263 rename that makes the prose track this) - worth reconciling in
+the same follow-up.
 
 Prompt rework specific to any Opus 5 shift, tied to each documented behavior
-change (`claude-api` bundled skill, `shared/model-migration.md`, "Migrating
-to Claude Opus 5" > "Behavioral shifts (prompt-tunable)", lines 1029-1098; a
+change (`claude-api` bundled skill, `shared/model-migration.md`, "Migrating to
+Claude Opus 5" > "Behavioral shifts (prompt-tunable)", lines 1029-1098; a
 vendor migration guide, the same weakest evidence class as section 6):
 
-- **Longer default output.** `reviewer.md`'s report contract fixes
-  structure (`VERDICT`/`STAGE`/`FINDINGS`) but sets no length bound. A
-  longer-by-default reviewer inflates every fix-round input and PR
-  comment; worth a length hint if reviewer moves.
+- **Longer default output.** `reviewer.md`'s report contract fixes structure
+  (`VERDICT`/`STAGE`/`FINDINGS`) but sets no length bound; a longer-by-default
+  reviewer inflates every fix-round input, worth a length hint if it moves.
 - **Self-verification without being asked, distinguished carefully.**
-  Self-check scaffolding aimed at a model's own output can become
-  redundant if the model already double-checks itself. That does not
-  apply to the workflow critic's consolidation step: `tm-review-changes.js:145`
-  instructs the critic to "verify it against the actual diff" for the
-  *parallel Sonnet reviewers'* raw findings, not the critic's own work. A
-  doc that told a maintainer to strip that instruction because "the model
-  self-verifies now" would remove a real cross-check on other agents, not
-  redundant scaffolding. Do not remove it.
+  Self-check scaffolding aimed at a model's own output can become redundant if
+  the model already double-checks itself. That does not apply to the workflow
+  critic's consolidation step: `tm-review-changes.js:145` instructs the critic
+  to "verify it against the actual diff" for the *parallel Sonnet reviewers'*
+  raw findings, not the critic's own work. A doc that told a maintainer to
+  strip that instruction because "the model self-verifies now" would remove a
+  real cross-check on other agents, not redundant scaffolding. Do not remove
+  it.
 - **Readier delegation, priced as a lead-seat risk.** `architect.md`/
-  `reviewer.md` have no Task tool, so those two seats are structurally
-  bounded regardless of model. The lead is not, and the lead is where the
-  one measured over-spawn failure in this repo's testing came from
+  `reviewer.md` have no Task tool, so those two seats are structurally bounded
+  regardless of model. The lead is not, and the lead is where the one measured
+  over-spawn failure in this repo's testing came from
   (`docs/reviews/2026-06-30-orchestration-comparison.md` addendum: the
-  unbounded arm alone reached 288 of a combined 297 agents and about
-  5.64M subagent tokens over ~51 minutes and died on an organization-wide
-  spend cap, against the bounded arm's 9). That trial measured the
-  construction's behavior on Sonnet 5, not a live session's own free-form
-  choice, and not Opus 5 at all, so it is evidence about unbounded
-  construction risk in general, not a measured Opus 5 spawning rate. If
-  the lead moves to Opus 5, an explicit
-  delegation cap is the mitigation this risk calls for, not a general
-  policy change.
-- **Task-scope expansion.** Hits `architect.md`'s advisory role and
-  collides with `reviewer.md`'s pass-1 rule that "scope creep... [is a]
-  blocking finding, even when the extra code is good." Watch for this
-  before trusting either seat unsupervised on a new model.
-- **Effort ceiling.** No change needed: Opus 5's effort ladder runs
-  through `max`, so `xhigh` (this policy's ceiling) is already available.
+  unbounded arm alone reached 288 of a combined 297 agents, out of about 5.64M
+  subagent tokens the two arms used combined, over ~51 minutes, and died on an
+  organization-wide spend cap, against the bounded arm's 9). That trial
+  measured Sonnet 5's behavior under an unpinned construction, not a live
+  session's free-form choice and not Opus 5 at all, so it is evidence about
+  unbounded construction risk in general, not a measured Opus 5 spawning rate.
+  An explicit delegation cap is the mitigation this risk calls for if the lead
+  moves, not a general policy change.
+- **Task-scope expansion.** Hits `architect.md`'s advisory role and collides
+  with `reviewer.md`'s pass-1 rule that "scope creep... [is a] blocking
+  finding, even when the extra code is good." Watch for it before trusting
+  either seat unsupervised.
+- **Effort ceiling.** No change needed: Opus 5's effort ladder runs through
+  `max`, so `xhigh` (this policy's ceiling) is already available.
 
 ## 8. Recommendation and confidence
 
 **Move the lead seat from Fable 5 to Opus 5 now (`/model claude-opus-5`);
-leave architect, reviewer, and the three workflow critic stages on
-Fable 5 until the effort-policy test gains an `opus` tier in a follow-up
-issue. Confidence: medium.**
+leave architect, reviewer, and the three workflow critic stages on Fable 5
+until the effort-policy test gains an `opus` tier in a follow-up issue.
+Confidence: medium.**
 
-This is option (c), not (b): a full move is blocked today by a real,
-verified test failure (section 7), and the vendor's own capability claim
-(section 6) argues against moving the two structurally-bounded judgment
-seats for quality reasons alone. The lead-only move is not blocked by
-that test (the lead's model is not frontmatter-pinned or asserted
-anywhere in `npm test`), captures a real and potentially majority share
-of the available savings (lead is the single largest token consumer in
-this repo's own aggregate data, section 4). That dollar range may not
-translate under this repo's Max-plan subscription, where nothing measures
-whether a lower per-token price buys more quota (below); what does bite
-here is availability - Opus 5 sits in its own rate-limit bucket, separate
-from the combined Opus 4.x pool (section 5), and this batch alone hit the
-Fable-5 limit twice. Moving the lead off the shared Fable pool removes
-that already-observed failure mode regardless of whether the dollar
-saving above translates into quota saved. Its blast radius is also
-contained: per `docs/reviews/2026-06-30-orchestration-comparison.md`'s
-Corollary, the pipeline pins architect and reviewer regardless of which
-model leads, so a lead-model change affects only the lead's own direct
-judgment work (scoping, parking decisions, un-delegated writing), not the
-review or sub-plan quality the pipeline already guarantees through
-Fable-pinned subagents.
+This is option (c), not (b): a full move is blocked today by a real, verified
+test failure (section 7), and the vendor's own capability claim (section 6)
+argues against moving the two structurally-bounded judgment seats for quality
+reasons alone. The lead-only move is not blocked by that test (the lead's
+model is not frontmatter-pinned or asserted anywhere in `npm test`), captures
+a real and potentially majority share of the available savings (lead is the
+single largest token consumer in this repo's own aggregate data, section 4).
+That dollar range may not translate under this repo's Max-plan subscription,
+where nothing measures whether a lower per-token price buys more quota
+(below); what does bite here is availability - Opus 5 sits in its own
+rate-limit bucket, separate from the combined Opus 4.x pool (section 5), and
+this batch alone hit the Fable-5 limit twice. Moving the lead off the shared
+Fable pool reduces exposure to that already-observed failure mode (it does not
+remove it: architect, reviewer, and the critics stay on Fable and can still
+hit the limit), regardless of whether the dollar saving above translates into
+quota saved. Its blast radius is also contained: per
+`docs/reviews/2026-06-30-orchestration-comparison.md`'s Corollary, the
+pipeline pins architect and reviewer regardless of which model leads, so a
+lead-model change affects only the lead's own direct judgment work (scoping,
+parking decisions, un-delegated writing), not the review or sub-plan quality
+the pipeline already guarantees.
 
-That Corollary section doesn't stop at containment: run on Sonnet 5 vs
-Opus 4.8, it reached the opposite conclusion - keep the stronger model in
-the lead seat, since the lead's own un-delegated judgment is the one
-place model choice isn't backstopped by the pipeline. The same logic, run
-on this document's own numbers, would favor keeping Fable 5: section 6's
-only capability signal, vendor positioning, ranks Fable 5 above Opus 5,
-so a lead-only move accepts the same kind of judgment risk that report
-argued against taking. Two things distinguish this case rather than
-defeat it: that report's swap had no offsetting pressure and explicitly
-kept Opus as lead, where sections 4 and 5 here document real pressure
-absent there (a 2x per-token premium, two recorded Fable-limit failures);
-and the vendor positions Opus 5 itself as narrowing that gap ("a
-step-change over Claude Opus 4.8... at half the cost of Claude Fable 5",
-section 6), not a repeat of the older Opus-4.8-vs-Sonnet-5 comparison.
-Neither point is capability evidence; both are why confidence stays
-medium rather than treating containment alone as sufficient, and why
-section 9's revert trigger names exactly the judgment-quality signal the
-Corollary flags.
+That Corollary section doesn't stop at containment: run on Sonnet 5 vs Opus
+4.8, it reached the opposite conclusion, keep the stronger model in the lead
+seat, since the lead's own un-delegated judgment is the one place model choice
+isn't backstopped by the pipeline. Its cost argument does not distinguish this
+case: the Corollary weighed comparable pressure (1.67x at sticker, 2.5x at the
+intro rate, against this document's 2.0x), said "Cost cuts the other way," and
+rejected the swap anyway, discounting its own case as unverified under the
+Max-plan subscription, the same discount section 8 applies here. What does
+distinguish this case is a floor claim, not a ranking claim: the Corollary's
+own conclusion, "keep Opus 4.8 as the default lead," argues against dropping
+the lead below Opus class, not that only the top-ranked model may hold the
+seat. This repo ran an Opus-class lead by policy until commit 7fd326e (#133)
+replaced it with Fable 5 (`git show 248d672 -- CLAUDE.md`); nothing in the
+record calls that inadequate, and #133 moved up because a stronger model
+appeared, not because Opus failed. Opus 5 is that model's successor at
+identical pricing and is already this repo's documented judgment-seat
+fallback, per commit ec14b7a (#263); this needs only "Opus 5 is at least Opus
+4.8's equal," nothing about the size of the gap to Fable 5.
 
-What caps this at medium rather than high: the precise dollar/quota
-savings from moving the lead alone are bounded (around 40.9% at sticker
-pricing, 43.6% at the live intro rate, section 4) but not pinned, since
-driver-3 does not publish a lead-only breakdown; "affordable" in the
-current policy is a Max-plan quota claim, and nothing here measures
-whether Opus 5's lower per-token price actually buys more quota; the two
-Fable-limit events are a recurrence, not a measured rate, so the
-availability case is real but modest; Opus 5's own spawning tendency as a
-lead is unmeasured (section 7's only data point is a Sonnet 5 trial); no
-first-party comparison of Opus 5 against Fable 5 on this repo's own
-judgment tasks exists, and the only capability signal available, vendor
-positioning, ranks Fable 5 above Opus 5 (section 6); and the pricing this
-recommendation is built on is itself cached, not live, with no embedded
+Availability is genuinely new; the Corollary has no availability fact or
+argument anywhere. But precisely: the two recorded events (section 5) were
+subagent judgment-seat dispatches recovered by a per-call Opus override, not
+lead-seat blocks; with the prior occurrence behind commit 11003f9 they are a
+recurrence across three occasions, not a rate; and moving the lead off Fable
+reduces exhaustion pressure on a shared pool the lead plausibly dominates
+(section 4), it does not remove the failure mode noted above. This also
+collides with the Model policy's opening line, "the strongest model in every
+plan/decision seat" (`.claude/team-guide.md`): commit 7fd326e (#133), one day
+after the Corollary, moved the lead to Fable for that reason, ratifying the
+Corollary's principle into standing policy rather than superseding it. A
+lead-only move to Opus 5 is an exception to that line, resolved by the
+policy's own fallback trigger ("unavailable, rate-limited, quota-exhausted" as
+grounds to run the lead on Opus), except that the exhaustion recurs rather
+than being one-off; the follow-up issue implementing this amends the
+orchestrator bullet, a human sign-off item, not a decision made here. The only
+capability signal still points the other way, vendor positioning ranking Fable
+5 above Opus 5 (section 6); that concession stays tied to the confidence cap
+below, not argued around.
+
+What caps this at medium rather than high: the precise dollar/quota savings
+from moving the lead alone are bounded (around 40.9% at sticker pricing, 43.6%
+at the live intro rate, section 4) but not pinned, since driver-3 does not
+publish a lead-only breakdown; "affordable" in the current policy is a
+Max-plan quota claim, and nothing here measures whether Opus 5's lower
+per-token price actually buys more quota; the two Fable-limit events are a
+recurrence, not a rate, so the availability case is real but modest; Opus 5's
+own spawning tendency as a lead is unmeasured (section 7's only data point is
+a Sonnet 5 trial); no first-party comparison of Opus 5 against Fable 5 exists,
+and the only capability signal, vendor positioning, ranks Fable 5 above Opus 5
+(section 6); and the pricing here is itself cached, not live, with no embedded
 cache date (section 4).
 
 ## 9. What would have to be true to revisit
 
 **To extend the move to architect, reviewer, and the critics:** the
-effort-policy test gains an `opus` tier (a follow-up issue, not this
-package); a repo-scoped comparison (a `tm-ab-test` run per role, since
-none has run yet) shows Opus 5's judgment output on this repo's own
-sub-plans or reviews holds up against Fable 5's, not just against vendor
-positioning; or Fable-limit exhaustion events recur often enough to look
-like a rate rather than two isolated incidents.
+effort-policy test gains an `opus` tier (a follow-up issue, not this package);
+a repo-scoped comparison (a `tm-ab-test` run per role, since none has run yet)
+shows Opus 5's judgment output on this repo's own sub-plans or reviews holds
+up against Fable 5's, not just against vendor positioning; or Fable-limit
+exhaustion events recur often enough to look like a rate rather than two
+isolated incidents.
 
-**To revert the lead-only move:** the lead's own scoping and parking
-decisions visibly degrade on Opus 5, traceable to real batch outcomes
-(missed scope calls, more parked `needs-human` items than before); a
-measured Max-plan quota check (per the existing "Cost-based fallback
-trigger" bullet) shows Opus 5's lower dollar price does not translate
-into lower quota consumption for the lead seat; or Opus 5 shows the same
-unbounded-delegation tendency the addendum measured for Sonnet 5, without
-the recommended delegation cap in place.
+**To revert the lead-only move:** the lead's own scoping and parking decisions
+visibly degrade on Opus 5, traceable to real batch outcomes (missed scope
+calls, more parked `needs-human` items than before); a measured Max-plan quota
+check (per the existing "Cost-based fallback trigger" bullet) shows Opus 5's
+lower dollar price does not translate into lower quota consumption for the
+lead seat; or Opus 5 shows the same unbounded-delegation tendency the addendum
+measured for Sonnet 5, without the recommended delegation cap in place.
 
 ## 10. Sources and limitations
 
-- `docs/research/2026-07-06-token-burn-investigation.md` (sections 3, 4,
-  5) and its script, `docs/research/2026-07-06-token-burn-analyze.mjs`
-  (lines 55-87).
+- `docs/research/2026-07-06-token-burn-investigation.md` (sections 3, 4, 5)
+  and its script, `docs/research/2026-07-06-token-burn-analyze.mjs` (lines
+  55-87).
 - `docs/reviews/2026-07-13-ab-plan-status-parser.md` and
   `docs/reviews/ab-tests.md`.
-- `docs/reviews/2026-06-30-orchestration-comparison.md` (Corollary,
-  addendum, and the $3/$15 vs $5/$25 pricing cross-check).
+- `docs/reviews/2026-06-30-orchestration-comparison.md` (Corollary, addendum,
+  and the $3/$15 vs $5/$25 pricing cross-check).
 - `claude-api` bundled skill: `shared/models.md` (self-described as cached,
   not live, at line 7, no embedded cache date; recommends the Models API for
   anything capability-related, which this document did not run);
   `shared/model-migration.md:1192` (Sonnet 5 pricing) and its "Migrating to
   Claude Opus 5" > "Behavioral shifts (prompt-tunable)" section, lines
-  1029-1098 (section 7's behavior-shift claims, a vendor migration guide,
-  the same weakest evidence class as section 6's capability claims);
+  1029-1098 (section 7's behavior-shift claims, a vendor migration guide, the
+  same weakest evidence class as section 6's capability claims);
   `python/claude-api/README.md:502` (Sonnet 5 pricing).
 - `.claude/team-guide.md`, `docs/team-guide-rationale.md`,
   `.claude/agents/architect.md`, `.claude/agents/reviewer.md`,
   `.claude/workflows/tm-review-changes.js`,
-  `.claude/workflows/__tests__/effort-policy.test.mjs`, and commit
-  `11003f9`, all read directly for this document.
+  `.claude/workflows/__tests__/effort-policy.test.mjs`, and commit `11003f9`,
+  all read directly for this document.
 
-Limitations: the price correction in section 4 is arithmetic, not a
-re-run against real transcripts (transcripts were not reachable from this
-worktree); the batch #201 and single-package dollar figures both predate
-current pricing and were not independently re-derived beyond the one
-worked example; capability evidence is vendor-only; and the two
-availability events are anecdote, explicitly not a rate.
+Limitations: the price correction in section 4 is arithmetic, not a re-run
+against real transcripts (transcripts were not reachable from this worktree);
+the batch #201 and single-package dollar figures both predate current pricing
+and were not independently re-derived beyond the one worked example;
+capability evidence is vendor-only; and the two availability events are
+anecdote, explicitly not a rate.

--- a/docs/team-guide-rationale.md
+++ b/docs/team-guide-rationale.md
@@ -68,8 +68,8 @@ until quality drops.
 
 ### Orchestrator: aggregate vs. per-batch token share
 
-Supports: "Fable costs 2x Opus 4.8 per token and weighs correspondingly
-against Max-plan quota. The premium is bounded in aggregate, not per batch."
+Supports: "Fable costs 2x Opus 5 per token. The premium is bounded in
+aggregate, not per batch."
 
 Across the 14-day, 25-project aggregate, Fable's own token share stays small
 (5.5% raw, 18.7% weighted proxy), but within a single kickoff batch it flips:


### PR DESCRIPTION
Batch #262, run through `/tm-advisor`, plus one follow-up commit requested directly. Two packages, one branch — this session is pinned to a single branch, so both land here as separate commits instead of one PR each. Rationale and cost of that deviation are logged on #262.

Closes #263
Closes #264

## Why

Opus 5 shipped. The question was whether the agent and skill instructions still name the right models. They mostly do — every seat pins an alias (`fable`, `sonnet`), and aliases already resolve to the current model, so nothing was running on a superseded model. What was stale is the procedure text a human copy-pastes, and this batch proved that is not a cosmetic distinction: both judgment-seat dispatches hit `You've reached your Fable 5 limit` mid-run, and the remedy the team guide told the operator to run was `/model claude-opus-4-8`.

## What changed

Seven commits: one for #263, five for #264, one follow-up.

**Package #263 — model references** (`ec14b7a`, 5 files, 10 insertions / 10 deletions)

Eight targeted string edits, in place, with no paragraph re-flow; every replacement is two characters shorter than the original, so the diff stays readable.

- `.claude/team-guide.md` — the `/model` command in the Fable-outage procedure, the fallback-seat line, the 2x cost claim, the permanent-move trigger, and the `CLAUDE_CODE_SUBAGENT_MODEL` seatbelt example
- `.claude/workflows/tm-{map-codebase,review-changes,review-codebase}.js` — the header comment naming the fallback
- `docs/team-guide-rationale.md` — the first `Supports:` quote

**Package #264 — Opus 5 vs Fable 5 for the judgment seats** (`898bcc4`, `d68dedf`, `d1c0301`, `adb8ef5`, `6f73e2d`)

Adds `docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md`, 442 lines. A recommendation only: it changes no policy, no pin, and no workflow stage.

Its recommendation is a **split, not a clean move** — take the lead seat to Opus 5 now, and hold architect, reviewer and the three workflow critic stages on Fable 5 until the effort-policy test gains an `opus` tier. Confidence: medium. The doc also records that the vendor's own model card still ranks Fable 5 above Opus 5 on capability, which is evidence against a full move, labeled as a vendor claim rather than a measurement.

Two substantive corrections it makes to this repo's existing numbers:

- **The repo's published dollar figures overstate Fable's share.** `docs/research/2026-07-06-token-burn-analyze.mjs` prices Opus at $15/$75 and Sonnet at one fifth of Opus; at current pricing Sonnet is three fifths. Re-derived, batch #201's Fable-priced weighted share is **81.9%**, not the published 93.3% — and the uniform-bucket-mix assumption behind that is validated against the source's own numbers (93.1% predicted vs 93.3% measured)
- **Halving that slice cuts batch-level spend by 40.9%** at sticker pricing, or **43.6%** at Sonnet's introductory rate, which is live through 2026-08-31

**Follow-up — the Opus 5 fallback is now usable** (`089f754`, 3 files, 10 insertions / 3 deletions)

The Model policy tells an operator to flip the `fable` pins to `opus` for a longer Fable outage. Following that instruction failed `npm test`: `EFFORT_BY_MODEL` in `effort-policy.test.mjs` had no `opus` key, so any flipped seat tripped `model "opus" has no effort rule`. The documented recovery path could not be taken without also editing the test that polices it — and this batch needed that path twice.

`opus` now carries fable's `xhigh`, so a flipped seat keeps its effort. Verified in both directions: with all five judgment pins flipped to `opus` the suite passes 65/65, and removing the tier reproduces the failure. Both agent frontmatter comments now name Opus 5 explicitly. No existing `effort:` pin was touched.

This also clears the blocker behind #264's split recommendation — see open question 2 below.

## The finding that outlives this PR

**Acting on #264's recommendation is an exception to written Model policy, not a config change.**

An architect arbitration found that commit `7fd326e` (#133), landed one day after the 2026-06-30 Corollary report, moved the lead to Fable with the reasoning that the lead "routes every handoff, refines batches, and makes the dispatch decisions, so it gets the strongest model" — ratifying the Corollary's principle into the policy line "The strongest model in every plan/decision seat." A lead-only move to Opus 5 is an exception to it, and the follow-up amends the orchestrator bullet.

**Merging this PR does not imply that decision.** The doc says so itself.

The recommendation rests on a floor claim, not on cost. The cost argument was conceded outright: the Corollary weighed comparable pressure (1.67x-2.5x against this doc's 2.0x), said "Cost cuts the other way", and rejected the swap anyway.

## Two things a reviewer should know

**The rationale quote was already broken, and `ec14b7a` removes a clause rather than substituting one.** `docs/team-guide-rationale.md:71` claimed to quote the team guide but carried `and weighs correspondingly against Max-plan quota`, a clause the team guide itself lost in `de2d0f4` (#225). The verbatim-match acceptance criterion exposed pre-existing drift, not just a stale model name. It was trimmed to match the team guide rather than restoring the clause upstream, because #225 deliberately shrank that injected file. Decision logged on #262, independently seconded by the reviewer.

**Every remaining "Opus 4.8" string in the repo is a historical record and was deliberately left alone.** A full sweep found 27 hits, all in dated files: measured token-count tables where `claude-opus-4-8` rows are real usage, a price table using the then-current $15/$75 tier, a dated report comparing Sonnet 5 against Opus 4.8, `Co-Authored-By` commit trailers, and the new research doc's deliberate citations. Renaming any of them would put false statements into the record. Nothing in live machinery still names Opus 4.8.

## Open questions for you

1. `.claude/team-guide.md:192` now couples a price ratio to a version name, the same coupling that made this issue necessary. It will go stale at the next model bump. Rewording to the tier ("2x the Opus tier") would decouple it, but criterion 2 mandated naming Opus 5, so widening scope is your call
2. ~~The team guide's other Fable-outage remedy fails `npm test`.~~ **Fixed in `089f754`.** Note this partially undercuts #264's split recommendation, which held architect, reviewer and the critic stages back specifically because of this blocker. The capability argument for holding them (vendor positioning still ranks Fable above Opus 5) is unaffected and stands on its own
3. One residual nit: line 241 of the research doc says "the effort-policy failure" where "blocker" is accurate. Disclosed rather than silently patched

## Verification

- `grep -rn "opus-4-8\|Opus 4.8\|sonnet-4-6" .claude/` returns nothing
- `npm test` 65/65 on the final commit
- Both `Supports:` quotes diffed character by character against their team-guide sentences
- No `model:` frontmatter pin or workflow stage pin changed; no `effort:` pin changed; no dated record edited; every #264 commit touches only the research doc
- **#263:** tester PASS round 1, reviewer APPROVE round 1, zero findings against the diff
- **#264:** tester FAIL -> PASS -> FAIL -> arbitration -> PASS; reviewer CHANGES_REQUESTED -> APPROVE; plus one fact-checker audit (26 claims verified, 3 contradicted) and one architect arbitration
- **`089f754`:** verified by flipping all five judgment pins to `opus` (65/65 pass) and by removing the tier to reproduce the original failure

This repo has no `.github/workflows/`, so there are no CI checks on this PR. `npm test` run locally is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMT3YhDmHtzrnTkfTwVWth