### PR TITLE
feat: make fable lead-session-only, sonnet the per-call judgment fallback

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,8 +2,8 @@
 name: architect
 description: Advisory lead for approach decisions. Use when an issue needs a sub-plan before implementation, when an issue looks mis-sized or needs splitting (size:L or size:XL), or when developer and reviewer disagree. Read-only; decides approach, never writes code.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Opus 5. Per-call fallback is fable = Fable 5, same xhigh
-# effort (see team-guide, Model policy).
+# Judgment role: Opus 5. Per-call fallback is sonnet = Sonnet 5, inheriting
+# this seat's xhigh effort (see team-guide, Model policy).
 model: opus
 effort: xhigh
 ---

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,8 +2,8 @@
 name: reviewer
 description: Reviews a work package diff against its issue and sub-plan, in two passes, spec compliance then code quality. Read-only; outputs APPROVE or CHANGES_REQUESTED with numbered file:line findings. Never edits files.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Opus 5. Per-call fallback is fable = Fable 5, same xhigh
-# effort (see team-guide, Model policy).
+# Judgment role: Opus 5. Per-call fallback is sonnet = Sonnet 5, inheriting
+# this seat's xhigh effort (see team-guide, Model policy).
 model: opus
 effort: xhigh
 ---

--- a/.claude/skills/tm-advisor/SKILL.md
+++ b/.claude/skills/tm-advisor/SKILL.md
@@ -168,7 +168,7 @@ advisor differs from a plain `/tm-kickoff` run in three ways:
   an interpretation call), decide it and post the decision with its reasoning
   as a comment on the batch issue before acting on it.
   An Opus-quota death on a judgment-seat dispatch is such a decision:
-  apply kickoff's per-call Fable override routing rule and log the switch
+  apply kickoff's per-call Sonnet override routing rule and log the switch
   on the batch issue. It is not grounds to park.
 - **Narrower parking gate.** Park (swap `in-progress` for `needs-human`) only
   for: a change to scope or acceptance criteria, a new dependency or cost,

--- a/.claude/skills/tm-kickoff/SKILL.md
+++ b/.claude/skills/tm-kickoff/SKILL.md
@@ -127,15 +127,15 @@ Routing rules:
   that package and report it (re-label and split per CLAUDE.md "Sizing").
 - An architect or reviewer dispatch dies on an Opus 5 limit (the limit
   error, or an empty return while Opus is exhausted): re-dispatch that one
-  agent with the same task and a per-call Fable override (the Agent tool's
-  `model` param, value `fable`). Do not flip a frontmatter pin or the
+  agent with the same task and a per-call Sonnet override (the Agent tool's
+  `model` param, value `sonnet`). Do not flip a frontmatter pin or the
   session model; the agent's own effort pin (xhigh) still applies. The
   model override is the change that permits the re-dispatch. Flag the
-  fallback in the report and log the switch as a decision comment on the
-  package issue; a model switch is never silent. Sonnet is not part of
-  this per-call override; the team-guide ladder covers the case where
-  Fable is also down. Workflow critic stages recover on their own
-  (criticWithFallback); this rule covers lead dispatches only.
+  fallback in the report, log the switch as a decision comment on the
+  package issue, and re-run the same judgment on Opus once quota returns;
+  a model switch is never silent and never the final word for a judgment
+  seat. Workflow critic stages recover on their own (criticWithFallback,
+  also sonnet); this rule covers lead dispatches only.
 - Never re-dispatch an unchanged prompt; something in the task must change
   first.
 - Cap: 3 fix rounds per stage, counted from the PR comments. Tester and

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -193,26 +193,27 @@ everywhere. Rationale: docs/team-guide-rationale.md.
   lead stays on the bounded tm- machinery. Fable costs 2x Opus 5 per
   token. The premium is bounded in aggregate, not per batch
   (docs/research/2026-07-06-token-burn-investigation.md, driver 3).
-- Lead-session fallback: Opus 5 at xhigh effort, a manual procedure. When
-  Fable 5 is unavailable, rate-limited, quota-exhausted, or refuses the
-  workload, switch the lead with `/model claude-opus-5`. Flip back when
-  Fable returns. This fallback covers the lead session only; no other seat
-  pins Fable, so no other pin needs to flip alongside it.
+- Lead-session fallback: Opus 5 at xhigh effort, a manual procedure. Fable is
+  lead-session-only: used as the orchestrator when available, and nothing
+  else in the machinery calls it. When Fable 5 is unavailable, rate-limited,
+  quota-exhausted, or refuses the workload, switch the lead with
+  `/model claude-opus-5`. Flip back when Fable returns. This fallback covers
+  the lead session only; no other seat pins Fable, so no other pin needs to
+  flip alongside it.
 - Judgment seats (architect, reviewer, workflow critics): Opus 5 at xhigh
   effort is the primary model, backstopped by the lead and, for architect
