### PR TITLE
docs: point the superseded Fable-hold recommendation at its own addendum

### DIFF
--- a/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
+++ b/docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
@@ -544,6 +544,13 @@ leave architect, reviewer, and the three workflow critic stages on Fable 5
 until the effort-policy test gains an `opus` tier in a follow-up issue.
 Confidence: medium.**
 
+> **Later note, added 2026-08-03, outside the 2026-07-24 analysis.** The
+> condition this recommendation names, an `opus` tier in the effort-policy
+> test, was already met when this document merged. See "Addendum, 2026-07-25:
+> the effort-policy blocker is cleared" above, which sets out what that does
+> and does not change, and the addenda after it for what later shipped. The
+> recommendation and confidence level above are unchanged.
+
 This is option (c), not (b): a full move would fail the effort-policy test
 today (section 7), and the vendor's own capability claim (section 6) argues
 against moving the two structurally-bounded judgment seats for quality
@@ -639,6 +646,13 @@ shows Opus 5's judgment output on this repo's own sub-plans or reviews holds
 up against Fable 5's, not just against vendor positioning; or Fable-limit
 exhaustion events recur often enough to look like a rate rather than four
 isolated events across three documented occasions.
+
+> **Later note, added 2026-08-03, outside the 2026-07-24 analysis.** The
+> first condition in the extend-trigger above, an `opus` tier in the
+> effort-policy test, is already met. See "Addendum, 2026-07-25: the
+> effort-policy blocker is cleared" above, which explains why meeting it does
+> not by itself move the seats, and the addenda after it for what later
+> shipped. The trigger text above is unchanged.
 
 **To revert the lead-only move:** the lead's own scoping and parking decisions
 visibly degrade on Opus 5, traceable to real batch outcomes (missed scope


### PR DESCRIPTION
Closes #274

## What changed

Two additive blockquote markers in `docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md`:

- **Marker A**, after section 8's bold recommendation ("Confidence: medium.") and before its justification paragraph.
- **Marker B**, after section 9's extend-trigger paragraph and before its revert-trigger paragraph.

Both point at the "Addendum, 2026-07-25: the effort-policy blocker is cleared" heading by its exact string (no line numbers), and note that the condition each site names (an `opus` tier in the effort-policy test) was already met when the document merged. Neither marker is labeled "Superseded": the recommendation and confidence level stand, only the stated blocking condition is cleared.

No existing line changes.

## Additive proof

```
$ git diff --numstat -- docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
14	0	docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md
```

14 insertions, 0 deletions. `git diff -U0` on the file confirms every changed line is a `+`.

## Deliberately untouched

The 2026-07-25 addendum's own site index (its `L...` line-number entries) is not touched. Those entries are already stale (three more addenda have landed since 2026-07-25) and both insertions in this PR push everything below them a few lines further off. Re-anchoring that index is out of scope for this issue; the index carries section headings and grep phrases alongside the numbers precisely so it tolerates drift.

## Verification run

- `npm test` - 70/70 pass, exit 0.
- `git diff --numstat -- docs/research/2026-07-24-opus-5-vs-fable-5-judgment-seats.md` - `14  0` (0 deletions).
- `git diff --stat` - one file changed, 14 insertions(+).
- `git diff -U0` - every changed line is a `+`.
- `git diff | grep '^+' | grep -E 'L[0-9]|:[0-9]+'` - no output (no line-number citation introduced).
- `git diff | grep '^+' | grep -- '—'` - no output (no em dashes).
- `sed -n '134p'` on the delivered file - still reads "This is section 3's fourth combination, that this document rejected as a", matching the external citation from `docs/reviews/2026-07-27-ab-judgment-seats.md:166`.
- Read both markers in place (section 8 and section 9): a reader who never saw the addendum learns the condition is met without needing the addendum's own prose.
