### PR TITLE
feat: move architect, reviewer, and workflow critics from fable to opus

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,9 +2,9 @@
 name: architect
 description: Advisory lead for approach decisions. Use when an issue needs a sub-plan before implementation, when an issue looks mis-sized or needs splitting (size:L or size:XL), or when developer and reviewer disagree. Read-only; decides approach, never writes code.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Fable 5. Fallback is opus = Opus 5, same xhigh effort
-# (see team-guide, Model policy).
-model: fable
+# Judgment role: Opus 5. Per-call fallback is fable = Fable 5, same xhigh
+# effort (see team-guide, Model policy).
+model: opus
 effort: xhigh
 ---
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,9 +2,9 @@
 name: reviewer
 description: Reviews a work package diff against its issue and sub-plan, in two passes, spec compliance then code quality. Read-only; outputs APPROVE or CHANGES_REQUESTED with numbered file:line findings. Never edits files.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Fable 5. Fallback is opus = Opus 5, same xhigh effort
-# (see team-guide, Model policy).
-model: fable
+# Judgment role: Opus 5. Per-call fallback is fable = Fable 5, same xhigh
+# effort (see team-guide, Model policy).
+model: opus
 effort: xhigh
 ---
 

--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -163,8 +163,8 @@ advisor differs from a plain `/tm-kickoff` run in three ways:
   scope and acceptance criteria (a NEEDS_DECISION, an arbitration outcome,
   an interpretation call), decide it and post the decision with its reasoning
   as a comment on the batch issue before acting on it.
-  A Fable-quota death on a judgment-seat dispatch is such a decision:
-  apply kickoff's per-call Opus override routing rule and log the switch
+  An Opus-quota death on a judgment-seat dispatch is such a decision:
+  apply kickoff's per-call Fable override routing rule and log the switch
   on the batch issue. It is not grounds to park.
 - **Narrower parking gate.** Park (swap `in-progress` for `needs-human`) only
   for: a change to scope or acceptance criteria, a new dependency or cost,

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -121,15 +121,16 @@ Routing rules:
   do not re-raise it.
 - If the architect's sub-plan says the work exceeds the size label, stop
   that package and report it (re-label and split per CLAUDE.md "Sizing").
-- An architect or reviewer dispatch dies on Fable 5 quota (the limit error,
-  or an empty return while Fable is exhausted): re-dispatch that one agent
-  with the same task and a per-call Opus override (the Agent tool's `model`
-  param, value `opus`). Do not flip a frontmatter pin or the session model;
-  the agent's own effort pin (xhigh) still applies. The model override is
-  the change that permits the re-dispatch. Log the switch as a decision
-  comment on the package issue; a model switch is never silent. Workflow
-  critic stages recover on their own (criticWithFallback); this rule covers
-  lead dispatches only.
+- An architect or reviewer dispatch dies on an Opus 5 limit (the limit
+  error, or an empty return while Opus is exhausted): re-dispatch that one
+  agent with the same task and a per-call Fable override (the Agent tool's
+  `model` param, value `fable`). Do not flip a frontmatter pin or the
+  session model; the agent's own effort pin (xhigh) still applies. The
+  model override is the change that permits the re-dispatch. Flag the
+  fallback in the report and log the switch as a decision comment on the
+  package issue; a model switch is never silent. Sonnet is never a
+  judgment fallback for these seats. Workflow critic stages recover on
+  their own (criticWithFallback); this rule covers lead dispatches only.
 - Never re-dispatch an unchanged prompt; something in the task must change
   first.
 - Cap: 3 fix rounds per stage, counted from the PR comments. Tester and

--- a/.claude/skills/tm-map-codebase/SKILL.md
+++ b/.claude/skills/tm-map-codebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tm-map-codebase
-description: Token-bounded full-repo map, run as a workflow (Sonnet scout and area workers plus one Fable critic that writes a dated architecture map). Plugin-only wrapper; the committed-repo root invokes the tm-map-codebase workflow directly by name. User-invocable only.
+description: Token-bounded full-repo map, run as a workflow (Sonnet scout and area workers plus one Opus critic that writes a dated architecture map). Plugin-only wrapper; the committed-repo root invokes the tm-map-codebase workflow directly by name. User-invocable only.
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/tm-review-changes/SKILL.md
+++ b/.claude/skills/tm-review-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tm-review-changes
-description: Token-bounded code review of the current diff, run as a workflow (fixed Sonnet reviewers, one per dimension including docs drift and performance, plus one Fable critic). Plugin-only wrapper; the committed-repo root invokes the tm-review-changes workflow directly by name. User-invocable only.
+description: Token-bounded code review of the current diff, run as a workflow (fixed Sonnet reviewers, one per dimension including docs drift and performance, plus one Opus critic). Plugin-only wrapper; the committed-repo root invokes the tm-review-changes workflow directly by name. User-invocable only.
 disable-model-invocation: true
 argument-hint: "[base ref, default origin/main]"
 ---

