### PR TITLE
fix: correct the factual defects batch #266's reviews found

### DIFF
--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -489,7 +489,7 @@ describe('criticWithFallback', () => {
     // string only matches an actual call.
     for (const file of FILES) {
       const src = readFileSync(join(workflowsDir, file), 'utf8')
-      assert.ok(src.includes('await criticWithFallback('), `${file} does not call criticWithFallback(`)
+      assert.ok(src.includes('await criticWithFallback('), `${file} does not contain 'await criticWithFallback('`)
     }
   })
 })

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -84,7 +84,7 @@ async function criticWithFallback(prompt, opts) {
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
-  // TypeError, and a proxied result could throw either way.
+  // TypeError.
   return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -54,7 +54,7 @@ async function criticWithFallback(prompt, opts) {
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
-  // TypeError, and a proxied result could throw either way.
+  // TypeError.
   return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -77,7 +77,7 @@ async function criticWithFallback(prompt, opts) {
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
-  // TypeError, and a proxied result could throw either way.
+  // TypeError.
   return { ...second, modelFallback: `${opts.model} -> opus` }
 }
 

--- a/docs/architecture/2026-07-05-codebase-map.md
+++ b/docs/architecture/2026-07-05-codebase-map.md
@@ -136,8 +136,8 @@ no dependency fields):
 - Claude Code harness: CLAUDE.md loading and @-imports, the plugin/marketplace
   system (reads marketplace.json and plugin.json), settings.json, the
   subagent/Task machinery that runs the role agents, and the Workflow tool
-  runtime that supplies the ambient `agent`, `parallel`, `phase`, and `args`
-  bindings the three scripts reference but never define.
+  runtime that supplies the ambient `agent`, `parallel`, `phase`, `log`, and
+  `args` bindings the three scripts reference but never define.
 - GitHub via the `gh` CLI: issues, PRs, labels, comments, and search are both
   the input source and the durable state store for tm-kickoff, tm-advisor,
   tm-to-issues, tm-new-project, and every role agent.
@@ -187,10 +187,10 @@ Cross-area dependencies:
 ## 5. Open questions
 
 - The Workflow runtime contract is assumed, not defined: `agent`, `parallel`,
-  `phase`, and `args` are ambient globals the three scripts call but nothing
-  in the repo declares. Their exact semantics (failure handling, null-padding,
-  schema enforcement) can only be confirmed against the Claude Code host, not
-  from source here.
+  `phase`, `log`, and `args` are ambient globals the three scripts call but
+  nothing in the repo declares. Their exact semantics (failure handling,
+  null-padding, schema enforcement) can only be confirmed against the Claude
+  Code host, not from source here.
 - operating-model.md defers the physical removal of NEW-PROJECT-SETUP.md and
   .claude/skills/tm-new-project/ to a later usability batch. The timing is a
   human decision, and the fate of templates/ci.yml, which

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -47,7 +47,7 @@ blocker that is now cleared. Line numbers are current as of this commit; a
 document that edits itself drifts, so each entry also carries a section
 heading and a quoted phrase to `grep` for if the number is wrong again:
 
-- L10-13, the summary: "the lead-only move is" (blocked by the test).
+- L10-13, the summary: "the lead-only move is" (not blocked by the test).
 - L178-182, section 3 ("Options"): "the one that would fail the
   effort-policy test".
 - L346-348, section 7 (the hardcode-inventory paragraph): "neither is

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -47,19 +47,19 @@ blocker that is now cleared. Line numbers are current as of this commit; a
 document that edits itself drifts, so each entry also carries a section
 heading and a quoted phrase to `grep` for if the number is wrong again:
 
-- L10-13, the summary: "the lead-only move is not" (blocked by the test).
+- L10-13, the summary: "the lead-only move is" (blocked by the test).
 - L178-182, section 3 ("Options"): "the one that would fail the
   effort-policy test".
 - L346-348, section 7 (the hardcode-inventory paragraph): "neither is
   blocked by the effort-policy blocker below".
 - L350-360, section 7, the "Flag prominently" block: "blocked by this
-  repo's own test today".
+  repo's own".
 - L362-368, section 7, the alias-table paragraph: "the same
   `shared/models.md` alias table".
 - L409-412, section 8, the recommendation: "until the effort-policy test
   gains an `opus` tier".
 - L414-417, section 8 body: "This is option (c), not (b)".
-- L502-503, section 9, first extend-trigger: "the effort-policy test gains
+- L502-503, section 9, first extend-trigger: "effort-policy test gains
   an `opus` tier (a follow-up issue, not this package)".
 
 None of that prose is edited by this addendum; it stays as written on
@@ -73,7 +73,7 @@ first extend-trigger names the same condition: "the effort-policy test gains
 an `opus` tier (a follow-up issue, not this package)." Both are written as
 satisfied-condition triggers, and both conditions are now met. Meeting them
 does not license moving architect, reviewer, or the critics to Opus 5. The
-effort-policy test was only ever the mechanical blocker (section 8's second
+effort-policy test was only ever the mechanical blocker (section 8's first
 leg, below); the capability reason (section 6, unchanged and unmet) was
 always the independent, load-bearing reason for the hold, and clearing a
 test does not clear a capability question no first-party comparison has


### PR DESCRIPTION
Closes #275

Part of batch #278.

Five factual corrections from batch #266's non-blocking findings. Only the things that are wrong; the matters of taste are deliberately left alone.

## 1. Three grep anchors that defeated the instruction beside them

The addendum's site index tells the reader to `grep` for a quoted phrase when a line number has drifted. Three of its eight anchors quoted a phrase that spans a hard line-wrap in the body, so that `grep` could never find the target. Each is shortened to a substring that lives verbatim on one target line, and each entry keeps its line count so no `L` reference anywhere in the addendum drifts.

Shortening the quote (rather than re-flowing the body) is the only option available: the addendum's own rule is that "None of that prose is edited by this addendum", and the issue's non-goals forbid rewriting the dated record.

Verified by running the `grep` the addendum itself recommends, for all eight anchors:

```
anchor1 'the lead-only move is'                                                   -> 12, 50
anchor2 'the one that would fail the effort-policy test'                           -> 180
anchor3 'neither is blocked by the effort-policy blocker below'                    -> 347
anchor4 "blocked by this repo's own"                                              -> 356
anchor5 'the same `shared/models.md` alias table'                                  -> 362
anchor6 'until the effort-policy test gains an `opus` tier'                        -> 411
anchor7 'This is option (c), not (b)'                                              -> 61, 414
anchor8 'effort-policy test gains an `opus` tier (a follow-up issue, not this package)' -> 503
```

Every anchor reaches its target. The extra hits at L50 and L61 are index entries quoting themselves, which anchor 7 already did before this change.

**Meaning preserved alongside the grep fix (review fix round 1).** Anchor 1's entry carries a gloss, and on `main` the quote plus that gloss reconstructed the summary's elided predicate: `"the lead-only move is not" (blocked by the test)`. Removing `not` from the quote to fix the wrap left the gloss asserting the opposite of the target, so the gloss is now `(not blocked by the test)`. L12-13 reads "the lead-only move is / not." and L417 states "The lead-only move is not blocked by that test", so the corrected entry matches both. The anchor, the line count, and every grep result above are unchanged by that fix.

One precision note on the issue's own wording: it said the broken `grep` "returns nothing for exactly those three". Anchors 4 and 8 did return nothing, but anchor 1 returned exactly one line, which was the index entry quoting itself rather than the target. Same defect, same fix.

## 2. A cross-reference that miscounted

The addendum called the effort-policy test "section 8's second leg". Section 8 names the test first (L414) and the capability claim second (L415-416), and its second enumerated item is the floor claim. The addendum's own two-legs paragraph (L82-84) orders test first as well. Corrected to "first leg". One word, in the paragraph doing the load-bearing "what does not change" work.

## 3. A failure message naming a string the assertion does not check

`helpers.test.mjs:492` asserted on `'await criticWithFallback('` but reported failure as `does not call criticWithFallback(`. Per the test's own comment, the bare `criticWithFallback(` substring is present even in a file that has the defect, so the message pointed at something that would exist in the failing file. The message now names the checked string.

Per the issue's non-goals, the assertion itself is untouched: making it resistant to a deliberately crafted decoy comment needs comment and string-literal stripping inside a zero-dependency test suite, which is separate work.

## 4. A comment clause that argued against both options

The `criticWithFallback` comment justifies returning a new object rather than mutating, then closed with a note that a proxied result could throw either way. That is true but it does not distinguish the two forms, since spreading a proxy runs its traps just as assigning to one does. It was residue from an earlier wording that also carried a claim already removed as false.

Removed from all three workflow files in one commit, since the comment sits inside the function body and `helpers.test.mjs` asserts the helper is byte-identical across all three. Splitting the change would have failed that test. The remaining sentence reads complete after the cut, not clipped.

## 5. A documented list missing an entry

The codebase map enumerated the Workflow runtime's ambient globals as `agent`, `parallel`, `phase` and `args`. `log` is also one, and the omission had a real cost: a tester could not verify a correct `log()` call from inside the repo and had to raise it as an unverifiable risk. All three workflow scripts call `log()` free and nothing declares it.

Both enumerations are corrected, the dependency summary and the open-questions section, not just one. One fixed and one stale would be the same defect the issue is closing.

**What kind of edit this is, stated precisely.** The map is a dated generated artifact and the repo convention supersedes rather than edits older reports, so the category matters for the precedent. This is **a sign-off-sanctioned update of a snapshot that went stale, not the correction of an error the artifact had when written.** At the map's generating commit (`d06fd07`, 2026-07-05) no workflow script referenced `log` at all; `log()` entered with `9465e67` (#270, 2026-07-25). The map was accurate on its own date.

The in-place edit is still the right call: criterion 5 requires it, batch #278's sign-off authorized it, and CLAUDE.md's "code wins, the doc is corrected" rule covers the map's standing claim against current code, while regenerating an entire map to add one word would violate simplicity-first. Recording the category explicitly because in-place edits to dated artifacts stay a safe precedent only when they are either corrections of same-date errors or labelled sanctioned updates. Commit `787b9a2`'s body frames this as an original omission, which is wrong; the framing here and in the squash message is the accurate one.

## Verification

- All eight anchor greps resolve to their target lines, transcript above, re-run after the review fix round.
- `npm test` -> exit 0, 70 tests / 9 suites, run after every commit. This covers the byte-identity assertion (proving item 4 landed identically in all three files), the wiring test, and the effort-policy suite.
- `grep -rn 'proxied' .claude/workflows/` returns nothing.
- Both codebase-map enumerations now list `log`.
- The addendum is 548 lines on both `origin/main` and this branch, so no `L` reference drifted.

## Held to the non-goals

The addendum is not shortened and its repetition is not reduced; the helper's `opts` parameter is not renamed; the quota-versus-skip comment is not trimmed; the wiring assertion is not hardened; and no figure, recommendation, or confidence level in the research doc changed.

## Noted, deliberately not fixed

`docs/plans/37-review-codebase.md:37` also enumerates the ambient globals without `log`. Left alone: plan docs are point-in-time snapshots by repo convention with no standing-truth duty, and this issue's scope names the codebase map. A one-line follow-up if you want it corrected.

## For the squash message

Two framing corrections worth carrying over, neither worth a history rewrite: the `log` addition is a sanctioned update of a stale snapshot rather than an original omission (see section 5), and commit `354a78a` uses `fix:` for a comment-only change where `docs:` fits the taxonomy better (defensible, since the comment asserted a claim that did not hold).