### PR TITLE
Harden the Fable outage path: workflow auto-recovery, first CI, and a research-doc addendum

### DIFF
--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -196,8 +196,9 @@ Rationale: docs/team-guide-rationale.md.
   Fable 5 is unavailable, rate-limited, quota-exhausted, or
   refuses the workload, switch the lead with `/model claude-opus-5`; for a
   longer outage flip the `fable` pins to `opus` in the `architect` and
-  `reviewer` frontmatters and the Fable-critic stage of every `tm-` workflow
-  (`.claude/workflows/`). Flip back when Fable returns. For a single
+  `reviewer` frontmatters (the Fable-critic stage of every `tm-` workflow
+  already retries on opus automatically when Fable returns nothing, no flip
+  needed there; `.claude/workflows/`). Flip back when Fable returns. For a single
   role-agent dispatch hitting Fable quota mid-batch, dispatch that one agent
   with a per-call Opus override (the Agent tool's `model` param) instead of
   flipping every pin. The ladder is Fable -> Opus; Sonnet is never a fallback

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -196,12 +196,14 @@ Rationale: docs/team-guide-rationale.md.
   Fable 5 is unavailable, rate-limited, quota-exhausted, or
   refuses the workload, switch the lead with `/model claude-opus-5`; for a
   longer outage flip the `fable` pins to `opus` in the `architect` and
-  `reviewer` frontmatters (the Fable-critic stage of every `tm-` workflow
-  already retries on opus automatically when Fable returns nothing, no flip
-  needed there; `.claude/workflows/`). Flip back when Fable returns. For a single
-  role-agent dispatch hitting Fable quota mid-batch, dispatch that one agent
-  with a per-call Opus override (the Agent tool's `model` param) instead of
-  flipping every pin. The ladder is Fable -> Opus; Sonnet is never a fallback
+  `reviewer` frontmatters. The Fable-critic stage of every `tm-` workflow
+  (`.claude/workflows/`) already retries on opus automatically when Fable
+  returns nothing, so no flip is needed there, though each run still burns
+  one doomed Fable dispatch before the retry fires. Flip back when Fable
+  returns. For a single role-agent dispatch hitting Fable quota mid-batch,
+  dispatch that one agent with a per-call Opus override (the Agent tool's
+  `model` param) instead of flipping every pin. The ladder is Fable -> Opus;
+  Sonnet is never a fallback
   for a judgment seat, and only steps in, flagged, if Opus is also down, with
   the review re-run on a judgment model afterward.
 - Cost-based fallback trigger: if Fable 5 stops being included under the

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -71,7 +71,11 @@ describe('agent frontmatter effort pins', () => {
 //
 // Agent-call opts in both workflows are single-line objects carrying both
 // label: and model:. The meta.phases display entries carry model: but
-// title:/detail: instead of label:, so requiring label: excludes them.
+// title:/detail: instead of label:, so requiring label: excludes them. The
+// criticWithFallback retry opts (`{ ...opts, model: 'opus' }`) also carry
+// model: with no label: and no literal effort:, so the same filter excludes
+// them too; that is safe because the spread inherits effort: from the
+// caller's opts line, which this test already checks.
 // ===========================================================================
 describe('workflow stage effort pins', () => {
   for (const file of WORKFLOW_FILES) {

--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -482,9 +482,14 @@ describe('criticWithFallback', () => {
   })
 
   test('every workflow file wires the critic call through criticWithFallback', () => {
+    // Assert on 'await criticWithFallback(', not the bare function name: the
+    // declaration line ('async function criticWithFallback(...') also matches
+    // the bare name, so that substring is present even if the call site were
+    // reverted to `await agent(`. The declaration has no `await`, so this
+    // string only matches an actual call.
     for (const file of FILES) {
       const src = readFileSync(join(workflowsDir, file), 'utf8')
-      assert.ok(src.includes('criticWithFallback('), `${file} does not call criticWithFallback(`)
+      assert.ok(src.includes('await criticWithFallback('), `${file} does not call criticWithFallback(`)
     }
   })
 })

--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -10,6 +10,10 @@
  * union in tm-review-codebase.js. Those are tested as logic kernels - the
  * test captures the expression's shape, not the real source text. This is
  * the one honest seam; it is documented below and called out in the PR.
+ *
+ * loadFn() accepts an optional sandbox object so a function whose free
+ * variables are workflow runtime globals (agent, log) can be run with stub
+ * implementations instead of throwing ReferenceError.
  */
 
 import { test, describe } from 'node:test'
@@ -27,10 +31,12 @@ const workflowsDir = join(__dir, '..')
 // Helper: slice a named function out of a JS source file and evaluate it in a
 // vm context. Returns the function value.
 // ---------------------------------------------------------------------------
-function loadFn(filename, fnName) {
+function loadFn(filename, fnName, sandbox = {}) {
   const src = readFileSync(join(workflowsDir, filename), 'utf8')
-  // Match "function <fnName>(" - handles single-line bodies too.
-  const startRe = new RegExp(`function ${fnName}\\s*\\(`)
+  // Match "function <fnName>(", optionally preceded by "async" - handles
+  // single-line bodies too. The async keyword must stay inside the slice, or
+  // runInContext throws on the function's first await.
+  const startRe = new RegExp(`(?:async\\s+)?function ${fnName}\\s*\\(`)
   const startMatch = startRe.exec(src)
   if (!startMatch) throw new Error(`${fnName} not found in ${filename}`)
 
@@ -46,7 +52,7 @@ function loadFn(filename, fnName) {
   }
   const fnSrc = src.slice(startMatch.index, pos)
 
-  const ctx = createContext({})
+  const ctx = createContext(sandbox)
   runInContext(fnSrc, ctx)
   return runInContext(fnName, ctx)
 }
@@ -56,7 +62,7 @@ function loadFn(filename, fnName) {
 // ---------------------------------------------------------------------------
 function sliceFnSrc(filename, fnName) {
   const src = readFileSync(join(workflowsDir, filename), 'utf8')
-  const startRe = new RegExp(`function ${fnName}\\s*\\(`)
+  const startRe = new RegExp(`(?:async\\s+)?function ${fnName}\\s*\\(`)
   const startMatch = startRe.exec(src)
   if (!startMatch) throw new Error(`${fnName} not found in ${filename}`)
   let pos = startMatch.index
@@ -384,5 +390,101 @@ describe('scoutDropped union', () => {
       mapDropped: null,
     })
     assert.deepEqual(result, [])
+  })
+})
+
+// ===========================================================================
+// 5. criticWithFallback (issue #267)
+//
+// The helper's only free variables are the workflow runtime globals `agent`
+// and `log`. Supplying stubs as the vm sandbox runs the actual shipped code,
+// not a hand-copied version.
+// ===========================================================================
+describe('criticWithFallback', () => {
+  const FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
+  const baseOpts = { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: { type: 'object' } }
+
+  test('happy path: first agent call succeeds, result returned unchanged', async () => {
+    const calls = []
+    const logs = []
+    const sandbox = {
+      agent: async (prompt, opts) => {
+        calls.push({ prompt, opts })
+        return { verdict: 'approve' }
+      },
+      log: (msg) => logs.push(msg),
+    }
+    const criticWithFallback = loadFn('tm-review-changes.js', 'criticWithFallback', sandbox)
+
+    const result = await criticWithFallback('the prompt', baseOpts)
+
+    assert.deepEqual(result, { verdict: 'approve' })
+    assert.equal(calls.length, 1)
+    assert.equal(logs.length, 0)
+    assert.equal('modelFallback' in result, false)
+  })
+
+  test('first call returns null, retries on opus and succeeds', async () => {
+    const calls = []
+    const logs = []
+    const sandbox = {
+      agent: async (prompt, opts) => {
+        calls.push({ prompt, opts })
+        return calls.length === 1 ? null : { verdict: 'approve' }
+      },
+      log: (msg) => logs.push(msg),
+    }
+    const criticWithFallback = loadFn('tm-review-changes.js', 'criticWithFallback', sandbox)
+
+    const result = await criticWithFallback('the prompt', baseOpts)
+
+    assert.equal(calls.length, 2)
+    const secondOpts = calls[1].opts
+    assert.equal(secondOpts.model, 'opus')
+    assert.equal(secondOpts.effort, baseOpts.effort)
+    assert.equal(secondOpts.label, baseOpts.label)
+    assert.equal(secondOpts.phase, baseOpts.phase)
+    assert.equal(secondOpts.schema, baseOpts.schema)
+    assert.ok(calls[1].prompt.includes('the prompt'), 'second prompt still carries the original prompt')
+    assert.ok(calls[1].prompt.length > 'the prompt'.length, 'second prompt carries an added notice')
+    assert.equal(result.verdict, 'approve')
+    assert.equal(result.modelFallback, 'fable -> opus')
+    assert.ok(logs.length >= 1, 'log() must be called to surface the fallback')
+  })
+
+  test('both calls return null: throws naming the label and both models', async () => {
+    const sandbox = {
+      agent: async () => null,
+      log: () => {},
+    }
+    const criticWithFallback = loadFn('tm-review-changes.js', 'criticWithFallback', sandbox)
+
+    let threw = null
+    try {
+      await criticWithFallback('the prompt', baseOpts)
+    } catch (err) {
+      threw = err
+    }
+    assert.ok(threw, 'expected criticWithFallback to throw when both attempts return null')
+    // vm-realm errors are not `instanceof` the host's Error, so assert on the
+    // message rather than the error's prototype chain.
+    assert.match(threw.message, /consolidate/)
+    assert.match(threw.message, /fable/)
+    assert.match(threw.message, /opus/)
+  })
+
+  test('is byte-identical across all three workflow files', () => {
+    const a = sliceFnSrc('tm-review-changes.js', 'criticWithFallback')
+    const b = sliceFnSrc('tm-review-codebase.js', 'criticWithFallback')
+    const c = sliceFnSrc('tm-map-codebase.js', 'criticWithFallback')
+    assert.equal(a, b, 'criticWithFallback diverged between tm-review-changes.js and tm-review-codebase.js')
+    assert.equal(b, c, 'criticWithFallback diverged between tm-review-codebase.js and tm-map-codebase.js')
+  })
+
+  test('every workflow file wires the critic call through criticWithFallback', () => {
+    for (const file of FILES) {
+      const src = readFileSync(join(workflowsDir, file), 'utf8')
+      assert.ok(src.includes('criticWithFallback('), `${file} does not call criticWithFallback(`)
+    }
   })
 })

--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -430,7 +430,7 @@ describe('criticWithFallback', () => {
     const sandbox = {
       agent: async (prompt, opts) => {
         calls.push({ prompt, opts })
-        return calls.length === 1 ? null : { verdict: 'approve' }
+        return calls.length === 1 ? null : Object.freeze({ verdict: 'approve' })
       },
       log: (msg) => logs.push(msg),
     }

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -81,10 +81,10 @@ async function criticWithFallback(prompt, opts) {
   )
   if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
   log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
-  // Return a new object rather than mutating `second`: workflow scripts are ES
-  // modules (strict mode), and the runtime's returned object could be frozen,
-  // sealed, or proxied, which would throw a TypeError on exactly this
-  // fallback path.
+  // Return a new object rather than mutating `second`: the runtime's returned
+  // object could be frozen or sealed, in which case mutating it would either
+  // silently drop the `modelFallback` marker (sloppy mode) or throw a
+  // TypeError, and a proxied result could throw either way.
   return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -81,8 +81,11 @@ async function criticWithFallback(prompt, opts) {
   )
   if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
   log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
-  second.modelFallback = `${opts.model} -> opus`
-  return second
+  // Return a new object rather than mutating `second`: workflow scripts are ES
+  // modules (strict mode), and the runtime's returned object could be frozen,
+  // sealed, or proxied, which would throw a TypeError on exactly this
+  // fallback path.
+  return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 
 const AREA = {

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -15,8 +15,10 @@ export const meta = {
 // but never exceeds MAX_AREAS + 2, no matter how large the repo is or how many
 // areas the scout proposes. There is no per-file fan-out and no loop. Models and
 // effort are pinned per stage, so the session model and effort never leak into
-// the scout or the workers; the single critic runs Fable 5 at xhigh effort (flip
-// its model pin to 'opus' under the Opus 5 fallback, see team-guide).
+// the scout or the workers; the single critic runs Fable 5 at xhigh effort and
+// auto-retries once on opus at the same effort if Fable returns nothing
+// (criticWithFallback below; see team-guide for the lead-level fallback,
+// which is still manual).
 //
 // When the repo is too big for MAX_AREAS areas to cover, the leftover paths are
 // reported (coverage.areasDropped, coverage.ceilingReached, and a suggested next
@@ -55,6 +57,33 @@ function safeRef(value, fallback) {
 }
 const root = safeRef(opts.path, '.')
 const MAX_AREAS = Number.isInteger(opts.areas) && opts.areas > 0 ? opts.areas : 24
+
+// Duplicated byte-for-byte across the three tm- workflows that run a Fable
+// critic (the workflow runtime has no shared imports); keep this copy in
+// sync, see helpers.test.mjs.
+async function criticWithFallback(prompt, opts) {
+  const first = await agent(prompt, opts)
+  // agent() returns null both when the model errors out after retries (for
+  // example Fable 5 quota exhaustion) and when the user skips the dispatch
+  // mid-run. Nothing in this script can tell those two cases apart, so there
+  // is no heuristic to invent here. The ruling is on which failure mode is
+  // worse: retrying a deliberate skip costs one extra skip prompt (the retry
+  // is itself an agent() call, so skipping again just returns null and the
+  // run ends below with a clear error), while not retrying a quota death
+  // costs the entire unattended run. Retry unconditionally.
+  if (first) return first
+  log(
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on opus at the same effort. Skipping again will end the run.`
+  )
+  const second = await agent(
+    `${prompt}\n\nNOTE: this is a retry on the opus fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'opus' }
+  )
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
+  second.modelFallback = `${opts.model} -> opus`
+  return second
+}
 
 const AREA = {
   type: 'object',
@@ -231,7 +260,7 @@ const suggestedNextActionClause = ceilingReached
   ? `, and coverage.suggestedNextAction to ${JSON.stringify(suggestedNextAction)}`
   : ''
 
-const report = await agent(
+const report = await criticWithFallback(
   `You are the senior architect synthesizing a full-codebase map from the area descriptions below. This is a map, not a review: do not add findings, severities, recommendations, or quality and security judgments. Describe what is there.${coverageNote}\n\nRun \`date +%F\` for today's date, make the docs/architecture/ directory if it does not exist, and write docs/architecture/<date>-codebase-map.md with exactly these sections, in this order:\n1. Executive summary: what the repo is and how its areas fit together, in a few paragraphs.\n2. Component table: one row per area, with columns for area, purpose, and key modules.\n3. Data-flow narrative: how data moves across areas, end to end.\n4. Dependency summary: external dependencies (packages, services) and cross-area dependencies.\n5. Open questions: anything the workers could not determine or that needs a human to confirm.\n\nIf coverage is partial, add a "Coverage" callout immediately after the executive summary stating how many paths were not mapped and the suggested next action.\n\nSet reportPath to the file you wrote. Set summary to a short plain-language summary of the whole repo. Set openQuestions to the same list you put in the report's Open Questions section.\n\nSet coverage.areasMapped to ${JSON.stringify(mappedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nArea maps (JSON):\n${JSON.stringify(raw, null, 2)}`,
   { label: 'synthesize', phase: 'Synthesize', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }
 )

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -13,8 +13,9 @@ export const meta = {
 // one Fable critic. It cannot become the 100-agent fan-out that an unpinned
 // session-model review produces. Models and effort are pinned per
 // stage, so the session model and effort never leak into the workers; the
-// single critic runs Fable 5 at xhigh effort (flip its model pin to 'opus'
-// under the Opus 5 fallback, see team-guide).
+// single critic runs Fable 5 at xhigh effort and auto-retries once on opus
+// at the same effort if Fable returns nothing (criticWithFallback below;
+// see team-guide for the lead-level fallback, which is still manual).
 //
 // Invoke with an optional base ref:
 //   Workflow({ name: 'tm-review-changes', args: { base: 'origin/main' } })
@@ -26,6 +27,33 @@ function safeRef(value, fallback) {
   return typeof value === 'string' && /^[\w.~^\/\-]+$/.test(value) && !value.includes('..') ? value : fallback
 }
 const base = safeRef(args && args.base, 'origin/main')
+
+// Duplicated byte-for-byte across the three tm- workflows that run a Fable
+// critic (the workflow runtime has no shared imports); keep this copy in
+// sync, see helpers.test.mjs.
+async function criticWithFallback(prompt, opts) {
+  const first = await agent(prompt, opts)
+  // agent() returns null both when the model errors out after retries (for
+  // example Fable 5 quota exhaustion) and when the user skips the dispatch
+  // mid-run. Nothing in this script can tell those two cases apart, so there
+  // is no heuristic to invent here. The ruling is on which failure mode is
+  // worse: retrying a deliberate skip costs one extra skip prompt (the retry
+  // is itself an agent() call, so skipping again just returns null and the
+  // run ends below with a clear error), while not retrying a quota death
+  // costs the entire unattended run. Retry unconditionally.
+  if (first) return first
+  log(
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on opus at the same effort. Skipping again will end the run.`
+  )
+  const second = await agent(
+    `${prompt}\n\nNOTE: this is a retry on the opus fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'opus' }
+  )
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
+  second.modelFallback = `${opts.model} -> opus`
+  return second
+}
 
 // This list is diff-scoped and intentionally longer than tm-review-codebase's
 // per-area dimension list: docs and perf need diff context (what changed, and
@@ -141,7 +169,7 @@ const coverageNote = dropped.length
   : ''
 
 phase('Consolidate')
-const report = await agent(
+const report = await criticWithFallback(
   `You are the senior reviewer. ${covered.length} parallel reviewers produced the raw findings below.${coverageNote} ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
   { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }
 )

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -51,8 +51,11 @@ async function criticWithFallback(prompt, opts) {
   )
   if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
   log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
-  second.modelFallback = `${opts.model} -> opus`
-  return second
+  // Return a new object rather than mutating `second`: workflow scripts are ES
+  // modules (strict mode), and the runtime's returned object could be frozen,
+  // sealed, or proxied, which would throw a TypeError on exactly this
+  // fallback path.
+  return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 
 // This list is diff-scoped and intentionally longer than tm-review-codebase's

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -51,10 +51,10 @@ async function criticWithFallback(prompt, opts) {
   )
   if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
   log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
-  // Return a new object rather than mutating `second`: workflow scripts are ES
-  // modules (strict mode), and the runtime's returned object could be frozen,
-  // sealed, or proxied, which would throw a TypeError on exactly this
-  // fallback path.
+  // Return a new object rather than mutating `second`: the runtime's returned
+  // object could be frozen or sealed, in which case mutating it would either
+  // silently drop the `modelFallback` marker (sloppy mode) or throw a
+  // TypeError, and a proxied result could throw either way.
   return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -16,8 +16,9 @@ export const meta = {
 // large the repo is or how many areas the scout proposes. There is no per-file
 // fan-out and no loop. Models and effort are pinned per stage, so the
 // session model and effort never leak into the scout or the workers; the
-// single critic runs Fable 5 at xhigh effort (flip its model pin to 'opus'
-// under the Opus 5 fallback, see team-guide).
+// single critic runs Fable 5 at xhigh effort and auto-retries once on opus
+// at the same effort if Fable returns nothing (criticWithFallback below;
+// see team-guide for the lead-level fallback, which is still manual).
 //
 // When the repo is too big for MAX_AREAS areas to cover, the leftover paths are
 // reported (coverage.ceilingReached, coverage.areasDropped, and a suggested next
@@ -49,6 +50,33 @@ function safeRef(value, fallback) {
 }
 const root = safeRef(opts.path, '.')
 const MAX_AREAS = Number.isInteger(opts.areas) && opts.areas > 0 ? opts.areas : 24
+
+// Duplicated byte-for-byte across the three tm- workflows that run a Fable
+// critic (the workflow runtime has no shared imports); keep this copy in
+// sync, see helpers.test.mjs.
+async function criticWithFallback(prompt, opts) {
+  const first = await agent(prompt, opts)
+  // agent() returns null both when the model errors out after retries (for
+  // example Fable 5 quota exhaustion) and when the user skips the dispatch
+  // mid-run. Nothing in this script can tell those two cases apart, so there
+  // is no heuristic to invent here. The ruling is on which failure mode is
+  // worse: retrying a deliberate skip costs one extra skip prompt (the retry
+  // is itself an agent() call, so skipping again just returns null and the
+  // run ends below with a clear error), while not retrying a quota death
+  // costs the entire unattended run. Retry unconditionally.
+  if (first) return first
+  log(
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on opus at the same effort. Skipping again will end the run.`
+  )
+  const second = await agent(
+    `${prompt}\n\nNOTE: this is a retry on the opus fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'opus' }
+  )
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
+  second.modelFallback = `${opts.model} -> opus`
+  return second
+}
 
 // FINDING and FINDINGS_SCHEMA are a shared base intentionally duplicated with
 // tm-review-changes.js (the workflow runtime has no shared imports); this copy
@@ -243,7 +271,7 @@ const suggestedNextActionClause = ceilingReached
   ? `, and coverage.suggestedNextAction to ${JSON.stringify(suggestedNextAction)}`
   : ''
 
-const report = await agent(
+const report = await criticWithFallback(
   `You are the senior reviewer consolidating a full-codebase review. The workers below produced the raw findings.${coverageNote}\n\nVerify each finding against the actual code, drop false positives and anything out of scope, merge duplicates (including the same problem found in two areas), and set a final severity. You may add a finding only if it is a clear must-fix the workers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nThen write the report file. Run \`date +%F\` for today's date, make the docs/reviews/ directory if it does not exist, and write docs/reviews/<date>-codebase-review.md with: the verdict and summary first; then a one-line health impression scored 0-10 and up to three named top risks; then, if coverage is partial, a prominent "Coverage: PARTIAL" callout immediately after that opening block that states how many paths were not reviewed and the suggested next action; then the findings as severity sections (must-fix, then should-fix, then nit), each organized by area; then a final "Coverage" section listing the areas reviewed, the paths not covered, the workers that failed, and (if partial) the suggested next action. Set reportPath to the file you wrote.\n\nReturn the structured summary. Set coverage.areasReviewed to ${JSON.stringify(reviewedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
   { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }
 )

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -74,10 +74,10 @@ async function criticWithFallback(prompt, opts) {
   )
   if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
   log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
-  // Return a new object rather than mutating `second`: workflow scripts are ES
-  // modules (strict mode), and the runtime's returned object could be frozen,
-  // sealed, or proxied, which would throw a TypeError on exactly this
-  // fallback path.
+  // Return a new object rather than mutating `second`: the runtime's returned
+  // object could be frozen or sealed, in which case mutating it would either
+  // silently drop the `modelFallback` marker (sloppy mode) or throw a
+  // TypeError, and a proxied result could throw either way.
   return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -74,8 +74,11 @@ async function criticWithFallback(prompt, opts) {
   )
   if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
   log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
-  second.modelFallback = `${opts.model} -> opus`
-  return second
+  // Return a new object rather than mutating `second`: workflow scripts are ES
+  // modules (strict mode), and the runtime's returned object could be frozen,
+  // sealed, or proxied, which would throw a TypeError on exactly this
+  // fallback path.
+  return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 
 // FINDING and FINDINGS_SCHEMA are a shared base intentionally duplicated with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# Adapted from .claude/skills/tm-new-project/templates/ci.yml.
+#
+# This repo has no install, typecheck, lint, build, or e2e step: no
+# dependencies, no lockfile, no application runtime (see CLAUDE.md's
+# "Useful commands"). The template's staged checks/build/e2e jobs collapse
+# to the one stage this repo actually has: unit tests.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# No paths-ignore: this repo is 77% markdown, so the template's docs/** and
+# **.md skips would block most PRs on a required check that never completes.
+# The suite runs in under a second, so there is nothing to save by skipping.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          # No cache: 'npm' here. There is no lockfile for setup-node's
+          # cache-path resolution to key off, so it would fail.
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ on:
   push:
     branches: [main]
 
-# No paths-ignore: this repo is 77% markdown, so the template's docs/** and
-# **.md skips would block most PRs on a required check that never completes.
-# The suite runs in under a second, so there is nothing to save by skipping.
+# No paths-ignore: the markdown here is test input, not inert prose.
+# .claude/workflows/__tests__/effort-policy.test.mjs reads .claude/agents/*.md
+# frontmatter, so a docs/** or **.md skip would let a PR that breaks that
+# suite (for example editing architect.md's model pin) skip CI entirely.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,6 +33,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          # 22 is a floor, not a preference: npm test's glob (see
+          # package.json) relies on node --test expanding it, which
+          # Node 20.20.2 fails (exit 1, "could not find"); 21.7.3 and
+          # 22.22.2 both expand it and run the suite.
           node-version: '22'
           # No cache: 'npm' here. There is no lockfile for setup-node's
           # cache-path resolution to key off, so it would fail.

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -43,10 +43,25 @@ so that commit is not reachable from this branch and `git show 089f754`
 will not resolve for anyone cloning today.
 
 **Where the document now reads stale.** Eight places assert or depend on the
-blocker that is now cleared: L10-13 (the summary), L72-76 (section 3), the
-line pair L240-242 and L244-254 (section 7, the "Flag prominently" block),
-L256-262 (the alias-table paragraph), L303-306 (the section 8
-recommendation), L308-311, and L396-397 (section 9's first extend-trigger).
+blocker that is now cleared. Line numbers are current as of this commit; a
+document that edits itself drifts, so each entry also carries a section
+heading and a quoted phrase to `grep` for if the number is wrong again:
+
+- L10-13, the summary: "the lead-only move is not" (blocked by the test).
+- L178-182, section 3 ("Options"): "the one that would fail the
+  effort-policy test".
+- L346-348, section 7 (the hardcode-inventory paragraph): "neither is
+  blocked by the effort-policy blocker below".
+- L350-360, section 7, the "Flag prominently" block: "blocked by this
+  repo's own test today".
+- L362-368, section 7, the alias-table paragraph: "the same
+  `shared/models.md` alias table".
+- L409-412, section 8, the recommendation: "until the effort-policy test
+  gains an `opus` tier".
+- L414-417, section 8 body: "This is option (c), not (b)".
+- L502-503, section 9, first extend-trigger: "the effort-policy test gains
+  an `opus` tier (a follow-up issue, not this package)".
+
 None of that prose is edited by this addendum; it stays as written on
 2026-07-24, and this list is here so a reader (or `grep`) can find each
 instance.
@@ -74,14 +89,16 @@ in the test being unfixed, only blocked by it as a practical matter. The
 recommendation itself, and its confidence level, are unchanged by this
 addendum.
 
-**The confidence check.** The six caps at L376-392 that hold section 8's
-confidence at medium are: the lead-only savings estimate is bounded but not
-pinned, the Max-plan quota translation is unmeasured, the four Fable-limit
-events are a recurrence and not a rate, Opus 5's own spawning tendency as a
-lead is unmeasured, no first-party capability comparison exists, and the
-pricing behind section 4 is cached, not live. None of the six cites the
+**The confidence check.** The six caps at L482-498, section 8 under "What
+caps this at medium rather than high", hold section 8's confidence at
+medium: the lead-only savings estimate is bounded but not pinned, the
+Max-plan quota translation is unmeasured, the four Fable-limit events are a
+recurrence and not a rate, Opus 5's own spawning tendency as a lead is
+unmeasured, no first-party capability comparison exists, and the pricing
+behind section 4 is cached, not live. None of the six cites the
 effort-policy test. Medium is untouched by this addendum, and that claim is
-checkable against L376-392 directly rather than asserted here.
+checkable against that same L482-498 block directly rather than asserted
+here.
 
 **Section 7 line drift.** The body's "Flag prominently" block (L244-254)
 quotes `effort-policy.test.mjs` at line 21 with two keys (`sonnet`, `fable`).

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -15,6 +15,95 @@ not.**
 A recommendation, not a policy change. Related: issue #264. Nothing here edits
 `.claude/team-guide.md`, any agent frontmatter, or any workflow stage.
 
+## Addendum, 2026-07-25: the effort-policy blocker is cleared
+
+Sections 1-10 below are unchanged and stand as written on 2026-07-24. This
+addendum is the only new material and it does not touch them. It exists
+because the blocker section 7 and section 8 describe as open is no longer
+open, and the most-read text in this document (the summary above) still
+states otherwise.
+
+**What cleared.** `git show daa176e --
+.claude/workflows/__tests__/effort-policy.test.mjs` shows the change:
+`EFFORT_BY_MODEL` now reads `{ sonnet: 'high', fable: 'xhigh', opus: 'xhigh'
+}`, at line 26 of that file, not line 21 as section 7's quote below says.
+
+**Chronology.** The fix did not land after this document merged. `git show
+--stat daa176e` shows the doc and the effort-policy fix in the same squash
+commit: both shipped together in PR #265, on the same branch, before merge.
+That is why the document above asserts a blocker its own PR already removed:
+the two changes were written in the same batch and squashed together without
+reconciling the prose against the test change.
+
+**References.** `daa176e` is the runnable citation for the fix. PR #265 is
+the durable GitHub reference for the same change. An earlier, pre-squash
+branch commit, `089f754`, also touched this area but is not cited as a
+runnable reference here: `git merge-base --is-ancestor 089f754 HEAD` fails,
+so that commit is not reachable from this branch and `git show 089f754`
+will not resolve for anyone cloning today.
+
+**Where the document now reads stale.** Eight places assert or depend on the
+blocker that is now cleared: L10-13 (the summary), L72-76 (section 3), the
+line pair L240-242 and L244-254 (section 7, the "Flag prominently" block),
+L256-262 (the alias-table paragraph), L303-306 (the section 8
+recommendation), L308-311, and L396-397 (section 9's first extend-trigger).
+None of that prose is edited by this addendum; it stays as written on
+2026-07-24, and this list is here so a reader (or `grep`) can find each
+instance.
+
+**The two trigger sentences, named and neutralised.** Section 8 recommends
+holding architect, reviewer, and the critics on Fable 5 "until the
+effort-policy test gains an `opus` tier in a follow-up issue." Section 9's
+first extend-trigger names the same condition: "the effort-policy test gains
+an `opus` tier (a follow-up issue, not this package)." Both are written as
+satisfied-condition triggers, and both conditions are now met. Meeting them
+does not license moving architect, reviewer, or the critics to Opus 5. The
+effort-policy test was only ever the mechanical blocker (section 8's second
+leg, below); the capability reason (section 6, unchanged and unmet) was
+always the independent, load-bearing reason for the hold, and clearing a
+test does not clear a capability question no first-party comparison has
+answered.
+
+**What is affected and what is not.** Section 8 gave the hold on architect,
+reviewer, and the critics two legs: the effort-policy test blocking it
+mechanically, and the vendor capability claim arguing against it on merit.
+One leg is gone; the other stands. "Nothing changes" is false: the hold used
+to rest on two independent reasons and now rests on one. "The recommendation
+weakens" is also false: option (c) still stands, and it was never grounded
+in the test being unfixed, only blocked by it as a practical matter. The
+recommendation itself, and its confidence level, are unchanged by this
+addendum.
+
+**The confidence check.** The six caps at L376-392 that hold section 8's
+confidence at medium are: the lead-only savings estimate is bounded but not
+pinned, the Max-plan quota translation is unmeasured, the four Fable-limit
+events are a recurrence and not a rate, Opus 5's own spawning tendency as a
+lead is unmeasured, no first-party capability comparison exists, and the
+pricing behind section 4 is cached, not live. None of the six cites the
+effort-policy test. Medium is untouched by this addendum, and that claim is
+checkable against L376-392 directly rather than asserted here.
+
+**Section 7 line drift.** The body's "Flag prominently" block (L244-254)
+quotes `effort-policy.test.mjs` at line 21 with two keys (`sonnet`, `fable`).
+The file now reads three keys (`sonnet`, `fable`, `opus`) at line 26, per
+`daa176e` above. That block is not edited here; this note only records the
+drift for a reader who goes to check the citation.
+
+What this addendum does not do: it does not revise the recommendation
+(option (c) still stands: lead to Opus 5, architect/reviewer/critics hold),
+does not touch the confidence level, and does not strengthen the lead-seat
+move (the lead's model was never frontmatter-pinned or test-asserted, so
+clearing this blocker adds nothing to that case). It does not claim the
+section 6 capability argument is weakened, dated, or superseded; no
+first-party comparison has run, and vendor positioning still ranks Fable 5
+above Opus 5, which is why the hold on architect, reviewer, and the critics
+survives. It does not claim the alias-table question (L256-262) is settled;
+whether `model: opus` resolves through the alias table to Opus 5 was
+unconfirmed when this document was written and is unconfirmed now, so this
+addendum stays silent on it. It does not overstate what the cleared test
+does: `EFFORT_BY_MODEL`'s `opus` entry permits an `opus`-pinned seat carrying
+`xhigh` effort; it does not endorse, require, or recommend running one.
+
 ## 1. Question and scope
 
 With Opus 5 released, should the orchestrator (lead), architect, and reviewer
@@ -238,7 +327,7 @@ as soon as the lead moves: `README.md` (7 hits; line 77, `fable, xhigh` on the
 lead node) and `docs/team-architecture.md:33` (`LEAD - main session (fable,
 xhigh effort)`) - the latter was already inside the `.claude`/`docs` scope
 above and simply left off the list. Neither is frontmatter or asserted in `npm
-test`, so neither is blocked by the effort-policy failure below, but both need
+test`, so neither is blocked by the effort-policy blocker below, but both need
 editing alongside any lead-seat move.
 
 **Flag prominently:** `.claude/workflows/__tests__/effort-policy.test.mjs:21`

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -100,7 +100,7 @@ effort-policy test. Medium is untouched by this addendum, and that claim is
 checkable against that same L482-498 block directly rather than asserted
 here.
 
-**Section 7 line drift.** The body's "Flag prominently" block (L244-254)
+**Section 7 line drift.** The body's "Flag prominently" block (L350-360)
 quotes `effort-policy.test.mjs` at line 21 with two keys (`sonnet`, `fable`).
 The file now reads three keys (`sonnet`, `fable`, `opus`) at line 26, per
 `daa176e` above. That block is not edited here; this note only records the
@@ -114,7 +114,7 @@ clearing this blocker adds nothing to that case). It does not claim the
 section 6 capability argument is weakened, dated, or superseded; no
 first-party comparison has run, and vendor positioning still ranks Fable 5
 above Opus 5, which is why the hold on architect, reviewer, and the critics
-survives. It does not claim the alias-table question (L256-262) is settled;
+survives. It does not claim the alias-table question (L362-368) is settled;
 whether `model: opus` resolves through the alias table to Opus 5 was
 unconfirmed when this document was written and is unconfirmed now, so this
 addendum stays silent on it. It does not overstate what the cleared test


### PR DESCRIPTION
Batch #266, run through `/tm-advisor`. Three packages, one branch - this session is pinned to a single branch, so all three land here as separate commits instead of one PR each. Rationale logged on #266.

Closes #267
Closes #268
Closes #269

## Why

Batch #262 hit the Fable 5 quota limit twice and recovered manually both times. Dispatching this batch hit it three more times: **every** judgment dispatch failed on quota, two days running. That is seven events across four documented occasions, and it is no longer the stray-dispatch nuisance #261 was filed about. It is the sustained-outage case its manual procedure was explicitly not written for.

## What changed

Nine commits across three packages.

**#268 - the first CI this repo has ever had** (`c3efac4`, `a0b8289`)

The team guide's CI cost policy specifies pinned timeouts, mandatory concurrency groups and staged jobs, and ships a worked template. This repo had no `.github/` directory at all. Every check that ever ran here was an agent or a human remembering to run `npm test` locally.

Adds one job: checkout, `actions/setup-node@v4` pinned to Node 22, `npm test`. Five-minute timeout, concurrency group with `cancel-in-progress`, `permissions: contents: read`.

Three decisions worth knowing:

- **`paths-ignore` dropped.** 47 of 61 tracked files here are markdown. Three of the last five merges touched only `docs/` or `.claude/*.md`, so the template's version would have skipped CI on all three, and a docs-only PR would hang forever as "Expected" once the check is required
- **Node pinned, and it is load-bearing.** The test script is `node --test ".claude/workflows/__tests__/*.test.mjs"` with quotes inside the script string, so **Node itself expands the glob**. `ubuntu-latest` ships whatever Node its image pins, and that moves without a repo change
- **No `cache: 'npm'` and no install step.** There is no lockfile. `npm ci` would fail hard and the cache step would too. Commented so nobody adds it later

**#267 - auto-recover the Fable critic onto Opus 5** (`6049fb1`, `41ab06f`, `9e011e3`)

`criticWithFallback`, triplicated byte-identically across the three `tm-` workflows. A critic stage that returns `null` retries once on Opus 5 at the same `xhigh` pin; if the retry also returns `null` the workflow throws rather than proceeding with a missing critic.

The retry is a null check, not a `try`/`catch`, because `agent()` returns `null` on a terminal API error rather than throwing. It also returns `null` when a user skips the dispatch, and nothing in the script can tell those apart. The code rules on asymmetric cost and says so: retrying a deliberate skip costs one extra skip prompt, not retrying a quota death costs the entire unattended run. Retry unconditionally.

**#269 - dated addendum to the Opus 5 research doc** (`328a8fe`, `5cc6646`, `47373af`)

`docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md` held architect, reviewer and the critic stages on Fable partly because the effort-policy test blocked flipping their pins to `opus`. `089f754` cleared that. The addendum records it without rewriting the dated analysis, and states plainly what it does not overturn: the capability argument for holding those seats is untouched and stands on its own.

## Two corrections to the record

**A commit message in this branch overclaims.** `5cc6646`'s body says it "recomputed every citation against the file as delivered and verified each with `sed -n`". That was not true of that commit: `47373af` exists because two citations were missed, one of which had been broken since `328a8fe` and never disclosed. `47373af`'s own message corrects it, naming both misses with their wrong and right targets. Recorded here rather than rewritten, since rewriting would need a force-push.

**A false claim reached three files before being caught.** `41ab06f` added a comment stating that workflow scripts are ES modules and therefore strict-mode code. That came from a lead instruction, verbatim. It is wrong: these files carry `export const meta` on line 1 and a bare top-level `return`, a combination that is a SyntaxError as a module and as a script, so the file cannot tell you its own mode. `9e011e3` removes it and rests the rationale on the mechanism that actually applies: mutating a frozen return silently drops the marker in sloppy mode. Confirmed by reverting to the mutation form and observing `modelFallback` come back `undefined` rather than throwing, and by zero `use strict` matches anywhere in `.claude/workflows/`.

## Known inherited risk, not introduced here

`node --test` with a glob matching nothing exits **0** with `# tests 0`. A green CI run is therefore not by itself proof that tests ran. This is a pre-existing property of the repo's `npm test` script, and fixing it needs an npm script change #268's non-goals forbid. Today the glob matches all 70 tests. Worth knowing before anyone moves the test files.

## What the CI found by running on itself

**A green run confirmed `# tests 70`, not 0.** The known hazard above did not fire.

**A run can fail with zero jobs.** `41ab06f` concluded `failure` having created no jobs at all, while `ci.yml` was byte-identical to the green run on its parent and `npm test` passed locally at that exact commit. Re-running produced no jobs either; the next commit ran green. Transient, but it means a red X here does not always mean a test failed.

**The action deprecation escalated mid-batch.** The first run warned that `actions/checkout@v4` and `actions/setup-node@v4` target the deprecated Node 20. A later run reports them "being forced to run on Node.js 24". That is a live compatibility risk, not housekeeping.

## After merge, two things only you can do

**The workflow existing is not the workflow gating.** Making "Unit tests" a required check is a branch-protection setting, not a file, and no package in this batch can do it. Until you flip it, this CI is advisory.

**Bump the actions to v5 before you flip it.** A required check that can conclude `failure` with zero jobs would block merges on infrastructure noise, and the checks UI does not distinguish that from a real failure.

## Verification

- `npm test` 70 pass, 0 fail; CI green on `9e011e3` with the count confirmed from the run log
- **#268:** tester PASS round 1, reviewer APPROVE, zero findings, including an independent recount of the 77% markdown figure
- **#267:** tester PASS -> reviewer CHANGES_REQUESTED -> PASS -> APPROVE -> PASS -> APPROVE. The blocking finding was a wiring test that could not fail: its assertion was satisfied by the function declaration itself, so nothing verified the helper was ever called
- **#269:** tester FAIL -> FAIL -> PASS, reviewer APPROVE. Both failures were the same defect, line-number citations pointing at unrelated prose, and both were found only when the tester enumerated the document itself instead of checking a handed-over list
- Every verification claim in this PR was re-derived by an agent that did not make it: byte-identity by independent extraction rather than by the test that asserts it, both deliberate breaks reproduced on different files than the developer used, and the retry's failure mode observed rather than inferred

Non-blocking findings from all three packages are in the comments for your review; none were silently fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMT3YhDmHtzrnTkfTwVWth

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMT3YhDmHtzrnTkfTwVWth)_