### PR TITLE
fix: apply arm B's prose findings and record the opus winner pick

### DIFF
--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -128,9 +128,10 @@ Routing rules:
   session model; the agent's own effort pin (xhigh) still applies. The
   model override is the change that permits the re-dispatch. Flag the
   fallback in the report and log the switch as a decision comment on the
-  package issue; a model switch is never silent. Sonnet is never a
-  judgment fallback for these seats. Workflow critic stages recover on
-  their own (criticWithFallback); this rule covers lead dispatches only.
+  package issue; a model switch is never silent. Sonnet is not part of
+  this per-call override; the team-guide ladder covers the case where
+  Fable is also down. Workflow critic stages recover on their own
+  (criticWithFallback); this rule covers lead dispatches only.
 - Never re-dispatch an unchanged prompt; something in the task must change
   first.
 - Cap: 3 fix rounds per stage, counted from the PR comments. Tester and

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -183,9 +183,10 @@ runs the team uninterrupted and reports (mechanics:
 
 ## Model policy
 
-The strongest model in every plan/decision seat, efficient workers everywhere
-else. The lever is where each model runs, not raw effort everywhere.
-Rationale: docs/team-guide-rationale.md.
+Fable 5 in the one seat nothing backstops (the lead), Opus 5 at xhigh in the
+backstopped judgment seats (architect, reviewer, workflow critics), efficient
+workers everywhere else. The lever is where each model runs, not raw effort
+everywhere. Rationale: docs/team-guide-rationale.md.
 
 - Orchestrator (the lead session, including `/tm-advisor` and `/tm-kickoff`):
   Fable 5 (`claude-fable-5`) at xhigh effort. Affordable only because the

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -2,7 +2,7 @@
  * Policy-lock test for the effort policy (issue #140).
  *
  * Every seat pins its own effort, so session /effort governs only the lead:
- * sonnet seats run high, fable seats run xhigh, and nothing runs at max.
+ * sonnet seats run high, opus (judgment) seats run xhigh, and nothing runs at max.
  * The test reads the real agent frontmatters and workflow sources, so a new
  * agent or workflow stage that omits its pin (and would silently inherit the
  * session effort) fails here instead of shipping.

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -174,6 +174,70 @@ combination is safer or better-judged than option (c) or the status quo; no
 measurement here supports a ranking. It does not touch sections 1-10 or the
 2026-07-25 addendum.
 
+## Addendum, 2026-07-28: the tm-ab-test ran, the human picked opus
+
+Sections 1-10 below are unchanged and stand as written on 2026-07-24, same as
+the 2026-07-25 and 2026-07-27 addenda above. This addendum records the
+outcome of the #286 `tm-ab-test` run and the human's pick.
+
+**What ran.** Issue #286 is the repo-scoped comparison section 9's first
+extend-trigger named: "a repo-scoped comparison (a `tm-ab-test` run per
+role, since none has run yet)." Both arms ran sequentially against the same
+base commit (`c0fb64e`), one reviewer dispatch and one architect dispatch
+per arm, pinned to Fable 5 (arm A) and Opus 5 (arm B). Full results:
+`docs/reviews/2026-07-27-ab-judgment-seats.md`.
+
+**What each arm produced.** Arm A's reviewer returned APPROVE with one nit;
+arm A's architect produced a complete sub-plan without running a probe. Arm
+B's reviewer returned CHANGES_REQUESTED, the same nit plus three findings no
+prior pass caught; arm B's architect returned NEEDS_DECISION, backed by
+three read-only probes showing the requested measurement is not currently
+possible. Arm B cost more (127,028 tokens against 99,212) and took longer
+(8m49s against 6m25s).
+
+**What this does not claim.** This addendum does not claim the run proves
+Opus 5 a better judgment model than Fable 5. The report itself frames one
+paired run as illustrative, not conclusive, and names the comparison
+direction, opus doing the deeper probing when vendor positioning ranks
+Fable above Opus, as unresolved: one run cannot separate model capability
+from dispatch-to-dispatch variance or prompt fit.
+
+**The human pick.** The human reviewed both arms' outputs and picked Arm B:
+opus. The PR #285 seat assignment (architect, reviewer, and the workflow
+critics on `model: opus` at xhigh) stands; no pin moves as a result of this
+addendum.
+
+**What the trigger condition required, and what satisfies it.** Section 9's
+first extend-trigger named three alternatives; the second was "a
+repo-scoped comparison (a `tm-ab-test` run per role, since none has run
+yet) shows Opus 5's judgment output on this repo's own sub-plans or reviews
+holds up against Fable 5's, not just against vendor positioning." That
+comparison has now run, on this repo's own tasks, and a human picked based
+on it. The trigger's condition is met, not because the run proved Opus
+superior, but because the comparison it called for happened and produced a
+human decision. Section 8's recommendation and confidence level are
+unchanged by this addendum, same as the two addenda above.
+
+**The revert trigger stays live.** The 2026-07-27 addendum's revert
+trigger, judgment quality visibly degrading on real batches (more incorrect
+sub-plans, missed scope calls, or review verdicts overturned on later
+scrutiny, traceable to the architect, reviewer, or critic seats), is not
+retired by this addendum. It remains the standing condition for flipping
+those pins back to `fable`.
+
+**Downstream of this run.** The three prose defects arm B's reviewer found,
+the Model policy opening thesis in `.claude/team-guide.md`, the absolute
+"Sonnet is never a judgment fallback" sentence in
+`.claude/skills/tm-kickoff/SKILL.md`, and the stale "fable seats run xhigh"
+docstring in `effort-policy.test.mjs`, are fixed in this same PR.
+
+**What this addendum does not do.** It does not touch sections 1-10 or the
+2026-07-25 and 2026-07-27 addenda above. It does not revise section 8's
+recommendation, which addressed a different comparison (option (c),
+lead-only). It does not claim the fourth combination (the shipped outcome)
+is now proven safer or better-judged; the honest framing is what each arm
+produced, not a ranking.
+
 ## 1. Question and scope
 
 With Opus 5 released, should the orchestrator (lead), architect, and reviewer


