### PR TITLE
hoist neutral process core into .claude/process-core.md

### DIFF
--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -28,7 +28,7 @@ Two phases, in order.
    for. Do not expand scope to every gap found in phase 1; note the rest in
    your report instead (see below).
 
-Your prose follows the "Writing style" section of `.claude/team-guide.md`
+Your prose follows the "Writing style" section of `.claude/process-core.md`
 (no em dashes, no AI-cliche phrases, plain direct English, short sentences):
 you are the one seat whose entire output is user-facing prose, so that section
 binds you more than it binds any other seat.

--- a/.claude/process-core.md
+++ b/.claude/process-core.md
@@ -1,12 +1,10 @@
 # Process core
 
-Neutral process guidance: no team roster, no model names, no tool names. Anything
-here should hold for a solo contributor or a different agent stack, not just this
-one. Team-specific process guidance (the agent roster, the advisor model, model
-policy, how to pick up a task) lives in `.claude/team-guide.md`. The repo root
-`CLAUDE.md` imports both files directly, this one first; a nested import from
-`team-guide.md` does not resolve for a plugin consumer, so each importing file
-lists both.
+Harness-neutral process guidance: it should hold for a solo contributor or a
+different agent stack, not just this one team. Team-specific process guidance
+(the agent roster, the advisor model, model policy, how to pick up a task)
+lives in `.claude/team-guide.md`. See README.md and CLAUDE.md for how a
+project or config dir imports both files.
 
 ## How we work
 
@@ -55,9 +53,8 @@ later (see "How to pick up a task" in .claude/team-guide.md).
 - Logic that has a right answer (math, parsing, business rules) is TDD: write the
   failing test against known inputs first, then the code.
 - Integration clients are tested against saved fixtures, not live endpoints.
-- End-to-end tests live in `e2e/` and gate deployment (see Repo layout). Run them
-  locally before pushing any change that touches the full stack. Unit-green is not
-  e2e-green.
+- End-to-end tests live in `e2e/` and gate deployment. Run them locally before
+  pushing any change that touches the full stack. Unit-green is not e2e-green.
 
 ### CI cost policy
 

