### PR TITLE
docs: make the Fable-quota Opus override a routing rule

### DIFF
--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -163,6 +163,9 @@ advisor differs from a plain `/tm-kickoff` run in three ways:
   scope and acceptance criteria (a NEEDS_DECISION, an arbitration outcome,
   an interpretation call), decide it and post the decision with its reasoning
   as a comment on the batch issue before acting on it.
+  A Fable-quota death on a judgment-seat dispatch is such a decision:
+  apply kickoff's per-call Opus override routing rule and log the switch
+  on the batch issue. It is not grounds to park.
 - **Narrower parking gate.** Park (swap `in-progress` for `needs-human`) only
   for: a change to scope or acceptance criteria, a new dependency or cost,
   anything irreversible or outward-facing, or a conflict with

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -121,15 +121,15 @@ Routing rules:
   do not re-raise it.
 - If the architect's sub-plan says the work exceeds the size label, stop
   that package and report it (re-label and split per CLAUDE.md "Sizing").
-- An architect or reviewer dispatch dies on Fable 5 quota (the limit
-  error, or an empty return while Fable is exhausted): re-dispatch that
-  one agent with the same task and a per-call Opus override (the Agent
-  tool's `model` param). Do not flip a frontmatter pin or the session
-  model; the agent's own effort pin (xhigh) still applies. The model
-  override is the change that permits the re-dispatch. Log the switch as
-  a decision comment on the package issue; a model switch is never
-  silent. Workflow critic stages recover on their own
-  (criticWithFallback); this rule covers lead dispatches only.
+- An architect or reviewer dispatch dies on Fable 5 quota (the limit error,
+  or an empty return while Fable is exhausted): re-dispatch that one agent
+  with the same task and a per-call Opus override (the Agent tool's `model`
+  param, value `opus`). Do not flip a frontmatter pin or the session model;
+  the agent's own effort pin (xhigh) still applies. The model override is
+  the change that permits the re-dispatch. Log the switch as a decision
+  comment on the package issue; a model switch is never silent. Workflow
+  critic stages recover on their own (criticWithFallback); this rule covers
+  lead dispatches only.
 - Never re-dispatch an unchanged prompt; something in the task must change
   first.
 - Cap: 3 fix rounds per stage, counted from the PR comments. Tester and

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -121,6 +121,15 @@ Routing rules:
   do not re-raise it.
 - If the architect's sub-plan says the work exceeds the size label, stop
   that package and report it (re-label and split per CLAUDE.md "Sizing").
+- An architect or reviewer dispatch dies on Fable 5 quota (the limit
+  error, or an empty return while Fable is exhausted): re-dispatch that
+  one agent with the same task and a per-call Opus override (the Agent
+  tool's `model` param). Do not flip a frontmatter pin or the session
+  model; the agent's own effort pin (xhigh) still applies. The model
+  override is the change that permits the re-dispatch. Log the switch as
+  a decision comment on the package issue; a model switch is never
+  silent. Workflow critic stages recover on their own
+  (criticWithFallback); this rule covers lead dispatches only.
 - Never re-dispatch an unchanged prompt; something in the task must change
   first.
 - Cap: 3 fix rounds per stage, counted from the PR comments. Tester and

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -192,8 +192,9 @@ Rationale: docs/team-guide-rationale.md.
   lead stays on the bounded tm- machinery. Fable costs 2x Opus 5 per
   token. The premium is bounded in aggregate, not per batch
   (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
-- Fallback: Opus 5 at xhigh effort (a procedure, not automatic). When
-  Fable 5 is unavailable, rate-limited, quota-exhausted, or
+- Fallback: Opus 5 at xhigh effort (the lead-session flip is a manual
+  procedure; the workflow critics and single-agent dispatches recover by
+  rule). When Fable 5 is unavailable, rate-limited, quota-exhausted, or
   refuses the workload, switch the lead with `/model claude-opus-5`; for a
   longer outage flip the `fable` pins to `opus` in the `architect` and
   `reviewer` frontmatters. The Fable-critic stage of every `tm-` workflow
@@ -201,8 +202,9 @@ Rationale: docs/team-guide-rationale.md.
   returns nothing, so no flip is needed there, though each run still burns
   one doomed Fable dispatch before the retry fires. Flip back when Fable
   returns. For a single role-agent dispatch hitting Fable quota mid-batch,
-  dispatch that one agent with a per-call Opus override (the Agent tool's
-  `model` param) instead of flipping every pin. The ladder is Fable -> Opus;
+  the kickoff routing rules own the response: a per-call Opus override
+  (the Agent tool's `model` param), logged as a decision, no pin flip
+  (`.claude/skills/tm-kickoff/SKILL.md`). The ladder is Fable -> Opus;
   Sonnet is never a fallback
   for a judgment seat, and only steps in, flagged, if Opus is also down, with
   the review re-run on a judgment model afterward.

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -193,21 +193,20 @@ Rationale: docs/team-guide-rationale.md.
   token. The premium is bounded in aggregate, not per batch
   (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
 - Fallback: Opus 5 at xhigh effort (the lead-session flip is a manual
-  procedure; the workflow critics and single-agent dispatches recover by
-  rule). When Fable 5 is unavailable, rate-limited, quota-exhausted, or
-  refuses the workload, switch the lead with `/model claude-opus-5`; for a
-  longer outage flip the `fable` pins to `opus` in the `architect` and
-  `reviewer` frontmatters. The Fable-critic stage of every `tm-` workflow
-  (`.claude/workflows/`) already retries on opus automatically when Fable
-  returns nothing, so no flip is needed there, though each run still burns
-  one doomed Fable dispatch before the retry fires. Flip back when Fable
-  returns. For a single role-agent dispatch hitting Fable quota mid-batch,
-  the kickoff routing rules own the response: a per-call Opus override
-  (the Agent tool's `model` param), logged as a decision, no pin flip
-  (`.claude/skills/tm-kickoff/SKILL.md`). The ladder is Fable -> Opus;
-  Sonnet is never a fallback
-  for a judgment seat, and only steps in, flagged, if Opus is also down, with
-  the review re-run on a judgment model afterward.
+  procedure; workflow critics recover automatically, single-agent dispatches
+  by the kickoff routing rule). When Fable 5 is unavailable, rate-limited,
+  quota-exhausted, or refuses the workload, switch the lead with `/model
+  claude-opus-5`; for a longer outage flip the `fable` pins to `opus` in the
+  `architect` and `reviewer` frontmatters. The Fable-critic stage of every
+  `tm-` workflow (`.claude/workflows/`) already retries on opus automatically
+  when Fable returns nothing, so no flip is needed there, though each run
+  still burns one doomed Fable dispatch before the retry fires. Flip back
+  when Fable returns. For a single role-agent dispatch hitting Fable quota
+  mid-batch, the kickoff routing rules own the response: a per-call Opus
+  override (the Agent tool's `model` param), logged as a decision, no pin
+  flip (`.claude/skills/tm-kickoff/SKILL.md`). The ladder is Fable -> Opus;
+  Sonnet is never a fallback for a judgment seat, and only steps in, flagged,
+  if Opus is also down, with the review re-run on a judgment model afterward.
 - Cost-based fallback trigger: if Fable 5 stops being included under the
   Max-plan subscription and shifts to metered API billing, do not switch to
   Opus automatically. Measure the lead's actual $/session cost at API rates


### PR DESCRIPTION
Closes #273

Part of batch #278. Closes the dispatchable remainder of #261.

## Why

#267 automated recovery for the workflow critic stages, which was the half that mattered most because workflow scripts run unattended. Lead-level dispatches still depended on the lead noticing a quota death and remembering to re-dispatch that one agent with a per-call Opus override, from prose in the Model policy.

The evidence that remembering is not enough is substantial: across two consecutive batches the Fable 5 limit was hit seven times on four separate occasions, and in the most recent batch every judgment dispatch died on quota and needed the override applied by hand. A fresh lead session should apply the response without rediscovering it, and the model switch should be recorded rather than silent.

## What changed

Three files, docs only, 18 insertions and 4 deletions. All three use the same phrases ("per-call Opus override", "the Agent tool's `model` param") so grep finds them together.

**`.claude/skills/tm-kickoff/SKILL.md`** gains a routing rule, placed immediately before the "Never re-dispatch an unchanged prompt" bullet because it has to define its relationship to that one. The rule names the trigger (an architect or reviewer dispatch dying on Fable 5 quota, either the limit error or an empty return while Fable is exhausted), prescribes the response (re-dispatch that one agent with the same task and a per-call Opus override), rules out the wrong responses (no frontmatter pin flip, no session-model flip, the agent's own effort pin still applies), requires the switch to be logged as a decision comment, and scopes itself to lead dispatches since workflow critic stages recover on their own via `criticWithFallback`.

The clause "the model override is the change that permits the re-dispatch" is deliberate: without it the new rule would appear to contradict the "never re-dispatch an unchanged prompt" bullet that follows.

**`.claude/skills/tm-advisor/SKILL.md`** gains one sentence on the "In-scope decisions are yours" bullet, settling two things the kickoff rule does not: that a Fable-quota death is an in-scope decision rather than grounds to park, and that inside a batch the log entry goes on the batch issue. It defers the mechanics to kickoff's rule rather than restating them, so the two cannot drift apart.

**`.claude/team-guide.md`** reconciles the Model policy's Fallback bullet instead of leaving it saying something different. The sentence that previously described the single-agent override becomes a cross-reference naming the kickoff rules as owner. The opening parenthetical "(a procedure, not automatic)" becomes "(the lead-session flip is a manual procedure; the workflow critics and single-agent dispatches recover by rule)", because after this change the old wording would misdescribe two of the bullet's three paths.

## The distinction this had to preserve

The Model policy bullet describes three separate mechanisms, and blurring them would be the easy mistake here:

1. **The lead-session model flip** for a longer outage. Stays a manual procedure, unchanged.
2. **The workflow critic auto-retry** from #267 (`criticWithFallback`). Unchanged, and the new rule explicitly says it does not cover this.
3. **The single-agent per-call override.** The only one moving under the new routing rule.

Where the log entry goes differs by pipeline, so the rule covers both: a comment on the package issue under a plain `/tm-kickoff` run, and the batch issue inside a `/tm-advisor` batch. The package issue was chosen for the plain case because the architect stage, the seat most likely to die, runs before any PR exists, while the package issue exists at every stage.

## Held to the non-goals

Fable 5 stays the first-tried judgment model. No `effort:` pin changed and no agent frontmatter edited. No batch-level "Fable is down" switch. Sonnet is not introduced as a judgment fallback. #261's plugin-cache-overwrite problem is untouched and still needs its own design pass.

Four near-miss sites were checked and deliberately left alone because they remain correct: the `architect.md` and `reviewer.md` frontmatter comments (and frontmatter edits are a non-goal anyway), `tm-map-codebase.js`'s pointer to team-guide for the lead-level story, `effort-policy.test.mjs`'s header describing the pin-flip path, and the dated 2026-07-24 research doc.

## Verification

- `npm test` -> exit 0, 70 tests / 9 suites / 0 fail. No test reads any SKILL.md or team-guide.md, so this criterion is verify-only; `effort-policy.test.mjs` reads agent frontmatters and workflow JS, `ci-template-policy.test.mjs` reads the tm-new-project CI template, and `helpers.test.mjs` reads workflow JS.
- `git diff --stat` is exactly the three files, with nothing under `.claude/agents/` or `.claude/workflows/`.
- `grep -rn 'per-call Opus override' .claude/ docs/ CLAUDE.md` returns exactly four hits: the three policy sites plus the dated research doc, which was on the do-not-touch list. The three policy sites agree with each other, with kickoff owning the mechanics and the other two pointing at it.
- Read-through check: a fresh lead reading only the kickoff routing rules has the trigger, the response, what not to do, the effort-pin note, the logging requirement, and the relationship to both neighbouring rules, without needing to open team-guide.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk5nzbKYpBKsRVzkXaNi7S)_