--- a/.claude/skills/tm-review-codebase/SKILL.md
+++ b/.claude/skills/tm-review-codebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tm-review-codebase
-description: Token-bounded full-repo review, run as a workflow (Sonnet scout and area workers plus one Fable critic that writes a dated report). Plugin-only wrapper; the committed-repo root invokes the tm-review-codebase workflow directly by name. User-invocable only.
+description: Token-bounded full-repo review, run as a workflow (Sonnet scout and area workers plus one Opus critic that writes a dated report). Plugin-only wrapper; the committed-repo root invokes the tm-review-codebase workflow directly by name. User-invocable only.
 disable-model-invocation: true
 ---
 

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -195,8 +195,8 @@ Rationale: docs/team-guide-rationale.md.
 - Lead-session fallback: Opus 5 at xhigh effort, a manual procedure. When
   Fable 5 is unavailable, rate-limited, quota-exhausted, or refuses the
   workload, switch the lead with `/model claude-opus-5`. Flip back when
-  Fable returns. This fallback covers the lead session only; Fable does not
-  run in any other seat, so no other pin needs to flip alongside it.
+  Fable returns. This fallback covers the lead session only; no other seat
+  pins Fable, so no other pin needs to flip alongside it.
 - Judgment seats (architect, reviewer, workflow critics): Opus 5 at xhigh
   effort is the primary model, backstopped by the lead and, for architect
   and reviewer, by the human merge gate. The per-call fallback is Fable 5 at

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -192,21 +192,26 @@ Rationale: docs/team-guide-rationale.md.
   lead stays on the bounded tm- machinery. Fable costs 2x Opus 5 per
   token. The premium is bounded in aggregate, not per batch
   (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
-- Fallback: Opus 5 at xhigh effort (the lead-session flip is a manual
-  procedure; workflow critics recover automatically, single-agent dispatches
-  by the kickoff routing rule). When Fable 5 is unavailable, rate-limited,
-  quota-exhausted, or refuses the workload, switch the lead with `/model
-  claude-opus-5`; for a longer outage flip the `fable` pins to `opus` in the
-  `architect` and `reviewer` frontmatters. The Fable-critic stage of every
-  `tm-` workflow (`.claude/workflows/`) already retries on opus automatically
-  when Fable returns nothing, so no flip is needed there, though each run
-  still burns one doomed Fable dispatch before the retry fires. Flip back
-  when Fable returns. For a single role-agent dispatch hitting Fable quota
-  mid-batch, the kickoff routing rules own the response: a per-call Opus
-  override (the Agent tool's `model` param), logged as a decision, no pin
-  flip (`.claude/skills/tm-kickoff/SKILL.md`). The ladder is Fable -> Opus;
-  Sonnet is never a fallback for a judgment seat, and only steps in, flagged,
-  if Opus is also down, with the review re-run on a judgment model afterward.
+- Lead-session fallback: Opus 5 at xhigh effort, a manual procedure. When
+  Fable 5 is unavailable, rate-limited, quota-exhausted, or refuses the
+  workload, switch the lead with `/model claude-opus-5`. Flip back when
+  Fable returns. This fallback covers the lead session only; Fable does not
+  run in any other seat, so no other pin needs to flip alongside it.
+- Judgment seats (architect, reviewer, workflow critics): Opus 5 at xhigh
+  effort is the primary model, backstopped by the lead and, for architect
+  and reviewer, by the human merge gate. The per-call fallback is Fable 5 at
+  the same xhigh effort. The critic stage of every `tm-` workflow
+  (`.claude/workflows/`) already retries on fable automatically when Opus
+  returns nothing, though each run still burns one doomed Opus dispatch
+  before the retry fires. For a single architect or reviewer dispatch
+  hitting Opus quota mid-batch, the kickoff routing rules own the response:
+  a per-call Fable override (the Agent tool's `model` param), logged as a
+  decision, no pin flip (`.claude/skills/tm-kickoff/SKILL.md`). The ladder
+  is Opus -> Fable -> Sonnet; Sonnet is never a fallback for a judgment seat
+  on its own terms, and only steps in, flagged, if Fable is also down, with
+  the review re-run on a judgment model afterward. Revert trigger: if
+  judgment quality visibly degrades on real batches, flip the architect,
+  reviewer, and critic pins back to fable and log the decision here.
 - Cost-based fallback trigger: if Fable 5 stops being included under the
   Max-plan subscription and shifts to metered API billing, do not switch to
   Opus automatically. Measure the lead's actual $/session cost at API rates
@@ -217,11 +222,11 @@ Rationale: docs/team-guide-rationale.md.
   `docs/reviews/2026-06-30-orchestration-comparison.md`. Keep `/effort` at
   `xhigh` and use the tm- scripts; use `ultracode` only for a one-off heavy
   task with no tm- script, preferring an Opus lead for that prompt.
-- Role agents (frontmatter `model:`): `architect`/`reviewer` run `fable`
-  (`opus` is the documented fallback); `developer`, `tester`,
+- Role agents (frontmatter `model:`): `architect`/`reviewer` run `opus`
+  (`fable` is the documented per-call fallback); `developer`, `tester`,
   `fact-checker`, `docs-writer`, `perf-investigator` run `sonnet`
   (`fact-checker` stays on Sonnet, not Haiku). Each agent also pins its own
-  effort (`sonnet` -> `high`, `fable` -> `xhigh`), independent of the
+  effort (`sonnet` -> `high`, `opus` -> `xhigh`), independent of the
   session's `/effort` setting.
 - Effort ceiling: `xhigh`. Nothing runs at `max`. Effort inherits to any seat
   that does not pin it. The effort-policy test in `npm test` fails any agent
@@ -230,7 +235,7 @@ Rationale: docs/team-guide-rationale.md.
   the strong model for synthesis or critique, bounded by construction so it
   cannot fan out unboundedly (`.claude/workflows/*.js`;
   docs/superpowers/specs/2026-06-13-review-codebase-design.md). A
-  cheaper-led session still gets Fable-quality judgment; a Fable-led session
+  cheaper-led session still gets Opus-quality judgment; a Fable-led session
   never pays Fable rates for worker stages.
 - Do not set `CLAUDE_CODE_SUBAGENT_MODEL`. It flattens every subagent to one
   model, defeating the split above. Use only as a temporary seatbelt (e.g.

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -7,8 +7,8 @@
  * agent or workflow stage that omits its pin (and would silently inherit the
  * session effort) fails here instead of shipping.
  *
- * `opus` carries fable's xhigh so the documented Fable-outage fallback is
- * usable: flipping a judgment seat's pin from fable to opus keeps its effort
+ * `fable` carries opus's xhigh so the documented per-call fallback is
+ * usable: flipping a judgment seat's pin from opus to fable keeps its effort
  * unchanged and still passes. Without that entry the fallback the Model policy
  * prescribes fails this suite the moment anyone follows it.
  */

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -7,10 +7,12 @@
  * agent or workflow stage that omits its pin (and would silently inherit the
  * session effort) fails here instead of shipping.
  *
- * `fable` carries opus's xhigh so the documented per-call fallback is
- * usable: flipping a judgment seat's pin from opus to fable keeps its effort
- * unchanged and still passes. Without that entry the fallback the Model policy
- * prescribes fails this suite the moment anyone follows it.
+ * `fable` carries opus's xhigh so the pin-flip revert path stays valid:
+ * flipping a judgment seat's pin from opus back to fable keeps its effort
+ * unchanged and still passes. (The per-call fallback, the Agent tool's model
+ * param, is effort-neutral and separate from this pin; it stays invisible to
+ * this static test either way.) Without that entry the revert the Model
+ * policy prescribes fails this suite the moment anyone follows it.
  */
 
 import { test, describe } from 'node:test'
@@ -72,7 +74,7 @@ describe('agent frontmatter effort pins', () => {
 // Agent-call opts in both workflows are single-line objects carrying both
 // label: and model:. The meta.phases display entries carry model: but
 // title:/detail: instead of label:, so requiring label: excludes them. The
-// criticWithFallback retry opts (`{ ...opts, model: 'opus' }`) also carry
+// criticWithFallback retry opts (`{ ...opts, model: 'fable' }`) also carry
 // model: with no label: and no literal effort:, so the same filter excludes
 // them too; that is safe because the spread inherits effort: from the
 // caller's opts line, which this test already checks.

--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -402,7 +402,7 @@ describe('scoutDropped union', () => {
 // ===========================================================================
 describe('criticWithFallback', () => {
   const FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
-  const baseOpts = { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: { type: 'object' } }
+  const baseOpts = { label: 'consolidate', phase: 'Consolidate', model: 'opus', effort: 'xhigh', schema: { type: 'object' } }
 
   test('happy path: first agent call succeeds, result returned unchanged', async () => {
     const calls = []
@@ -424,7 +424,7 @@ describe('criticWithFallback', () => {
     assert.equal('modelFallback' in result, false)
   })
 
-  test('first call returns null, retries on opus and succeeds', async () => {
+  test('first call returns null, retries on fable and succeeds', async () => {
     const calls = []
     const logs = []
     const sandbox = {
@@ -440,7 +440,7 @@ describe('criticWithFallback', () => {
 
     assert.equal(calls.length, 2)
     const secondOpts = calls[1].opts
-    assert.equal(secondOpts.model, 'opus')
+    assert.equal(secondOpts.model, 'fable')
     assert.equal(secondOpts.effort, baseOpts.effort)
     assert.equal(secondOpts.label, baseOpts.label)
     assert.equal(secondOpts.phase, baseOpts.phase)
@@ -448,7 +448,7 @@ describe('criticWithFallback', () => {
     assert.ok(calls[1].prompt.includes('the prompt'), 'second prompt still carries the original prompt')
     assert.ok(calls[1].prompt.length > 'the prompt'.length, 'second prompt carries an added notice')
     assert.equal(result.verdict, 'approve')
-    assert.equal(result.modelFallback, 'fable -> opus')
+    assert.equal(result.modelFallback, 'opus -> fable')
     assert.ok(logs.length >= 1, 'log() must be called to surface the fallback')
   })
 

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -1,11 +1,11 @@
 export const meta = {
   name: 'tm-map-codebase',
   description:
-    'Token-bounded full-repo map: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker maps each area (purpose, entry points, key modules, data and control flow, external dependencies, conventions), and one Fable critic synthesizes a dated architecture map. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling. This is a map, not a review: no findings, no severities, no recommendations.',
+    'Token-bounded full-repo map: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker maps each area (purpose, entry points, key modules, data and control flow, external dependencies, conventions), and one Opus critic synthesizes a dated architecture map. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling. This is a map, not a review: no findings, no severities, no recommendations.',
   phases: [
     { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', model: 'sonnet' },
     { title: 'Map', detail: 'one Sonnet worker per area describes it', model: 'sonnet' },
-    { title: 'Synthesize', detail: 'one Fable critic writes the consolidated map', model: 'fable' },
+    { title: 'Synthesize', detail: 'one Opus critic writes the consolidated map', model: 'opus' },
   ],
 }
 
@@ -15,8 +15,8 @@ export const meta = {
 // but never exceeds MAX_AREAS + 2, no matter how large the repo is or how many
 // areas the scout proposes. There is no per-file fan-out and no loop. Models and
 // effort are pinned per stage, so the session model and effort never leak into
-// the scout or the workers; the single critic runs Fable 5 at xhigh effort and
-// auto-retries once on opus at the same effort if Fable returns nothing
+// the scout or the workers; the single critic runs Opus 5 at xhigh effort and
+// auto-retries once on fable at the same effort if Opus returns nothing
 // (criticWithFallback below; see team-guide for the lead-level fallback,
 // which is still manual).
 //
@@ -58,13 +58,13 @@ function safeRef(value, fallback) {
 const root = safeRef(opts.path, '.')
 const MAX_AREAS = Number.isInteger(opts.areas) && opts.areas > 0 ? opts.areas : 24
 
-// Duplicated byte-for-byte across the three tm- workflows that run a Fable
+// Duplicated byte-for-byte across the three tm- workflows that run an Opus
 // critic (the workflow runtime has no shared imports); keep this copy in
 // sync, see helpers.test.mjs.
 async function criticWithFallback(prompt, opts) {
   const first = await agent(prompt, opts)
   // agent() returns null both when the model errors out after retries (for
-  // example Fable 5 quota exhaustion) and when the user skips the dispatch
+  // example Opus 5 quota exhaustion) and when the user skips the dispatch
   // mid-run. Nothing in this script can tell those two cases apart, so there
   // is no heuristic to invent here. The ruling is on which failure mode is
   // worse: retrying a deliberate skip costs one extra skip prompt (the retry
@@ -73,19 +73,19 @@ async function criticWithFallback(prompt, opts) {
   // costs the entire unattended run. Retry unconditionally.
   if (first) return first
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on opus at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on fable at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the opus fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'opus' }
+    `${prompt}\n\nNOTE: this is a retry on the fable fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'fable' }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the fable fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the fable fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> opus` }
+  return { ...second, modelFallback: `${opts.model} -> fable` }
 }
 
 const AREA = {
@@ -265,7 +265,7 @@ const suggestedNextActionClause = ceilingReached
 
 const report = await criticWithFallback(
   `You are the senior architect synthesizing a full-codebase map from the area descriptions below. This is a map, not a review: do not add findings, severities, recommendations, or quality and security judgments. Describe what is there.${coverageNote}\n\nRun \`date +%F\` for today's date, make the docs/architecture/ directory if it does not exist, and write docs/architecture/<date>-codebase-map.md with exactly these sections, in this order:\n1. Executive summary: what the repo is and how its areas fit together, in a few paragraphs.\n2. Component table: one row per area, with columns for area, purpose, and key modules.\n3. Data-flow narrative: how data moves across areas, end to end.\n4. Dependency summary: external dependencies (packages, services) and cross-area dependencies.\n5. Open questions: anything the workers could not determine or that needs a human to confirm.\n\nIf coverage is partial, add a "Coverage" callout immediately after the executive summary stating how many paths were not mapped and the suggested next action.\n\nSet reportPath to the file you wrote. Set summary to a short plain-language summary of the whole repo. Set openQuestions to the same list you put in the report's Open Questions section.\n\nSet coverage.areasMapped to ${JSON.stringify(mappedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nArea maps (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'synthesize', phase: 'Synthesize', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }
+  { label: 'synthesize', phase: 'Synthesize', model: 'opus', effort: 'xhigh', schema: REPORT_SCHEMA }
 )
 
 return report

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -1,20 +1,20 @@
 export const meta = {
   name: 'tm-review-changes',
   description:
-    'Token-bounded code review: Sonnet workers review the diff across fixed dimensions, one Fable critic consolidates. Models are pinned per stage in-script, so it never inherits the session model or fans out unboundedly.',
+    'Token-bounded code review: Sonnet workers review the diff across fixed dimensions, one Opus critic consolidates. Models are pinned per stage in-script, so it never inherits the session model or fans out unboundedly.',
   phases: [
     { title: 'Review', detail: 'one Sonnet worker per dimension', model: 'sonnet' },
-    { title: 'Consolidate', detail: 'one Fable critic verifies and merges findings', model: 'fable' },
+    { title: 'Consolidate', detail: 'one Opus critic verifies and merges findings', model: 'opus' },
   ],
 }
 
 // Bounded by construction. The dimension list is fixed, there is no per-file
 // fan-out and no loop, so a run is exactly DIMENSIONS.length Sonnet workers plus
-// one Fable critic. It cannot become the 100-agent fan-out that an unpinned
+// one Opus critic. It cannot become the 100-agent fan-out that an unpinned
 // session-model review produces. Models and effort are pinned per
 // stage, so the session model and effort never leak into the workers; the
-// single critic runs Fable 5 at xhigh effort and auto-retries once on opus
-// at the same effort if Fable returns nothing (criticWithFallback below;
+// single critic runs Opus 5 at xhigh effort and auto-retries once on fable
+// at the same effort if Opus returns nothing (criticWithFallback below;
 // see team-guide for the lead-level fallback, which is still manual).
 //
 // Invoke with an optional base ref:
@@ -28,13 +28,13 @@ function safeRef(value, fallback) {
 }
 const base = safeRef(args && args.base, 'origin/main')
 
-// Duplicated byte-for-byte across the three tm- workflows that run a Fable
+// Duplicated byte-for-byte across the three tm- workflows that run an Opus
 // critic (the workflow runtime has no shared imports); keep this copy in
 // sync, see helpers.test.mjs.
 async function criticWithFallback(prompt, opts) {
   const first = await agent(prompt, opts)
   // agent() returns null both when the model errors out after retries (for
-  // example Fable 5 quota exhaustion) and when the user skips the dispatch
+  // example Opus 5 quota exhaustion) and when the user skips the dispatch
   // mid-run. Nothing in this script can tell those two cases apart, so there
   // is no heuristic to invent here. The ruling is on which failure mode is
   // worse: retrying a deliberate skip costs one extra skip prompt (the retry
@@ -43,19 +43,19 @@ async function criticWithFallback(prompt, opts) {
   // costs the entire unattended run. Retry unconditionally.
   if (first) return first
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on opus at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on fable at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the opus fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'opus' }
+    `${prompt}\n\nNOTE: this is a retry on the fable fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'fable' }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the fable fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the fable fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> opus` }
+  return { ...second, modelFallback: `${opts.model} -> fable` }
 }
 
 // This list is diff-scoped and intentionally longer than tm-review-codebase's
@@ -174,7 +174,7 @@ const coverageNote = dropped.length
 phase('Consolidate')
 const report = await criticWithFallback(
   `You are the senior reviewer. ${covered.length} parallel reviewers produced the raw findings below.${coverageNote} ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: 'Consolidate', model: 'opus', effort: 'xhigh', schema: REPORT_SCHEMA }
 )
 
 return report

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -1,11 +1,11 @@
 export const meta = {
   name: 'tm-review-codebase',
   description:
-    'Token-bounded full-repo review: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker reviews each area plus one Sonnet architecture worker audits repo-wide structure, and one Fable critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling.',
+    'Token-bounded full-repo review: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker reviews each area plus one Sonnet architecture worker audits repo-wide structure, and one Opus critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling.',
   phases: [
     { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', model: 'sonnet' },
     { title: 'Review', detail: 'one Sonnet worker per area plus one architecture worker', model: 'sonnet' },
-    { title: 'Consolidate', detail: 'one Fable critic verifies, writes the report, consolidates', model: 'fable' },
+    { title: 'Consolidate', detail: 'one Opus critic verifies, writes the report, consolidates', model: 'opus' },
   ],
 }
 
@@ -16,8 +16,8 @@ export const meta = {
 // large the repo is or how many areas the scout proposes. There is no per-file
 // fan-out and no loop. Models and effort are pinned per stage, so the
 // session model and effort never leak into the scout or the workers; the
-// single critic runs Fable 5 at xhigh effort and auto-retries once on opus
-// at the same effort if Fable returns nothing (criticWithFallback below;
+// single critic runs Opus 5 at xhigh effort and auto-retries once on fable
+// at the same effort if Opus returns nothing (criticWithFallback below;
 // see team-guide for the lead-level fallback, which is still manual).
 //
 // When the repo is too big for MAX_AREAS areas to cover, the leftover paths are
@@ -51,13 +51,13 @@ function safeRef(value, fallback) {
 const root = safeRef(opts.path, '.')
 const MAX_AREAS = Number.isInteger(opts.areas) && opts.areas > 0 ? opts.areas : 24
 
-// Duplicated byte-for-byte across the three tm- workflows that run a Fable
+// Duplicated byte-for-byte across the three tm- workflows that run an Opus
 // critic (the workflow runtime has no shared imports); keep this copy in
 // sync, see helpers.test.mjs.
 async function criticWithFallback(prompt, opts) {
   const first = await agent(prompt, opts)
   // agent() returns null both when the model errors out after retries (for
-  // example Fable 5 quota exhaustion) and when the user skips the dispatch
+  // example Opus 5 quota exhaustion) and when the user skips the dispatch
   // mid-run. Nothing in this script can tell those two cases apart, so there
   // is no heuristic to invent here. The ruling is on which failure mode is
   // worse: retrying a deliberate skip costs one extra skip prompt (the retry
@@ -66,19 +66,19 @@ async function criticWithFallback(prompt, opts) {
   // costs the entire unattended run. Retry unconditionally.
   if (first) return first
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on opus at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on fable at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the opus fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'opus' }
+    `${prompt}\n\nNOTE: this is a retry on the fable fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'fable' }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the opus fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the opus fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the fable fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the fable fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> opus` }
+  return { ...second, modelFallback: `${opts.model} -> fable` }
 }
 
 // FINDING and FINDINGS_SCHEMA are a shared base intentionally duplicated with
@@ -276,7 +276,7 @@ const suggestedNextActionClause = ceilingReached
 
 const report = await criticWithFallback(
   `You are the senior reviewer consolidating a full-codebase review. The workers below produced the raw findings.${coverageNote}\n\nVerify each finding against the actual code, drop false positives and anything out of scope, merge duplicates (including the same problem found in two areas), and set a final severity. You may add a finding only if it is a clear must-fix the workers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nThen write the report file. Run \`date +%F\` for today's date, make the docs/reviews/ directory if it does not exist, and write docs/reviews/<date>-codebase-review.md with: the verdict and summary first; then a one-line health impression scored 0-10 and up to three named top risks; then, if coverage is partial, a prominent "Coverage: PARTIAL" callout immediately after that opening block that states how many paths were not reviewed and the suggested next action; then the findings as severity sections (must-fix, then should-fix, then nit), each organized by area; then a final "Coverage" section listing the areas reviewed, the paths not covered, the workers that failed, and (if partial) the suggested next action. Set reportPath to the file you wrote.\n\nReturn the structured summary. Set coverage.areasReviewed to ${JSON.stringify(reviewedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: 'Consolidate', model: 'fable', effort: 'xhigh', schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: 'Consolidate', model: 'opus', effort: 'xhigh', schema: REPORT_SCHEMA }
 )
 
 return report

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ below).
   CI, plugin install, design-plugin vetting). Idempotent, and does not
   delete `NEW-PROJECT-SETUP.md`.
 - `.claude/workflows/` - bounded orchestration scripts. `tm-review-changes`
-  reviews a diff with a fixed set of Sonnet reviewers plus one Fable critic;
+  reviews a diff with a fixed set of Sonnet reviewers plus one Opus critic;
   `tm-review-codebase` audits the whole repo with a Sonnet scout that splits it into
   areas (scaled to the repo, capped at a ceiling), per-area Sonnet workers, an
-  architecture worker, and one Fable critic. Both pin models in-script so the cost
+  architecture worker, and one Opus critic. Both pin models in-script so the cost
   is bounded by construction.
 - `.claude/settings.json` - enables obra's superpowers plugin per project
   (`superpowers@claude-plugins-official`; the methodology skills:
@@ -76,13 +76,13 @@ graph TD
     H["Human<br/>files and sizes issues, merges PRs"] --> L
     L["Lead - main session<br/>fable, xhigh<br/>routes every handoff"]
 
-    L -->|"1 sub-plan"| A["architect<br/>fable, xhigh<br/>read-only - approach"]
+    L -->|"1 sub-plan"| A["architect<br/>opus, xhigh<br/>read-only - approach"]
     A -.->|"sub-plan"| L
     L -->|"2 implement"| D["developer<br/>sonnet, high<br/>worktree - TDD - draft PR"]
     D -.->|"branch + PR"| L
     L -->|"3 test"| T["tester<br/>sonnet, high<br/>read-only - re-runs suite"]
     T -.->|"verdict"| L
-    L -->|"4 review"| R["reviewer<br/>fable, xhigh<br/>read-only - spec then quality"]
+    L -->|"4 review"| R["reviewer<br/>opus, xhigh<br/>read-only - spec then quality"]
     R -.->|"verdict"| L
     L -.->|"fix loop"| D
     L -->|"on demand"| F["fact-checker<br/>sonnet, high<br/>read-only - audits claims"]
@@ -96,8 +96,8 @@ graph TD
     G -->|"6 human merges"| H
 
     subgraph WF["Review workflows"]
-        RC["tm-review-changes<br/>Sonnet reviewers, high<br/>+ 1 Fable critic, xhigh"]
-        RB["tm-review-codebase<br/>Sonnet scout + area workers, high<br/>+ 1 Fable critic, xhigh"]
+        RC["tm-review-changes<br/>Sonnet reviewers, high<br/>+ 1 Opus critic, xhigh"]
+        RB["tm-review-codebase<br/>Sonnet scout + area workers, high<br/>+ 1 Opus critic, xhigh"]
     end
 
     L -->|"run as slash commands"| WF

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -121,6 +121,59 @@ addendum stays silent on it. It does not overstate what the cleared test
 does: `EFFORT_BY_MODEL`'s `opus` entry permits an `opus`-pinned seat carrying
 `xhigh` effort; it does not endorse, require, or recommend running one.
 
+## Addendum, 2026-07-27: the shipped outcome is the fourth combination, not option (c)
+
+Sections 1-10 below are unchanged and stand as written on 2026-07-24, same as
+the 2026-07-25 addendum above. This addendum records what actually shipped
+(issue #284) and why it departs from section 8's recommendation.
+
+**What shipped.** `.claude/agents/architect.md`, `.claude/agents/reviewer.md`,
+and the three workflow critic stages (`tm-review-changes.js`,
+`tm-review-codebase.js`, `tm-map-codebase.js`) moved from `model: fable` to
+`model: opus`, at unchanged xhigh effort. The lead session stays on Fable 5.
+This is section 3's fourth combination, the one that document rejected as a
+candidate on 2026-07-24 ("architect/reviewer to Opus 5, lead stays Fable"),
+not option (c) (the one section 8 recommended: lead to Opus 5, everything
+else held on Fable 5 pending the effort-policy fix).
+
+**Why the fourth combination became viable.** Section 3 rejected it only
+because the frontmatter and critic-stage move would fail the effort-policy
+test, while the lead's own model carries no such pin. The 2026-07-25 addendum
+above already recorded that this blocker cleared: `EFFORT_BY_MODEL` gained an
+`opus: 'xhigh'` entry in commit `daa176e` (PR #265), before this document's
+own addendum was written. Once that entry existed, both directions (lead to
+Opus, or judgment seats to Opus) passed the same test; the fourth combination
+was never blocked on capability grounds by section 3, only by that one test.
+
+**Why this order and not section 8's.** Section 8's case for the lead move
+rests on the lead being the largest token consumer and on availability
+(section 5). Neither argument decides between the fourth combination and
+option (c); it decides lead-vs-nothing. The reason to also move architect,
+reviewer, and the critics is a different one, not in section 8: capability
+allocation. Fable 5 is worth its 2x-per-token premium only in the one seat
+nothing backstops. The lead session has no seat above it; a bad lead
+judgment call ships. Architect and reviewer output is checked by the human
+merge gate before anything lands, and a workflow critic's output is
+consumed by the lead, which can re-run or challenge it. Section 6's
+capability caution (no first-party Opus-vs-Fable comparison, vendor
+positioning ranks Fable above Opus) still applies and is why this addendum
+does not claim the fourth combination is proven better, only that the seats
+it touches are the ones a wrong call is cheapest to catch.
+
+**Revert trigger.** If judgment quality visibly degrades on real batches
+(more incorrect sub-plans, missed scope calls, or review verdicts overturned
+on later scrutiny, traceable to the architect, reviewer, or critic seats
+specifically), flip those pins back to `fable` and log the decision in
+`.claude/team-guide.md`'s Model policy section, per that section's own
+revert-trigger bullet.
+
+**What this addendum does not do.** It does not revise section 8's
+recommendation or confidence level; that recommendation was for option (c)
+and stands as written for that comparison. It does not claim the fourth
+combination is safer or better-judged than option (c) or the status quo; no
+measurement here supports a ranking. It does not touch sections 1-10 or the
+2026-07-25 addendum.
+
 ## 1. Question and scope
 
 With Opus 5 released, should the orchestrator (lead), architect, and reviewer

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -131,7 +131,7 @@ the 2026-07-25 addendum above. This addendum records what actually shipped
 and the three workflow critic stages (`tm-review-changes.js`,
 `tm-review-codebase.js`, `tm-map-codebase.js`) moved from `model: fable` to
 `model: opus`, at unchanged xhigh effort. The lead session stays on Fable 5.
-This is section 3's fourth combination, the one that document rejected as a
+This is section 3's fourth combination, that this document rejected as a
 candidate on 2026-07-24 ("architect/reviewer to Opus 5, lead stays Fable"),
 not option (c) (the one section 8 recommended: lead to Opus 5, everything
 else held on Fable 5 pending the effort-policy fix).

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -32,10 +32,10 @@ graph TD
     H["Human<br/>files and sizes issues, merges PRs"] --> L
     L["LEAD - main session (fable, xhigh effort)<br/>message bus and router<br/>owns no code; durable state lives in GitHub"]
 
-    L -->|"JOB: SUB_PLAN / SPLIT / ARBITRATION"| A["architect (fable)<br/>read-only - approach, splits, arbitration"]
+    L -->|"JOB: SUB_PLAN / SPLIT / ARBITRATION"| A["architect (opus)<br/>read-only - approach, splits, arbitration"]
     L -->|"issue + sub-plan"| D["developer (sonnet)<br/>one issue end to end - worktree - TDD - draft PR"]
     L -->|"branch + issue"| T["tester (sonnet)<br/>read-only - re-runs suite, attacks change"]
-    L -->|"PR + issue + untested claims"| R["reviewer (fable)<br/>read-only - spec pass then quality pass"]
+    L -->|"PR + issue + untested claims"| R["reviewer (opus)<br/>read-only - spec pass then quality pass"]
     L -->|"report text + branch or PR"| F["fact-checker (sonnet)<br/>read-only - audits claims against evidence"]
     L -->|"dispatch: docs to write"| DW["docs-writer (sonnet)<br/>gap analysis, then author user-facing docs"]
     L -->|"reported slowness"| P["perf-investigator (sonnet)<br/>measurement-only - baseline and target"]

--- a/docs/team-guide-rationale.md
+++ b/docs/team-guide-rationale.md
@@ -128,12 +128,12 @@ Supports: "pin worker stages to a cheap model at `high` effort in the
 script and reserve the strong model for synthesis or critique."
 
 The `tm-review-changes` workflow in `.claude/workflows/` is the worked
-example: a fixed set of Sonnet reviewers plus one Fable critic pinned to
+example: a fixed set of Sonnet reviewers plus one Opus critic pinned to
 xhigh effort, bounded by construction so it cannot fan out into the
 100-agent review that an unpinned session model produces. `tm-review-codebase`
 applies the same discipline to a whole-repo audit: a Sonnet scout splits the
 repo into N areas (sized to the repo, capped at a ceiling), Sonnet workers
-review each area plus repo-wide structure, and one Fable critic consolidates.
+review each area plus repo-wide structure, and one Opus critic consolidates.
 The agent count is N + 3, so it scales with repo size up to the ceiling and
 never fans out unboundedly. `tm-map-codebase` reuses the same
 scout/worker/critic shape for a purely descriptive map (purpose, entry


### PR DESCRIPTION
## Summary
- Flip the architect, reviewer, and three workflow critic stages from Fable 5 to Opus 5 at unchanged xhigh effort.
- Reverse the critic auto-retry direction: opus critic retries once on fable if opus returns nothing.
- Rewrite prose describing the old seat assignment (team-guide.md Model policy, SKILL.md descriptions, README, team-architecture.md, team-guide-rationale.md) and append a dated decision addendum to the Opus-vs-Fable research doc.
- The lead session's own model (Fable 5) is unchanged.

Closes #284

## Test plan
- [x] `npm test` green from repo root
- [ ] `grep -rn "Fable critic" --include="*.md" --include="*.js"` over `.claude/`, `README.md`, `docs/team-architecture.md`, `docs/team-guide-rationale.md` returns nothing