--- a/.claude/process-core.md
+++ b/.claude/process-core.md
@@ -1,0 +1,90 @@
+# Process core
+
+Neutral process guidance: no team roster, no model names, no tool names. Anything
+here should hold for a solo contributor or a different agent stack, not just this
+one. Team-specific process guidance (the agent roster, the advisor model, model
+policy, how to pick up a task) lives in `.claude/team-guide.md`, which imports
+this file.
+
+## How we work
+
+### Issues and branches
+
+- Every unit of work is a GitHub issue first. Nothing new gets built without an issue.
+- Branch from `main` per issue: `feat/<issue-number>-<short-slug>` or
+  `fix/<issue-number>-<short-slug>`.
+- Merge via PR. Direct pushes to `main` are blocked.
+- The PR references the issue with `Closes #N`. One topic per PR.
+
+### Sizing (t-shirt size per issue)
+
+Every issue carries a t-shirt size label, estimated in human working hours:
+
+- `size:S` - under 1 hour. One focused change.
+- `size:M` - 1 to 3 hours. Write a sub-plan first.
+- `size:L` - 4 to 6 hours. Split into smaller issues, or break into checkpointed
+  sub-plans (below).
+- `size:XL` - a full day, about 8 hours. Too big to start as one issue. Split it.
+
+Size the issue when you file it, then re-check while planning. If the full
+plan shows the work is bigger than its label, re-label and split rather than
+push through (rationale: docs/team-guide-rationale.md).
+
+### Sub-plans (checkpoint before deep work)
+
+Before any deep planning or implementation, write a short sub-plan first: a
+handful of checkpoint bullets (the approach, the files you expect to touch, the
+order, the verification step) posted in the issue or the draft PR. This is cheap
+insurance: if the connection drops or the session hits its limit, the next
+session reads the checkpoint and resumes instead of restarting. For anything
+sized `M` or larger, the sub-plan is also where you confirm the work still fits
+one session and decompose it if it does not. Expanding it into a full plan comes
+later (see "How to pick up a task").
+
+### Commits
+
+- Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`,
+  `perf:`, `build:`, `ci:`.
+- Imperative mood, lowercase, no period.
+- The body explains why, not what.
+
+### Tests
+
+- Logic that has a right answer (math, parsing, business rules) is TDD: write the
+  failing test against known inputs first, then the code.
+- Integration clients are tested against saved fixtures, not live endpoints.
+- End-to-end tests live in `e2e/` and gate deployment (see Repo layout). Run them
+  locally before pushing any change that touches the full stack. Unit-green is not
+  e2e-green.
+
+### CI cost policy
+
+- Agents verify locally first; CI is the final gate, not the first check.
+- e2e in CI runs on ready-for-review PRs and on pushes to `main` only. Draft
+  PRs run cheaper checks instead (typecheck, lint, unit).
+- Every CI job pins `timeout-minutes`. A `concurrency` group with
+  `cancel-in-progress: true` is mandatory on every workflow.
+- Making a repo public to escape the free-minutes limit is forbidden. Fix the
+  workflow instead.
+- See the CI template under `.claude/skills/tm-new-project/` for the worked
+  example.
+
+### Writing style (commits, PRs, docs, comments)
+
+- No em dashes. Use regular hyphens, commas, or parentheses.
+- No AI-cliche phrases ("leverage", "robust", "seamless", "comprehensive",
+  "elevate", "delve", "in the realm of", "it's worth noting", "moreover",
+  "furthermore"). Plain, direct English. Short sentences.
+- Add a comment only when the why is non-obvious. Do not restate what the code does.
+
+## What not to do
+
+- Don't push directly to `main`. Open a PR.
+- Don't merge a PR that has not run the full check suite, including e2e if the
+  change touches the stack.
+- Don't bypass git hooks (`--no-verify`). If a hook fails, fix the cause.
+- Don't introduce a new dependency without saying why in the PR body.
+
+## When in doubt
+
+Ask. A 30-second clarifying question beats a 30-minute wrong direction.

--- a/.claude/process-core.md
+++ b/.claude/process-core.md
@@ -3,8 +3,10 @@
 Neutral process guidance: no team roster, no model names, no tool names. Anything
 here should hold for a solo contributor or a different agent stack, not just this
 one. Team-specific process guidance (the agent roster, the advisor model, model
-policy, how to pick up a task) lives in `.claude/team-guide.md`, which imports
-this file.
+policy, how to pick up a task) lives in `.claude/team-guide.md`. The repo root
+`CLAUDE.md` imports both files directly, this one first; a nested import from
+`team-guide.md` does not resolve for a plugin consumer, so each importing file
+lists both.
 
 ## How we work
 

--- a/.claude/process-core.md
+++ b/.claude/process-core.md
@@ -41,7 +41,7 @@ insurance: if the connection drops or the session hits its limit, the next
 session reads the checkpoint and resumes instead of restarting. For anything
 sized `M` or larger, the sub-plan is also where you confirm the work still fits
 one session and decompose it if it does not. Expanding it into a full plan comes
-later (see "How to pick up a task").
+later (see "How to pick up a task" in .claude/team-guide.md).
 
 ### Commits
 

--- a/.claude/skills/tm-new-project/templates/ci.yml
+++ b/.claude/skills/tm-new-project/templates/ci.yml
@@ -4,7 +4,7 @@
 # placeholder `run:` command with this repo's real install, typecheck,
 # lint, unit test, build, and e2e commands. The structure encodes the CI
 # cost policy: staged jobs, pinned timeouts, concurrency cancellation, and
-# a draft-PR skip for build/e2e. See team-guide.md's CI cost policy section
+# a draft-PR skip for build/e2e. See process-core.md's CI cost policy section
 # for the reasoning.
 
 name: CI

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -213,8 +213,9 @@ New project commands follow the same rule: name them `tm-<thing>`.
 
 - Don't improve `.claude/` machinery only in this repo. Change the template
   (sv-tmueller/orchestrai) first, then run `/plugin update` in each config dir
-  to pick it up. The config-dir CLAUDE.md imports `team-guide.md` from the
-  marketplace clone, so that file updates automatically once the plugin does.
+  to pick it up. The config-dir CLAUDE.md imports `process-core.md` and
+  `team-guide.md` from the marketplace clone, so both files update
+  automatically once the plugin does.
 
 See `.claude/process-core.md`'s "What not to do" for the branch, merge-gate,
 git-hook, and dependency rules.

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -1,77 +1,8 @@
+@process-core.md
+
 # Team guide
 
 Generic process guidance for the orchestrator team. Project specifics live in each repo's CLAUDE.md.
-
-## How we work
-
-### Issues and branches
-
-- Every unit of work is a GitHub issue first. Nothing new gets built without an issue.
-- Branch from `main` per issue: `feat/<issue-number>-<short-slug>` or
-  `fix/<issue-number>-<short-slug>`.
-- Merge via PR. Direct pushes to `main` are blocked.
-- The PR references the issue with `Closes #N`. One topic per PR.
-
-### Sizing (t-shirt size per issue)
-
-Every issue carries a t-shirt size label, estimated in human working hours:
-
-- `size:S` - under 1 hour. One focused change.
-- `size:M` - 1 to 3 hours. Write a sub-plan first.
-- `size:L` - 4 to 6 hours. Split into smaller issues, or break into checkpointed
-  sub-plans (below).
-- `size:XL` - a full day, about 8 hours. Too big to start as one issue. Split it.
-
-Size the issue when you file it, then re-check while planning. If the full
-plan shows the work is bigger than its label, re-label and split rather than
-push through (rationale: docs/team-guide-rationale.md).
-
-### Sub-plans (checkpoint before deep work)
-
-Before any deep planning or implementation, write a short sub-plan first: a
-handful of checkpoint bullets (the approach, the files you expect to touch, the
-order, the verification step) posted in the issue or the draft PR. This is cheap
-insurance: if the connection drops or the session hits its limit, the next
-session reads the checkpoint and resumes instead of restarting. For anything
-sized `M` or larger, the sub-plan is also where you confirm the work still fits
-one session and decompose it if it does not. Expanding it into a full plan comes
-later (see "How to pick up a task").
-
-### Commits
-
-- Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`,
-  `perf:`, `build:`, `ci:`.
-- Imperative mood, lowercase, no period.
-- The body explains why, not what.
-
-### Tests
-
-- Logic that has a right answer (math, parsing, business rules) is TDD: write the
-  failing test against known inputs first, then the code.
-- Integration clients are tested against saved fixtures, not live endpoints.
-- End-to-end tests live in `e2e/` and gate deployment (see Repo layout). Run them
-  locally before pushing any change that touches the full stack. Unit-green is not
-  e2e-green.
-
-### CI cost policy
-
-- Agents verify locally first; CI is the final gate, not the first check.
-- e2e in CI runs on ready-for-review PRs and on pushes to `main` only. Draft
-  PRs run cheaper checks instead (typecheck, lint, unit).
-- Every CI job pins `timeout-minutes`. A `concurrency` group with
-  `cancel-in-progress: true` is mandatory on every workflow.
-- Making a repo public to escape the free-minutes limit is forbidden. Fix the
-  workflow instead.
-- See the CI template under `.claude/skills/tm-new-project/` for the worked
-  example.
-
-### Writing style (commits, PRs, docs, comments)
-
-- No em dashes. Use regular hyphens, commas, or parentheses.
-- No AI-cliche phrases ("leverage", "robust", "seamless", "comprehensive",
-  "elevate", "delve", "in the realm of", "it's worth noting", "moreover",
-  "furthermore"). Plain, direct English. Short sentences.
-- Add a comment only when the why is non-obvious. Do not restate what the code does.
 
 ## Workflow defaults
 
@@ -255,7 +186,8 @@ Moving the team between Max and Pro: docs/operations/plan-downgrade-runbook.md.
 2. Pick an unassigned issue with no unresolved blockers. Check its `size:` label;
    if it is unsized, size it first, and if it is `L` or `XL`, decompose it before
    starting.
-3. Post a short sub-plan on the issue (the checkpoint bullets above).
+3. Post a short sub-plan on the issue (the checkpoint bullets in
+   `.claude/process-core.md`'s "Sub-plans" section).
 4. Create a branch and open a draft PR linking the issue (`Closes #N`).
 5. Expand the sub-plan into a full plan via `superpowers:writing-plans`, saved to
    `docs/plans/<issue-number>-<slug>.md`. If the plan reveals the issue is bigger
