### PR TITLE
fix: guard tm- skills against a redundant Skill tool call

### DIFF
--- a/.claude/skills/tm-ab-test/SKILL.md
+++ b/.claude/skills/tm-ab-test/SKILL.md
@@ -5,6 +5,10 @@ disable-model-invocation: true
 argument-hint: <task-issue-number> <arm-A-name>:headless|supervised <arm-B-name>:headless|supervised
 ---
 
+You are reading this because the user typed the command, so this skill is
+already loaded. Do not call the Skill tool for it. Start with the first step
+below.
+
 You are the lead, running a paired comparison, not a new pipeline. Every
 step below sequences existing bounded machinery (`/tm-kickoff`, a tm-
 workflow, or a single role-agent dispatch); this skill adds no new agent

--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -5,6 +5,10 @@ disable-model-invocation: true
 argument-hint: "<the need | blank to resume an open batch>"
 ---
 
+You are reading this because the user typed the command, so this skill is
+already loaded. Do not call the Skill tool for it. Start with the first step
+below.
+
 You are the advisor: the user's sparring partner and the team's dispatcher.
 You refine a raw need into work packages, hold the single sign-off gate, then
 run the batch without interrupting the user. The design behind this loop is

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -5,6 +5,10 @@ disable-model-invocation: true
 argument-hint: <issue numbers | label:<name>>
 ---
 
+You are reading this because the user typed the command, so this skill is
+already loaded. Do not call the Skill tool for it. Start with the first step
+below.
+
 You are the lead and the message bus. Agents cannot call each other; every
 handoff is you routing one agent's report into the next agent's task. Keep
 your own context lean: delegate the work, route the verdicts, decide the

--- a/.claude/skills/tm-map-codebase/SKILL.md
+++ b/.claude/skills/tm-map-codebase/SKILL.md
@@ -4,6 +4,10 @@ description: Token-bounded full-repo map, run as a workflow (Sonnet scout and ar
 disable-model-invocation: true
 ---
 
+You are reading this because the user typed the command, so this skill is
+already loaded. Do not call the Skill tool for it. Start with the first step
+below.
+
 Run the `tm-map-codebase` workflow against the whole repo. This skill exists
 only so the plugin install (`orchestrai@orchestrai`) can reach the workflow:
 the committed-repo root already exposes it directly as `/tm-map-codebase`

--- a/.claude/skills/tm-new-project/SKILL.md
+++ b/.claude/skills/tm-new-project/SKILL.md
@@ -4,6 +4,10 @@ description: "Run the once-per-repo plugin-adoption setup as a guided flow: crea
 disable-model-invocation: true
 ---
 
+You are reading this because the user typed the command, so this skill is
+already loaded. Do not call the Skill tool for it. Start with the first step
+below.
+
 Run the setup in `NEW-PROJECT-SETUP.md` against the current repo (the cwd):
 automate what can be automated, print exact commands for what cannot.
 Idempotent: each section below checks its own precondition and skips what is

--- a/.claude/skills/tm-review-changes/SKILL.md
+++ b/.claude/skills/tm-review-changes/SKILL.md
@@ -5,6 +5,10 @@ disable-model-invocation: true
 argument-hint: "[base ref, default origin/main]"
 ---
 
+You are reading this because the user typed the command, so this skill is
+already loaded. Do not call the Skill tool for it. Start with the first step
+below.
+
 Run the `tm-review-changes` workflow against the current diff. This skill
 exists only so the plugin install (`orchestrai@orchestrai`) can reach the
 workflow: the committed-repo root already exposes it directly as

--- a/.claude/skills/tm-review-codebase/SKILL.md
+++ b/.claude/skills/tm-review-codebase/SKILL.md
@@ -4,6 +4,10 @@ description: Token-bounded full-repo review, run as a workflow (Sonnet scout and
 disable-model-invocation: true
 ---
 
+You are reading this because the user typed the command, so this skill is
+already loaded. Do not call the Skill tool for it. Start with the first step
+below.
+
 Run the `tm-review-codebase` workflow against the whole repo. This skill
 exists only so the plugin install (`orchestrai@orchestrai`) can reach the
 workflow: the committed-repo root already exposes it directly as


### PR DESCRIPTION
## What

Adds one guard paragraph to the top of the body of all seven `tm-` skills, identical wording in each:

> You are reading this because the user typed the command, so this skill is already loaded. Do not call the Skill tool for it. Start with the first step below.

No frontmatter changes. `disable-model-invocation: true` stays on all seven.

## Why

An Opus 5 lead session in a consuming repo ran `/orchestrai:tm-kickoff 56 2 3 4 5 6` and then called `Skill(orchestrai:tm-kickoff)`, which the harness refused with `cannot be used with Skill tool due to disable-model-invocation`.

The refusal is correct and the flag stays. It is what keeps kickoff and advisor user-typed only (`.claude/team-guide.md:122`). The flag blocks the Skill tool, not the slash command: typing the command injects the SKILL.md body with `$ARGUMENTS` already substituted. The lead had everything it needed and only had to start executing.

Install was ruled out as a cause. The repo copy and both cached plugin copies (`~/.claude-work`, `~/.claude-personal`, orchestrai 2.2.0) had identical frontmatter, and `orchestrai@orchestrai` is enabled in both config dirs.

Cost was a wasted turn and a confusing error, not a failed run. It reads as a lead-model behavior difference, and Opus 5 is the documented manual lead fallback under Model policy, so the flows should be robust on it. All seven skills get the guard rather than only the two reported, since all seven are slash-command entry points carrying the same flag.

## Verification

- `grep` for the guard across `.claude/skills/*/SKILL.md`: 7 files, 1 occurrence each.
- `git diff -U0` contains no added or removed frontmatter lines; all 7 `disable-model-invocation: true` lines intact.
- `npm test`: 70 pass, 0 fail.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)