### PR TITLE
ci: bump checkout and setup-node actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           # 22 is a floor, not a preference: npm test's glob (see
           # package.json) relies on node --test expanding it, which


### PR DESCRIPTION
Closes #271

Part of batch #278.

## Why

The run log on `9e011e3` reported `actions/checkout@v4` and `actions/setup-node@v4` as being forced to run on Node.js 24, a runtime they were not built against. Earlier runs in the same batch warned only about the deprecated Node 20, so this escalated mid-batch. Moving both to the v5 major removes the forced-runtime path.

This is a precondition for making the unit-test check required: a required check that can fail for reasons unrelated to the code blocks merges on noise, and the checks UI does not distinguish that from a genuine failure.

## What changed

Two lines in `.github/workflows/ci.yml`: `actions/checkout@v4` -> `@v5` and `actions/setup-node@v4` -> `@v5`. Nothing else. `node-version: '22'` stays (the pin is load-bearing, since the test script's quoted glob is expanded by Node itself), and triggers, `timeout-minutes`, the concurrency group and `permissions` are untouched.

The v5 behavior changes in `setup-node` are inert here: the Node version is explicitly pinned and no `cache:` input is used, so v5's default-version and cache-resolution changes never engage.

`v5` was confirmed to exist as a current major by listing tags directly against each action's repository, not from documentation summaries: `actions/checkout` `refs/tags/v5` resolves to `v5.1.0`, `actions/setup-node` `refs/tags/v5` resolves to `v5.0.0`.

## Deliberately not changed

`.claude/skills/tm-new-project/templates/ci.yml` stays at v4. No test asserts action versions on it (`ci-template-policy.test.mjs` reads only that file and only checks structure), no test reads `.github/workflows/` at all, and the template belongs to the template-copy path that `docs/architecture/operating-model.md` section 3 records as retired with removal deferred to a later batch. Bumping a file slated for deletion would be scope creep on a `size:S` issue.

Making the check required in branch protection is a repository setting, out of scope here.

## Verification

Local `npm test` -> exit 0, 70 tests across 9 suites, all pass. That confirms nothing in the suite pins v4, but it does not verify the three acceptance criteria that live in the CI run log. Those are checked against this PR's own run: job success, no Node-version deprecation or forced-runtime warning, and a non-zero test count matching the local 70.

## Overlap to note when merging

Batch #278 also carries #272, which corrects the Node-floor comment a few lines below these two `uses:` lines in the same file. Whichever of the two PRs merges second may need a trivial conflict resolution in that hunk. The two changes do not otherwise interact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk5nzbKYpBKsRVzkXaNi7S)_