@@ -281,17 +213,11 @@ New project commands follow the same rule: name them `tm-<thing>`.
 
 ## What not to do
 
-- Don't push directly to `main`. Open a PR.
-- Don't merge a PR that has not run the full check suite, including e2e if the
-  change touches the stack.
-- Don't bypass git hooks (`--no-verify`). If a hook fails, fix the cause.
 - Don't improve `.claude/` machinery only in this repo. Change the template
   (sv-tmueller/orchestrai) first, then run `/plugin update` in each config dir
   to pick it up. The config-dir CLAUDE.md imports `team-guide.md` from the
   marketplace clone, so that file updates automatically once the plugin does.
-- Don't introduce a new dependency without saying why in the PR body.
+
+See `.claude/process-core.md`'s "What not to do" for the branch, merge-gate,
+git-hook, and dependency rules.
 <!-- Add project-specific traps here: the mistakes that quietly break this codebase. -->
-
-## When in doubt
-
-Ask. A 30-second clarifying question beats a 30-minute wrong direction.

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -1,5 +1,3 @@
-@process-core.md
-
 # Team guide
 
 Generic process guidance for the orchestrator team. Project specifics live in each repo's CLAUDE.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # AGENTS.md
 
 Orientation for any AGENTS.md-aware worker seat (Codex today; other tools
-read this same file) working in this repo. This file is self-contained: it
-does not use Claude's `@` import syntax, so read it in full, not just the
-headings.
+read this same file) working in this repo. The full instructions are this
+file plus the one doc it names, `.claude/process-core.md`: no Claude `@`
+import syntax here, so read both files in full, not just the headings.
 
 ## What this repo is
 