### PR DESCRIPTION
## Summary

The #286 `tm-ab-test` ran a paired reviewer/architect comparison of Fable 5 vs Opus 5 in the judgment seats (report: docs/reviews/2026-07-27-ab-judgment-seats.md). Arm B (opus) found three prose defects on merged main that no prior pass caught. This PR fixes them exactly as prescribed and records the human's winner pick durably in the research doc.

1. `.claude/team-guide.md` (~line 186): the Model policy's opening thesis, "the strongest model in every plan/decision seat", contradicted the shipped bullets beneath it. Rewritten to state the shipped rule.
2. `.claude/skills/tm-kickoff/SKILL.md` (~lines 131-132): "Sonnet is never a judgment fallback for these seats" was absolute and contradicted the team-guide ladder's both-down case. Scoped to the per-call rule.
3. `.claude/workflows/__tests__/effort-policy.test.mjs` line 5 docstring: named fable as the xhigh tier when no seat pins fable anymore. Renamed to opus (the judgment seats). `EFFORT_BY_MODEL` and all assertions are untouched.
4. `docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md`: new 2026-07-28 addendum inserted after the 2026-07-27 addendum, before section 1. Records that the #286 A/B ran on this repo's own tasks, the human picked Arm B (opus), and section 9's repo-scoped-comparison trigger is met. Does not claim the run proves Opus better (arm B cost more and took longer; one paired run is illustrative, not conclusive). Keeps the 2026-07-27 revert trigger live. Prior addenda and sections 1-10 are untouched (insertions only).

## Test plan

- [x] `npm test` green (70/70)
- [x] `git diff --stat` shows exactly 4 files
- [x] `git diff -- .claude/workflows/__tests__/effort-policy.test.mjs` shows only the line-5 docstring change; `EFFORT_BY_MODEL` not in the diff
- [x] `git diff -- docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md` shows insertions only, zero deletions
- [x] `grep -rn "strongest model" --include="*.md" .` returns only the research doc's frozen section 9 quote plus pre-existing quotes in the (untouched) A/B report
- [x] `grep -n "fable seats" .claude/workflows/__tests__/effort-policy.test.mjs` returns nothing
- [x] Full diff read for style: no em dashes, no AI-cliche words

Closes #291