-  and reviewer, by the human merge gate. The per-call fallback is Fable 5 at
+  and reviewer, by the human merge gate. The per-call fallback is Sonnet at
   the same xhigh effort. The critic stage of every `tm-` workflow
-  (`.claude/workflows/`) already retries on fable automatically when Opus
+  (`.claude/workflows/`) already retries on sonnet automatically when Opus
   returns nothing, though each run still burns one doomed Opus dispatch
   before the retry fires. For a single architect or reviewer dispatch
   hitting Opus quota mid-batch, the kickoff routing rules own the response:
-  a per-call Fable override (the Agent tool's `model` param), logged as a
-  decision, no pin flip (`.claude/skills/tm-kickoff/SKILL.md`). The ladder
-  is Opus -> Fable -> Sonnet; Sonnet is never a fallback for a judgment seat
-  on its own terms, and only steps in, flagged, if Fable is also down, with
-  the review re-run on a judgment model afterward. Revert trigger: if
-  judgment quality visibly degrades on real batches, flip the architect,
-  reviewer, and critic pins back to fable and log the decision here.
+  a per-call Sonnet override (the Agent tool's `model` param), flagged in
+  the report, logged as a decision on the package issue, with the judgment
+  re-run on Opus once quota returns (`.claude/skills/tm-kickoff/SKILL.md`).
+  The ladder is Opus -> Sonnet, flagged and re-run; nothing else in the
+  machinery falls back to Fable. If judgment quality visibly degrades on
+  real batches, log the observation here.
 - Cost-based fallback trigger: if Fable 5 stops being included under the
   Max-plan subscription and shifts to metered API billing, do not switch to
   Opus automatically. Measure the lead's actual $/session cost at API rates
@@ -224,11 +225,14 @@ everywhere. Rationale: docs/team-guide-rationale.md.
   `xhigh` and use the tm- scripts; use `ultracode` only for a one-off heavy
   task with no tm- script, preferring an Opus lead for that prompt.
 - Role agents (frontmatter `model:`): `architect`/`reviewer` run `opus`
-  (`fable` is the documented per-call fallback); `developer`, `tester`,
+  (`sonnet` is the documented per-call fallback); `developer`, `tester`,
   `fact-checker`, `docs-writer`, `perf-investigator` run `sonnet`
   (`fact-checker` stays on Sonnet, not Haiku). Each agent also pins its own
   effort (`sonnet` -> `high`, `opus` -> `xhigh`), independent of the
-  session's `/effort` setting.
+  session's `/effort` setting. The `sonnet` -> `high` line is a pin rule for
+  seats that run sonnet as their primary model; a per-call sonnet fallback
+  on a judgment seat is not one of those pins, so it inherits the seat's
+  `xhigh` effort instead.
 - Effort ceiling: `xhigh`. Nothing runs at `max`. Effort inherits to any seat
   that does not pin it. The effort-policy test in `npm test` fails any agent
   or workflow stage that omits its pin or reintroduces max.

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -7,12 +7,12 @@
  * agent or workflow stage that omits its pin (and would silently inherit the
  * session effort) fails here instead of shipping.
  *
- * `fable` carries opus's xhigh so the pin-flip revert path stays valid:
- * flipping a judgment seat's pin from opus back to fable keeps its effort
- * unchanged and still passes. (The per-call fallback, the Agent tool's model
- * param, is effort-neutral and separate from this pin; it stays invisible to
- * this static test either way.) Without that entry the revert the Model
- * policy prescribes fails this suite the moment anyone follows it.
+ * Fable is lead-session-only (issue #298): no agent or workflow stage pins it
+ * any more, so EFFORT_BY_MODEL carries only sonnet and opus. The per-call
+ * sonnet fallback used when a judgment seat's Opus dispatch dies on quota
+ * (the Agent tool's model param) is effort-neutral and separate from this
+ * pin; it inherits the seat's xhigh effort and stays invisible to this
+ * static test either way.
  */
 
 import { test, describe } from 'node:test'
@@ -25,7 +25,7 @@ const __dir = dirname(fileURLToPath(import.meta.url))
 const workflowsDir = join(__dir, '..')
 const agentsDir = join(__dir, '..', '..', 'agents')
 
-const EFFORT_BY_MODEL = { sonnet: 'high', fable: 'xhigh', opus: 'xhigh' }
+const EFFORT_BY_MODEL = { sonnet: 'high', opus: 'xhigh' }
 const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
 
 // ===========================================================================
@@ -74,7 +74,7 @@ describe('agent frontmatter effort pins', () => {
 // Agent-call opts in both workflows are single-line objects carrying both
 // label: and model:. The meta.phases display entries carry model: but
 // title:/detail: instead of label:, so requiring label: excludes them. The
-// criticWithFallback retry opts (`{ ...opts, model: 'fable' }`) also carry
+// criticWithFallback retry opts (`{ ...opts, model: 'sonnet' }`) also carry
 // model: with no label: and no literal effort:, so the same filter excludes
 // them too; that is safe because the spread inherits effort: from the
 // caller's opts line, which this test already checks.

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -7,8 +7,8 @@
  * agent or workflow stage that omits its pin (and would silently inherit the
  * session effort) fails here instead of shipping.
  *
- * Fable is lead-session-only (issue #298): no agent or workflow stage pins it
- * any more, so EFFORT_BY_MODEL carries only sonnet and opus. The per-call
+ * The lead-only model (issue #298) no longer backs any agent or workflow
+ * stage, so EFFORT_BY_MODEL carries only sonnet and opus. The per-call
  * sonnet fallback used when a judgment seat's Opus dispatch dies on quota
  * (the Agent tool's model param) is effort-neutral and separate from this
  * pin; it inherits the seat's xhigh effort and stays invisible to this

--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -424,7 +424,7 @@ describe('criticWithFallback', () => {
     assert.equal('modelFallback' in result, false)
   })
 
-  test('first call returns null, retries on fable and succeeds', async () => {
+  test('first call returns null, retries on sonnet and succeeds', async () => {
     const calls = []
     const logs = []
     const sandbox = {
@@ -440,7 +440,7 @@ describe('criticWithFallback', () => {
 
     assert.equal(calls.length, 2)
     const secondOpts = calls[1].opts
-    assert.equal(secondOpts.model, 'fable')
+    assert.equal(secondOpts.model, 'sonnet')
     assert.equal(secondOpts.effort, baseOpts.effort)
     assert.equal(secondOpts.label, baseOpts.label)
     assert.equal(secondOpts.phase, baseOpts.phase)
@@ -448,7 +448,7 @@ describe('criticWithFallback', () => {
     assert.ok(calls[1].prompt.includes('the prompt'), 'second prompt still carries the original prompt')
     assert.ok(calls[1].prompt.length > 'the prompt'.length, 'second prompt carries an added notice')
     assert.equal(result.verdict, 'approve')
-    assert.equal(result.modelFallback, 'opus -> fable')
+    assert.equal(result.modelFallback, 'opus -> sonnet')
     assert.ok(logs.length >= 1, 'log() must be called to surface the fallback')
   })
 
@@ -469,7 +469,7 @@ describe('criticWithFallback', () => {
     // vm-realm errors are not `instanceof` the host's Error, so assert on the
     // message rather than the error's prototype chain.
     assert.match(threw.message, /consolidate/)
-    assert.match(threw.message, /fable/)
+    assert.match(threw.message, /sonnet/)
     assert.match(threw.message, /opus/)
   })
 

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -16,7 +16,7 @@ export const meta = {
 // areas the scout proposes. There is no per-file fan-out and no loop. Models and
 // effort are pinned per stage, so the session model and effort never leak into
 // the scout or the workers; the single critic runs Opus 5 at xhigh effort and
-// auto-retries once on fable at the same effort if Opus returns nothing
+// auto-retries once on sonnet at the same effort if Opus returns nothing
 // (criticWithFallback below; see team-guide for the lead-level fallback,
 // which is still manual).
 //
@@ -73,19 +73,19 @@ async function criticWithFallback(prompt, opts) {
   // costs the entire unattended run. Retry unconditionally.
   if (first) return first
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on fable at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on sonnet at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the fable fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'fable' }
+    `${prompt}\n\nNOTE: this is a retry on the sonnet fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'sonnet' }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the fable fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the fable fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the sonnet fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the sonnet fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> fable` }
+  return { ...second, modelFallback: `${opts.model} -> sonnet` }
 }
 
 const AREA = {

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -13,7 +13,7 @@ export const meta = {
 // one Opus critic. It cannot become the 100-agent fan-out that an unpinned
 // session-model review produces. Models and effort are pinned per
 // stage, so the session model and effort never leak into the workers; the
-// single critic runs Opus 5 at xhigh effort and auto-retries once on fable
+// single critic runs Opus 5 at xhigh effort and auto-retries once on sonnet
 // at the same effort if Opus returns nothing (criticWithFallback below;
 // see team-guide for the lead-level fallback, which is still manual).
 //
@@ -43,19 +43,19 @@ async function criticWithFallback(prompt, opts) {
   // costs the entire unattended run. Retry unconditionally.
   if (first) return first
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on fable at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on sonnet at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the fable fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'fable' }
+    `${prompt}\n\nNOTE: this is a retry on the sonnet fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'sonnet' }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the fable fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the fable fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the sonnet fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the sonnet fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> fable` }
+  return { ...second, modelFallback: `${opts.model} -> sonnet` }
 }
 
 // This list is diff-scoped and intentionally longer than tm-review-codebase's

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -16,7 +16,7 @@ export const meta = {
 // large the repo is or how many areas the scout proposes. There is no per-file
 // fan-out and no loop. Models and effort are pinned per stage, so the
 // session model and effort never leak into the scout or the workers; the
-// single critic runs Opus 5 at xhigh effort and auto-retries once on fable
+// single critic runs Opus 5 at xhigh effort and auto-retries once on sonnet
 // at the same effort if Opus returns nothing (criticWithFallback below;
 // see team-guide for the lead-level fallback, which is still manual).
 //
@@ -66,19 +66,19 @@ async function criticWithFallback(prompt, opts) {
   // costs the entire unattended run. Retry unconditionally.
   if (first) return first
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on fable at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on sonnet at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the fable fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'fable' }
+    `${prompt}\n\nNOTE: this is a retry on the sonnet fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: 'sonnet' }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the fable fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the fable fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the sonnet fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the sonnet fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> fable` }
+  return { ...second, modelFallback: `${opts.model} -> sonnet` }
 }
 
 // FINDING and FINDINGS_SCHEMA are a shared base intentionally duplicated with

--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -238,6 +238,22 @@ lead-only). It does not claim the fourth combination (the shipped outcome)
 is now proven safer or better-judged; the honest framing is what each arm
 produced, not a ranking.
 
+## Addendum, 2026-08-03: fable removed from every subagent and fallback role
+
+Sections 1-10 below are unchanged and stand as written on 2026-07-24, same
+as the three addenda above. This addendum records issue #298 (batch #297):
+Fable 5 is now lead-session-only. Every seat that still named `fable`,
+architect, reviewer, the workflow critics' `criticWithFallback` retry, and
+the kickoff/advisor per-call override, moves to the Opus -> Sonnet ladder:
+Sonnet flagged in the report, logged as a decision, judgment re-run on
+Opus once quota returns. The 2026-07-27 addendum's revert trigger (flip
+judgment pins back to `fable`) is retired with it; team-guide now logs the
+observation instead.
+
+**Motive.** Batch #297 is preparing plan-downgrade readiness: a lead
+session already fallen back to Opus should not also depend on Fable
+anywhere else in the machinery. A Fable outage now degrades only the lead.
+
 ## 1. Question and scope
 
 With Opus 5 released, should the orchestrator (lead), architect, and reviewer


### PR DESCRIPTION
Closes #298

## Summary
- Fable 5 becomes lead-session-only in the team's model policy: used as the
  orchestrator when available, nothing else in the machinery calls it.
- `criticWithFallback` in all three workflow scripts (`tm-review-changes.js`,
  `tm-review-codebase.js`, `tm-map-codebase.js`) retries the Opus critic on
  `sonnet` instead of `fable`, byte-identical across the three files. Header
  comments and `effort-policy.test.mjs`'s `EFFORT_BY_MODEL` updated to match
  (fable dropped from the pin table entirely).
- `tm-kickoff` and `tm-advisor` routing rules: the per-call override for an
  Opus-quota death on architect/reviewer moves from `fable` to `sonnet`,
  flagged in the report, logged as a decision, with mandatory re-review on
  Opus once quota returns.
- `architect.md` / `reviewer.md` frontmatter comments updated: "per-call
  fallback is sonnet = Sonnet 5, inheriting this seat's xhigh effort."
- Dated addendum (2026-08-03) appended to
  `docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md` recording
  the shipped change and its plan-downgrade-readiness motive (batch #297).
  Existing addenda untouched.

## Scope boundary
Mandatory re-review on Opus applies to kickoff/advisor architect/reviewer
dispatches only. The three workflow scripts only *label* the sonnet
fallback in logs/reports; there is no re-run obligation inside a workflow
run itself.

## Verification
- `npm test` -> 70 pass, 0 fail.
- `grep -rn -i fable .claude/` returns hits only in `team-guide.md`, only in
  the orchestrator bullet, the lead-session fallback bullet, the cost-based
  fallback trigger, and the workflows bullet's closing line ("a Fable-led
  session never pays Fable rates for worker stages") - that last one is a
  lead-session claim (Fable only ever runs as the lead), satisfying AC1.
- `grep -rn fable .claude/workflows/` returns nothing.
- `git diff origin/main --stat` confirms README.md, docs/team-architecture.md,
  docs/team-guide-rationale.md, and the three `tm-*/SKILL.md` workflow
  wrappers are untouched, and the untracked
  `docs/reviews/2026-07-27-ab-judgment-seats 2.md` was not swept in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)