@@ -29,21 +29,6 @@ This runs the unit tests with Node's built-in test runner. There are zero
 runtime dependencies. There is no application runtime, so install, dev,
 typecheck, and lint are N/A. Run `npm test` before any commit.
 
-## Writing style
-
-Applies to commits, PRs, docs, and comments:
-
-- No em dashes. Use regular hyphens, commas, or parentheses.
-- No AI-cliche phrases: "leverage", "robust", "seamless", "comprehensive",
-  "elevate", "delve", "in the realm of", "it's worth noting", "moreover",
-  "furthermore". Plain, direct English. Short sentences.
-- Add a comment only when the why is non-obvious. Do not restate what the
-  code does.
-
-Commits follow Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`,
-`test:`, `refactor:`, `perf:`, `build:`, `ci:`. Imperative mood, lowercase,
-no period. The body explains why, not what.
-
 ## Repo layout
 
 ```
@@ -57,19 +42,19 @@ docs/
   team-architecture.md  flat-star agent-team diagrams and rationale
 ```
 
-`.claude/` holds Claude-host machinery (agents, skills, workflows). A
-non-Claude seat may read it for context but never executes or modifies it.
+`.claude/` holds Claude-host machinery (agents, skills, workflows) plus one
+process doc, `.claude/process-core.md`. A non-Claude seat may read the
+machinery for context but never executes or modifies it; `process-core.md`
+is different, it is normative for this seat too (see Guardrails).
 
 ## Guardrails
 
-- Every unit of work is a GitHub issue first. Nothing new gets built without
-  an issue.
-- Branch from `main` per issue: `feat/<issue-number>-<short-slug>` or
-  `fix/<issue-number>-<short-slug>`.
-- Merge via PR. The PR references the issue with `Closes #N`. One topic per
-  PR. Direct pushes to `main` are blocked.
-- Never bypass git hooks (`--no-verify`). If a hook fails, fix the cause.
-- Do not introduce a new dependency without saying why in the PR body.
+Read `.claude/process-core.md` in full: it covers issues and branches,
+sizing, sub-plans, commits, tests, CI cost policy, writing style, and the
+neutral what-not-to-do rules (no direct push to `main`, full check suite
+before merge, no `--no-verify`, no undeclared dependency). It applies to
+this seat unchanged.
+
 - `.claude/` changes are template-first: this repo (sv-tmueller/orchestrai)
   is the template. Machinery changes land here and propagate to other repos
   through the plugin, never as one-off forks in consumer repos.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ The generic team process guidance lives in `.claude/team-guide.md` and loads via
 
 ## Code style
 
-Follow the "Writing style" section in `.claude/team-guide.md` for commits,
+Follow the "Writing style" section in `.claude/process-core.md` for commits,
 PRs, docs, and comments. The JS in this repo follows the zero-dependency test
 style (see "Useful commands").
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,10 @@ When code and a doc disagree, the code wins and the doc is corrected in the same
 
 ## Team process
 
-The generic team process guidance lives in `.claude/team-guide.md` and loads via the import below:
+The neutral process core and the team-specific process guidance load via the
+imports below, core first:
 
+@.claude/process-core.md
 @.claude/team-guide.md
 
 ## Code style

--- a/NEW-PROJECT-SETUP.md
+++ b/NEW-PROJECT-SETUP.md
@@ -10,7 +10,7 @@ Run once when adopting the orchestrai plugin into an existing repo.
 - [ ] Protect `main`: block direct pushes, require a PR, require status checks to
       pass before merge.
 - [ ] (Optional) Create the labels the workflow uses: the sizing set `size:S`,
-      `size:M`, `size:L`, `size:XL` (see team-guide.md "Sizing") plus
+      `size:M`, `size:L`, `size:XL` (see process-core.md "Sizing") plus
       `in-progress` and `needs-human` (see team-guide.md "Agent team").
       `/tm-kickoff` and `/tm-advisor` create these six automatically on first
       run, including `/tm-advisor` (file only). So this step is only needed if

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ below).
 - `CLAUDE.md` - standing guidance for Claude Code sessions: what the repo is,
   where decisions live, code style, useful commands.
 - `.claude/team-guide.md` - team-specific process guidance (agent team,
-  advisor model, model policy, how-to-pick-up-a-task, repo layout). Imports
-  `.claude/process-core.md` for the neutral rules that hold regardless of
+  advisor model, model policy, how-to-pick-up-a-task, repo layout).
+  `.claude/process-core.md` holds the neutral rules that hold regardless of
   team or model (issues/branches/commits conventions, sizing, sub-plans,
-  tests, CI cost policy, writing style, what-not-to-do). Imported by the
-  repo CLAUDE.md; a config dir imports it from the marketplace clone instead
-  (see "Getting the team into your repos" below).
+  tests, CI cost policy, writing style, what-not-to-do). The repo `CLAUDE.md`
+  imports both files directly, core first; a config dir imports both from the
+  marketplace clone instead (see "Getting the team into your repos" below).
 - `NEW-PROJECT-SETUP.md` - the once-per-repo adoption checklist: branch
   protection, installing the plugin, docs structure, CI/CD and e2e wiring,
   and the first slice of work. Stays in the repo as a living checklist; it
@@ -128,12 +128,21 @@ Current Claude Code builds may also register the two workflows directly under
 the plugin namespace, producing duplicate menu entries; this is undocumented
 behavior, and the wrapper skills remain the supported path.
 
-A plugin cannot place `team-guide.md` where a config-dir `CLAUDE.md` can
-import it, so wire that import yourself: add
-`@plugins/marketplaces/orchestrai/.claude/team-guide.md` to
-`<config-dir>/CLAUDE.md` (the path is relative to that file; the marketplace
-clone auto-updates, so the import always tracks the latest guide). Note that
-a config-dir `CLAUDE.md` replaces `~/.claude/CLAUDE.md` instead of stacking
+A plugin cannot place `team-guide.md` and `process-core.md` where a config-dir
+`CLAUDE.md` can import them, so wire both imports yourself: add
+
+```text
+@plugins/marketplaces/orchestrai/.claude/process-core.md
+@plugins/marketplaces/orchestrai/.claude/team-guide.md
+```
+
+to `<config-dir>/CLAUDE.md` (the paths are relative to that file; the
+marketplace clone auto-updates, so the imports always track the latest
+guides). A nested import from `team-guide.md` to `process-core.md` does not
+resolve for a plugin consumer, so both files must be imported directly; if
+your config dir already has the single `team-guide.md` import line from
+before this change, add the `process-core.md` line above it. Note that a
+config-dir `CLAUDE.md` replaces `~/.claude/CLAUDE.md` instead of stacking
 with it, so re-import the four global coding principles in the same file if
 you rely on them. A repo that carries its own committed team overrides the
 plugin's copy, so the two never clash.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ below).
 
 - `CLAUDE.md` - standing guidance for Claude Code sessions: what the repo is,
   where decisions live, code style, useful commands.
-- `.claude/team-guide.md` - generic team process guidance (agent team, advisor
-  model, model policy, sizing, the issues/branches/commits conventions,
-  how-to-pick-up-a-task, what-not-to-do). Imported by the repo CLAUDE.md; a
-  config dir imports it from the marketplace clone instead (see "Getting the
-  team into your repos" below).
+- `.claude/team-guide.md` - team-specific process guidance (agent team,
+  advisor model, model policy, how-to-pick-up-a-task, repo layout). Imports
+  `.claude/process-core.md` for the neutral rules that hold regardless of
+  team or model (issues/branches/commits conventions, sizing, sub-plans,
+  tests, CI cost policy, writing style, what-not-to-do). Imported by the
+  repo CLAUDE.md; a config dir imports it from the marketplace clone instead
+  (see "Getting the team into your repos" below).
 - `NEW-PROJECT-SETUP.md` - the once-per-repo adoption checklist: branch
   protection, installing the plugin, docs structure, CI/CD and e2e wiring,
   and the first slice of work. Stays in the repo as a living checklist; it

--- a/docs/architecture/operating-model.md
+++ b/docs/architecture/operating-model.md
@@ -45,7 +45,7 @@ packages before anything is filed. Owned by
 `docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md`.
 
 **Refine to sized, filed issues.** Signed-off packages become GitHub issues,
-sized and stress-tested. Owned by `.claude/team-guide.md` ("Issues and
+sized and stress-tested. Owned by `.claude/process-core.md` ("Issues and
 branches", "Sizing"), `/tm-grill-me`, and `/tm-advisor` (file only).
 
 **Flat-star pipeline.** Each issue runs through architect, developer, tester,

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -1,8 +1,10 @@
 # Agent team architecture
 
 How the orchestrator team actually runs. The operating rules live in
-`.claude/team-guide.md`; this doc adds the picture. The per-package mechanics
-(parking, caps, routing) live in `.claude/skills/tm-kickoff/SKILL.md`.
+`.claude/team-guide.md` (which imports the neutral core,
+`.claude/process-core.md`); this doc adds the picture. The per-package
+mechanics (parking, caps, routing) live in
+`.claude/skills/tm-kickoff/SKILL.md`.
 
 "Agent team" is this template's name for the flat-star pattern below, not
 Claude Code's experimental agent-teams feature (enabled with

--- a/docs/team-architecture.md
+++ b/docs/team-architecture.md
@@ -1,8 +1,9 @@
 # Agent team architecture
 
 How the orchestrator team actually runs. The operating rules live in
-`.claude/team-guide.md` (which imports the neutral core,
-`.claude/process-core.md`); this doc adds the picture. The per-package
+`.claude/team-guide.md` and the neutral core, `.claude/process-core.md`
+(imported together, core first, by the repo `CLAUDE.md`); this doc adds the
+picture. The per-package
 mechanics (parking, caps, routing) live in
 `.claude/skills/tm-kickoff/SKILL.md`.
 

--- a/docs/team-guide-rationale.md
+++ b/docs/team-guide-rationale.md
@@ -1,8 +1,9 @@
 # Team guide rationale
 
-Evidence and rationale relocated from `.claude/team-guide.md`. The operative
-rules live there; this file holds the why and the numbers. Organized by
-source section, each chunk headed by the rule it supports.
+Evidence and rationale relocated from `.claude/team-guide.md` and
+`.claude/process-core.md`. The operative rules live there; this file holds
+the why and the numbers. Organized by source section, each chunk headed by
+the rule it supports.
 
 ## Workflow defaults
 


### PR DESCRIPTION
Closes #305

## Summary
Portability phase 1: split the neutral process guidance (issues/branches, sizing, sub-plans,
commits, tests, CI cost policy, writing style, the neutral what-not-to-do bullets, when-in-doubt)
out of `.claude/team-guide.md` into a standalone `.claude/process-core.md`.

Wiring is the **flat shape**, not the sub-plan's primary nested-import shape: the repo root
`CLAUDE.md` imports both `@.claude/process-core.md` and `@.claude/team-guide.md` directly, core
first. A nested import (`team-guide.md` containing `@process-core.md`) does not resolve for a
plugin consumer; see "Sentinel probe" below. `team-guide.md` keeps everything team-specific
(workflow defaults, agent team, operating model, model policy, how to pick up a task, repo layout,
the template-first what-not-to-do bullet).

Pointer sweep done: `CLAUDE.md` (Code style, and the two imports above), `AGENTS.md` (drops its own
Writing style section and the now-duplicated Guardrails bullets, points at `.claude/process-core.md`
as a plain path since it has no `@` import syntax; unaffected by the flat-vs-nested question),
`README.md` (repo-layout bullet plus the "Getting the team into your repos" consumer instructions,
now two import lines and a migration note), `NEW-PROJECT-SETUP.md`, `docs/architecture/operating-model.md`,
`docs/team-architecture.md`, `docs/team-guide-rationale.md`, `.claude/agents/docs-writer.md`.

Out of scope (per sub-plan): dated records under `docs/reviews/` and `docs/research/` that cite
`team-guide.md` line numbers, and `docs/superpowers/specs/2026-08-03-provider-portability-design.md`
line 236 (already stale before this change). Left untouched, they describe the state at their date.

## Sentinel probe: nested shape fails, flat shape validated (lead's run)

The developer dispatch could not run the sub-plan's live sentinel probe from the sandboxed
worktree (credentialed `claude -p` invocations were denied by the sandbox's auto-mode classifier;
see the prior revision of this PR body for the detail). The lead ran the probe outside the sandbox
against PR head `52aba73` and posted the result as a fix-round finding on this PR. Quoting that
finding verbatim, as the lead's run, not this developer's:

> Probe setup: detached worktree of PR head 52aba73 symlinked as `plugins/marketplaces/orchestrai`
> under a scratch project dir whose CLAUDE.md carried the byte-identical consumer import line;
> uncommitted sentinels appended to `process-core.md` (`SENTINEL-305-...`) and `team-guide.md`
> (`SENTINEL-TG-...`); headless `claude -p` (haiku) asked to print each sentinel if loaded. This
> replicates the consumer clone path structurally; the outer config-dir hop itself is
> production-proven for team-guide.md today.
>
> - Nested shape (team-guide.md contains `@process-core.md`): `FOUND-TG NO-CORE`. The outer hop
>   through the symlinked clone resolves; the nested hop does not. The `NO-CORE` with the sentinel
>   present in the file is also the negative control: nothing leaks through another channel.
> - Flat shape (importing file lists both `@.../process-core.md` and `@.../team-guide.md`; nested
>   line removed): `FOUND-TG FOUND-CORE`.

This contradicts the previous revision of this PR body, which substituted Claude Code's official
docs ("imports can recursively import other files, with a maximum depth of four hops") as evidence
the nested shape would resolve. That docs claim did not hold in this harness; it is dropped rather
than kept as a hedge. The empirical result governs: the nested import line
(`.claude/team-guide.md`'s `@process-core.md`) is removed, and `CLAUDE.md` imports both files
directly (flat shape), per the sub-plan's own validated fallback.

**Caveat carried forward:** this developer dispatch still could not run the probe itself (same
sandbox restriction as before). The evidence above is the lead's transcript, not a probe this PR's
author executed, and the lead's run tested the flat shape as a manual variant against PR head
`52aba73` (nested import line removed for that arm), not the actual committed files from this fix
round. A reviewer or tester with an authenticated `claude -p` session should re-run the probe
against this PR's final files for independent confirmation before merge.

## Verification

`npm test`: 70/70 pass, exit 0.

No-content-drift (mechanical diff per moved section, pre-change vs. new home): empty diff for
every one of `### Issues and branches`, `### Sizing`, `### Sub-plans`, `### Commits`, `### Tests`,
`### CI cost policy`, `### Writing style`, the four neutral `## What not to do` bullets, and
`## When in doubt`. No heading-level change; every heading kept its original level and text.
(Re-run after this fix round; the section moves themselves are unchanged from the prior revision,
only the import wiring changed.)

No-second-copy grep (distinctive strings of each hoisted rule, across `CLAUDE.md`, `AGENTS.md`,
`.claude/team-guide.md`):

```
AGENTS.md:55:before merge, no `--no-verify`, no undeclared dependency). It applies to
.claude/team-guide.md:98:- A batch is up to 6 independent `size:S`/`size:M` issues, run through the
```

Both are pointer/incidental matches, not restated rules: the `AGENTS.md` line is the Guardrails
paragraph naming what `.claude/process-core.md` covers (a summary pointer, not a duplicated
bullet); the `team-guide.md` line is pre-existing, unrelated content in "Operating model
(advisor)" describing batch composition, not a copy of the Sizing section's rule text.

None of this ran against a real config dir; the lead's sentinel probe used a throwaway
`CLAUDE_CONFIG_DIR` and a symlinked worktree clone, never a real one.

### Fix round 2 (tester finding 1)

`process-core.md:44` carried an unnamed cross-reference, `(see "How to pick up a task")`, to a
heading that lives only in `team-guide.md` after the hoist. It resolved as a same-document
reference before the split; a reader of `process-core.md` alone can no longer resolve it. Fixed by
naming the file: `(see "How to pick up a task" in .claude/team-guide.md)`.

This means the `### Sub-plans` section's no-drift diff against `origin/main`'s `team-guide.md` is
no longer empty, intentionally: that one parenthetical now differs, everything else in the section
is unchanged. `npm test` re-run: 70/70 pass, exit 0. `process-core.md:58`'s pre-existing ambiguous
`(see Repo layout)` is untouched, byte-identical to `origin/main`, out of scope for this fix round.

### Fix round 3 (reviewer round 1, commit `665d445`)

Four findings, all pointer or prose fixes, no wiring change:

1. `.claude/skills/tm-new-project/templates/ci.yml:7` still named `team-guide.md`'s CI cost policy
   section after the move; repointed to `process-core.md`. Checked first: the ci-template-policy
   test asserts only structural properties (jobs, timeouts, concurrency, draft-PR gating), not this
   comment's text, so the fix carries no test risk.
2. `process-core.md:3`'s header overclaimed ("no team roster, no model names, no tool names") and
   restated Claude `@`-import mechanics already covered in README.md and CLAUDE.md. Softened to a
   harness-neutral framing and replaced the import-mechanics paragraph with a pointer to those two
   files.
3. `team-guide.md:216`'s template-first bullet described `/plugin update` refreshing a single file
   (`team-guide.md`); named both `process-core.md` and `team-guide.md`, since a consumer now imports
   two files from the marketplace clone.
4. `process-core.md:58`'s `(see Repo layout)` pointed at a heading that, post-hoist, lives only in
   other documents, none of which actually document `e2e/`; dropped the parenthetical rather than
   name a target doc that doesn't cover the claim.

This means the `### Tests` section's no-drift diff against `origin/main`'s `team-guide.md` is no
longer empty either, intentionally: it now differs only by the dropped `(see Repo layout)`
parenthetical. `npm test` re-run: 70/70 pass, exit 0. No-second-copy grep re-run: same two
pointer-only matches as before, unchanged.

## Test plan
- [x] `npm test` (70/70, exit 0; re-run again on fix round 3, `665d445`)
- [x] No-drift diffs for each moved section (empty, except `### Sub-plans` and `### Tests`, which
      now intentionally differ from `origin/main` by the named-pointer fix and the dropped
      parenthetical above)
- [x] No-second-copy grep sweep (pointer-only matches, re-run on fix round 3, unchanged)
- [x] Pointer sweep across the listed files, including the flat-vs-nested correction
- [x] Live sentinel probe: run by the lead outside this sandbox against PR head `52aba73` with a
      manual flat-shape variant (see "Sentinel probe" above), not against this fix round's final
      files and not by this developer dispatch
- [x] Re-run the live sentinel probe against this PR's final files, outside the sandbox, before
      merge: done by the lead (PR comment on head `e787bad`), both the consumer shape and the repo
      shape reported `FOUND-CORE FOUND-TG`; no outside-sandbox re-run needed before merge. Heads
      `913bbd7` (fix round 2) and `665d445` (fix round 3) touch only prose inside `process-core.md`
      and `team-guide.md`, never an `@` import line, so the probe result on `e787bad` still covers
      them.


