### PR TITLE
feat: adapter interface and model tier abstraction

### DIFF
--- a/.claude/adapters/claude-code.json
+++ b/.claude/adapters/claude-code.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Adapter table for the Claude Code host. Maps model tiers to concrete models and efforts. The process layer and tests reference tiers, never model names. Adding a new model means editing this table, not the process layer or agent role contracts. See docs/superpowers/specs/2026-08-14-portable-orchestrator-design.md section 3.3.",
+  "host": "claude-code",
+  "description": "Reference adapter. Wraps the Claude Code Agent tool and Workflow tool runtime.",
+  "tiers": {
+    "judgment": { "model": "opus", "effort": "xhigh" },
+    "worker": { "model": "sonnet", "effort": "high" },
+    "lead": { "model": "fable", "effort": "xhigh" }
+  },
+  "roles": {
+    "architect": "judgment",
+    "developer": "worker",
+    "docs-writer": "worker",
+    "fact-checker": "worker",
+    "perf-investigator": "worker",
+    "reviewer": "judgment",
+    "tester": "worker"
+  },
+  "effort_ceiling": "xhigh",
+  "forbidden_efforts": ["max"]
+}

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,8 +2,10 @@
 name: architect
 description: Advisory lead for approach decisions. Use when an issue needs a sub-plan before implementation, when an issue looks mis-sized or needs splitting (size:L or size:XL), or when developer and reviewer disagree. Read-only; decides approach, never writes code.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Opus 5. Per-call fallback is sonnet = Sonnet 5, inheriting
-# this seat's xhigh effort (see team-guide, Model policy).
+# Tier: judgment. Resolved to model+effort via the adapter table
+# (.claude/adapters/claude-code.json). Per-call fallback is the worker
+# tier, inheriting this seat's effort (see team-guide, Model policy).
+tier: judgment
 model: opus
 effort: xhigh
 ---

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -2,6 +2,9 @@
 name: developer
 description: Implements exactly one GitHub issue end to end (branch, TDD, conventional commits, draft PR).
 tools: Read, Grep, Glob, Bash, Write, Edit, TodoWrite, WebFetch
+# Tier: worker. Resolved to model+effort via the adapter table
+# (.claude/adapters/claude-code.json).
+tier: worker
 model: sonnet
 effort: high
 isolation: worktree

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -2,6 +2,9 @@
 name: docs-writer
 description: Authors or updates user-facing documentation (README, guides, API docs) from a gap analysis of what is missing or stale. Dispatch on demand, for example after a tm-map-codebase run, when user-facing docs are missing or stale. Never part of the per-package kickoff pipeline; one dispatch, no fan-out.
 tools: Read, Grep, Glob, Write, Edit
+# Tier: worker. Resolved to model+effort via the adapter table
+# (.claude/adapters/claude-code.json).
+tier: worker
 model: sonnet
 effort: high
 ---

--- a/.claude/agents/fact-checker.md
+++ b/.claude/agents/fact-checker.md
@@ -2,6 +2,9 @@
 name: fact-checker
 description: Audits the factual claims in a report, sub-plan, PR description, or agent output against reproducible evidence. Use after a developer DONE report, a batch final report, or any output whose claims matter but carry no evidence. Read-only; returns per-claim verdicts (VERIFIED, CONTRADICTED, UNVERIFIED) with the exact command behind each. Never fixes anything.
 tools: Read, Grep, Glob, Bash
+# Tier: worker. Resolved to model+effort via the adapter table
+# (.claude/adapters/claude-code.json).
+tier: worker
 model: sonnet
 effort: high
 isolation: worktree

--- a/.claude/agents/perf-investigator.md
+++ b/.claude/agents/perf-investigator.md
@@ -2,6 +2,9 @@
 name: perf-investigator
 description: Establishes a measured performance baseline and target before any code changes, for a reported slowness. Use only when a package's job is specifically a performance investigation, outside the per-package pipeline. Never edits code; returns a baseline-and-target report the lead hands to developer before implementation and to tester for the after-measurement.
 tools: Read, Grep, Glob, Bash
+# Tier: worker. Resolved to model+effort via the adapter table
+# (.claude/adapters/claude-code.json).
+tier: worker
 model: sonnet
 effort: high
 isolation: worktree

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,8 +2,10 @@
 name: reviewer
 description: Reviews a work package diff against its issue and sub-plan, in two passes, spec compliance then code quality. Read-only; outputs APPROVE or CHANGES_REQUESTED with numbered file:line findings. Never edits files.
 tools: Read, Grep, Glob, Bash
-# Judgment role: Opus 5. Per-call fallback is sonnet = Sonnet 5, inheriting
-# this seat's xhigh effort (see team-guide, Model policy).
+# Tier: judgment. Resolved to model+effort via the adapter table
+# (.claude/adapters/claude-code.json). Per-call fallback is the worker
+# tier, inheriting this seat's effort (see team-guide, Model policy).
+tier: judgment
 model: opus
 effort: xhigh
 ---

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -2,6 +2,9 @@
 name: tester
 description: Independent verification of a work package branch. Runs the full check suite and tries to break the change. Read-only on the repo; reports PASS or numbered failures with reproduction commands. Never fixes code.
 tools: Read, Grep, Glob, Bash
+# Tier: worker. Resolved to model+effort via the adapter table
+# (.claude/adapters/claude-code.json).
+tier: worker
 model: sonnet
 effort: high
 isolation: worktree

--- a/.claude/team-guide.md
+++ b/.claude/team-guide.md
@@ -201,8 +201,8 @@ issue, with the sub-plan comment standing in for step 5's full plan (see
 
 ## Repo layout (team)
 
-`.claude/` holds `agents/`, `skills/`, `workflows/`, and `settings.json`
-(full annotated tree: docs/team-guide-rationale.md).
+`.claude/` holds `agents/`, `skills/`, `workflows/`, `adapters/`, and
+`settings.json` (full annotated tree: docs/team-guide-rationale.md).
 
 Every skill and workflow built in this repo carries the `tm-` prefix
 (`/tm-advisor`, `/tm-kickoff`, `/tm-review-changes`, and so on), marking them

--- a/.claude/workflows/__tests__/adapter-table.test.mjs
+++ b/.claude/workflows/__tests__/adapter-table.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Adapter table structural test (issue #313).
+ *
+ * Validates the STRUCTURE of every adapter table JSON file in
+ * .claude/adapters/: required tiers present, every tier has a model and
+ * effort, every role maps to a known tier, and every agent file has a
+ * corresponding role.
+ *
+ * CONFORMANCE CHECKS (does the table match the policy?) live in
+ * effort-policy.test.mjs, not here. This file checks structure only;
+ * that file checks values. The role-to-agent-file cross-checks live
+ * here exclusively (review #320 finding 4).
+ *
+ * Host-agnostic: iterates every *.json in the adapters directory, so a
+ * future Hermes or Codex adapter table is validated automatically
+ * (review #320 finding 5).
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const adaptersDir = join(__dir, '..', '..', 'adapters')
+const agentsDir = join(__dir, '..', '..', 'agents')
+
+const REQUIRED_TIERS = ['judgment', 'worker', 'lead']
+const REQUIRED_TIER_FIELDS = ['model', 'effort']
+
+// Load every adapter table in the directory.
+const adapterFiles = readdirSync(adaptersDir).filter((f) => f.endsWith('.json'))
+const adapterTables = adapterFiles.map((f) => ({
+  name: f,
+  path: join(adaptersDir, f),
+  table: JSON.parse(readFileSync(join(adaptersDir, f), 'utf8')),
+}))
+
+test('at least one adapter table exists', () => {
+  assert.ok(adapterTables.length > 0, `no *.json files found in ${adaptersDir}`)
+})
+
+for (const { name, table } of adapterTables) {
+  describe(`adapter table structure: ${name}`, () => {
+    test('has a tiers map', () => {
+      assert.ok(table.tiers, `${name}: must have a tiers map`)
+      assert.ok(typeof table.tiers === 'object', `${name}: tiers must be an object`)
+    })
+
+    test('has all required tiers', () => {
+      for (const tier of REQUIRED_TIERS) {
+        assert.ok(
+          table.tiers[tier],
+          `${name}: missing required tier "${tier}"`
+        )
+      }
+    })
+
+    test('every tier maps to a model and an effort', () => {
+      for (const [tier, cfg] of Object.entries(table.tiers)) {
+        for (const field of REQUIRED_TIER_FIELDS) {
+          assert.ok(
+            cfg[field],
+            `${name}: tier "${tier}" is missing "${field}"`
+          )
+        }
+      }
+    })
+
+    test('has a roles map', () => {
+      assert.ok(table.roles, `${name}: must have a roles map`)
+      assert.ok(typeof table.roles === 'object', `${name}: roles must be an object`)
+    })
+
+    test('every role maps to a known tier', () => {
+      for (const [role, tier] of Object.entries(table.roles)) {
+        assert.ok(
+          table.tiers[tier],
+          `${name}: role "${role}" maps to tier "${tier}", which is not in the tiers map`
+        )
+      }
+    })
+
+    test('every role in the table has a corresponding agent file', () => {
+      const agentNames = readdirSync(agentsDir)
+        .filter((f) => f.endsWith('.md'))
+        .map((f) => f.replace(/\.md$/, ''))
+      for (const role of Object.keys(table.roles)) {
+        assert.ok(
+          agentNames.includes(role),
+          `${name}: references role "${role}" but no ${role}.md found in ${agentsDir}`
+        )
+      }
+    })
+
+    test('every agent file has a role in the table', () => {
+      const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith('.md'))
+      for (const file of agentFiles) {
+        const role = file.replace(/\.md$/, '')
+        assert.ok(
+          table.roles[role],
+          `${name}: agent file ${file} has no entry in the roles map`
+        )
+      }
+    })
+  })
+}

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -1,18 +1,25 @@
 /**
- * Policy-lock test for the effort policy (issue #140).
+ * Policy-lock test for the effort policy (issue #140, migrated to tier
+ * assertions in #313, hardened in review of #320).
  *
- * Every seat pins its own effort, so session /effort governs only the lead:
- * sonnet seats run high, opus (judgment) seats run xhigh, and nothing runs at max.
- * The test reads the real agent frontmatters and workflow sources, so a new
- * agent or workflow stage that omits its pin (and would silently inherit the
- * session effort) fails here instead of shipping.
+ * Every seat pins its own effort, so session /effort governs only the
+ * lead. The test reads the adapter table (.claude/adapters/claude-code.json)
+ * to derive tier-to-model and tier-to-effort mappings, then asserts each
+ * agent frontmatter's tier, model, and effort are consistent with the
+ * table.
  *
- * The lead-only model (issue #298) no longer backs any agent or workflow
- * stage, so EFFORT_BY_MODEL carries only sonnet and opus. The per-call
- * sonnet fallback used when a judgment seat's Opus dispatch dies on quota
- * (the Agent tool's model param) is effort-neutral and separate from this
- * pin; it inherits the seat's xhigh effort and stays invisible to this
- * static test either way.
+ * POLICY VALUES ARE HARDCODED IN THIS FILE, NOT READ FROM THE TABLE.
+ * The forbidden efforts list and the effort ceiling are the authority;
+ * the adapter table must conform to them, not the reverse. Otherwise
+ * editing the JSON disables the lock (review #320 finding 2).
+ *
+ * Lead tier is rejected on agent seats and workflow stages: fable is
+ * lead-session-only (team-guide Model policy); letting it onto a worker
+ * seat is a live 2x-cost regression path (review #320 finding 1).
+ *
+ * The workflow stage pins (the agent() calls in the three .js files) are
+ * checked the same way: each stage's model must correspond to a tier in
+ * the adapter table, and its effort must match that tier's effort.
  */
 
 import { test, describe } from 'node:test'
@@ -24,14 +31,132 @@ import { join, dirname } from 'node:path'
 const __dir = dirname(fileURLToPath(import.meta.url))
 const workflowsDir = join(__dir, '..')
 const agentsDir = join(__dir, '..', '..', 'agents')
+const adaptersDir = join(__dir, '..', '..', 'adapters')
 
-const EFFORT_BY_MODEL = { sonnet: 'high', opus: 'xhigh' }
+// ---------------------------------------------------------------------------
+// Policy constants: THESE ARE THE AUTHORITY, not the adapter table.
+// The adapter table must conform to these values. If someone edits the
+// JSON to weaken the policy, these hardcoded values still catch it.
+// ---------------------------------------------------------------------------
+const FORBIDDEN_EFFORTS = ['max']
+const EFFORT_CEILING = 'xhigh'
+const ALLOWED_AGENT_TIERS = ['judgment', 'worker']
+
+const EFFORT_RANK = { low: 0, medium: 1, high: 2, xhigh: 3, max: 4 }
+
+// ---------------------------------------------------------------------------
+// Load the adapter table and derive tier mappings.
+// ---------------------------------------------------------------------------
+const adapterTable = JSON.parse(readFileSync(join(adaptersDir, 'claude-code.json'), 'utf8'))
+const TIERS = adapterTable.tiers
+const ROLE_TIERS = adapterTable.roles
+
+// Build tier -> effort for quick lookup.
+const EFFORT_BY_TIER = {}
+for (const [tier, cfg] of Object.entries(TIERS)) {
+  EFFORT_BY_TIER[tier] = cfg.effort
+}
+
+// Build tier -> model for quick lookup.
+const MODEL_BY_TIER = {}
+for (const [tier, cfg] of Object.entries(TIERS)) {
+  MODEL_BY_TIER[tier] = cfg.model
+}
+
+// ---------------------------------------------------------------------------
+// Load every adapter table in the directory (review #320 finding 15).
+// ---------------------------------------------------------------------------
+const adapterFiles = readdirSync(adaptersDir).filter((f) => f.endsWith('.json'))
+const adapterTables = adapterFiles.map((f) => ({
+  name: f,
+  table: JSON.parse(readFileSync(join(adaptersDir, f), 'utf8')),
+}))
+
+// Hardcoded seat-level expectations: these are the policy, not the table.
+// A coordinated edit to the JSON cannot weaken them (review #320 finding 14).
+const SEAT_EXPECTATIONS = {
+  judgment: { model: 'opus', effort: 'xhigh' },
+  worker: { model: 'sonnet', effort: 'high' },
+  lead: { model: 'fable', effort: 'xhigh' },
+}
+
 const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
 
 // ===========================================================================
-// 1. Agent frontmatter: every role agent pins model and the matching effort
+// 0. Every adapter table conforms to the hardcoded policy.
+//    The table is the data; this test is the authority.
 // ===========================================================================
-describe('agent frontmatter effort pins', () => {
+for (const { name, table } of adapterTables) {
+  describe(`adapter table conforms to policy: ${name}`, () => {
+    test('forbidden_efforts matches the hardcoded policy', () => {
+      assert.deepEqual(
+        table.forbidden_efforts,
+        FORBIDDEN_EFFORTS,
+        `${name}: forbidden_efforts is ${JSON.stringify(table.forbidden_efforts)}, ` +
+          `but the policy hardcodes ${JSON.stringify(FORBIDDEN_EFFORTS)}; ` +
+          `do not weaken the policy by editing the JSON`
+      )
+    })
+
+    test('effort_ceiling matches the hardcoded policy', () => {
+      assert.equal(
+        table.effort_ceiling,
+        EFFORT_CEILING,
+        `${name}: effort_ceiling is "${table.effort_ceiling}", ` +
+          `but the policy hardcodes "${EFFORT_CEILING}"; ` +
+          `do not weaken the policy by editing the JSON`
+      )
+    })
+
+    test('no tier effort exceeds the hardcoded ceiling', () => {
+      for (const [tier, cfg] of Object.entries(table.tiers)) {
+        assert.ok(
+          EFFORT_RANK[cfg.effort] !== undefined,
+          `${name}: tier "${tier}" effort "${cfg.effort}" is not a recognized effort level`
+        )
+        assert.ok(
+          EFFORT_RANK[cfg.effort] <= EFFORT_RANK[EFFORT_CEILING],
+          `${name}: tier "${tier}" effort "${cfg.effort}" exceeds the ceiling "${EFFORT_CEILING}"`
+        )
+      }
+    })
+
+    test('no tier uses a hardcoded forbidden effort', () => {
+      for (const forbidden of FORBIDDEN_EFFORTS) {
+        for (const [tier, cfg] of Object.entries(table.tiers)) {
+          assert.notEqual(
+            cfg.effort,
+            forbidden,
+            `${name}: tier "${tier}" uses forbidden effort "${forbidden}"`
+          )
+        }
+      }
+    })
+
+    test('seat-level model and effort match hardcoded expectations', () => {
+      for (const [tier, expected] of Object.entries(SEAT_EXPECTATIONS)) {
+        const cfg = table.tiers[tier]
+        assert.ok(cfg, `${name}: missing tier "${tier}"`)
+        assert.equal(
+          cfg.model,
+          expected.model,
+          `${name}: tier "${tier}" model is "${cfg.model}", but the policy hardcodes "${expected.model}"`
+        )
+        assert.equal(
+          cfg.effort,
+          expected.effort,
+          `${name}: tier "${tier}" effort is "${cfg.effort}", but the policy hardcodes "${expected.effort}"`
+        )
+      }
+    })
+  })
+}
+
+// ===========================================================================
+// 1. Agent frontmatter: every role agent pins tier, and model+effort match
+//    the adapter table's mapping for that tier. Lead tier is rejected.
+// ===========================================================================
+describe('agent frontmatter tier pins', () => {
   const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith('.md'))
 
   test('the role agents are present', () => {
@@ -42,34 +167,61 @@ describe('agent frontmatter effort pins', () => {
   })
 
   for (const file of agentFiles) {
-    test(`${file} pins model and the matching effort`, () => {
+    test(`${file} pins tier, model, and effort consistent with the adapter table`, () => {
       const src = readFileSync(join(agentsDir, file), 'utf8')
       const fm = src.match(/^---\n([\s\S]*?)\n---/)
       assert.ok(fm, `${file} has no frontmatter block`)
 
+      const tier = fm[1].match(/^tier:\s*(\S+)/m)?.[1]
+      assert.ok(tier, `${file} must pin tier: explicitly`)
+      assert.ok(
+        TIERS[tier],
+        `${file} pins tier "${tier}", which is not in the adapter table; ` +
+          `add it to .claude/adapters/claude-code.json`
+      )
+
+      // Reject lead tier on agent seats: fable is lead-session-only.
+      assert.ok(
+        ALLOWED_AGENT_TIERS.includes(tier),
+        `${file} pins tier "${tier}", but agent seats may only use ` +
+          `${ALLOWED_AGENT_TIERS.join(' or ')}; lead is reserved for the session`
+      )
+
       const model = fm[1].match(/^model:\s*(\S+)/m)?.[1]
       assert.ok(model, `${file} must pin model: explicitly`)
-
-      const expected = EFFORT_BY_MODEL[model]
-      assert.ok(
-        expected,
-        `${file} pins model "${model}", which has no effort rule; ` +
-          `extend EFFORT_BY_MODEL in this test when adding a new model tier`
+      assert.equal(
+        model,
+        MODEL_BY_TIER[tier],
+        `${file} (tier ${tier}) must pin model: ${MODEL_BY_TIER[tier]}, ` +
+          `found ${model}; the adapter table maps tier ${tier} to ${MODEL_BY_TIER[tier]}`
       )
 
       const effort = fm[1].match(/^effort:\s*(\S+)/m)?.[1]
       assert.equal(
         effort,
-        expected,
-        `${file} (model ${model}) must pin effort: ${expected}, ` +
+        EFFORT_BY_TIER[tier],
+        `${file} (tier ${tier}) must pin effort: ${EFFORT_BY_TIER[tier]}, ` +
           `found ${effort ?? 'none (would inherit the session effort)'}`
       )
     })
   }
+
+  test('no agent file uses a forbidden effort', () => {
+    for (const forbidden of FORBIDDEN_EFFORTS) {
+      for (const file of agentFiles) {
+        const src = readFileSync(join(agentsDir, file), 'utf8')
+        assert.ok(
+          !new RegExp(`effort:\\s*${forbidden}`).test(src),
+          `${file} contains effort: ${forbidden}`
+        )
+      }
+    }
+  })
 })
 
 // ===========================================================================
-// 2. Workflow stages: every agent() call pins the effort matching its model
+// 2. Workflow stages: every agent() call pins the effort matching its
+//    model's tier in the adapter table.
 //
 // Agent-call opts in both workflows are single-line objects carrying both
 // label: and model:. The meta.phases display entries carry model: but
@@ -78,6 +230,11 @@ describe('agent frontmatter effort pins', () => {
 // model: with no label: and no literal effort:, so the same filter excludes
 // them too; that is safe because the spread inherits effort: from the
 // caller's opts line, which this test already checks.
+//
+// FORMAT IS LOAD-BEARING: the filter requires label: and model: on the
+// same line. Reformatting an agent() opts object across multiple lines
+// silently removes it from the checks below. Do not reformat these calls
+// (review #320 finding 20).
 // ===========================================================================
 describe('workflow stage effort pins', () => {
   for (const file of WORKFLOW_FILES) {
@@ -94,29 +251,50 @@ describe('workflow stage effort pins', () => {
       )
     })
 
-    test(`${file}: every stage pins the effort matching its model`, () => {
+    test(`${file}: every stage pins the effort matching its model's tier`, () => {
       for (const line of optLines) {
         const model = line.match(/model:\s*'(\w+)'/)?.[1]
         assert.ok(model, `${file}: unparseable model in: ${line.trim()}`)
 
-        const expected = EFFORT_BY_MODEL[model]
+        // Find the tier for this model in the adapter table.
+        let tier = null
+        for (const [t, cfg] of Object.entries(TIERS)) {
+          if (cfg.model === model) {
+            tier = t
+            break
+          }
+        }
         assert.ok(
-          expected,
-          `${file}: model "${model}" has no effort rule; ` +
-            `extend EFFORT_BY_MODEL in this test when adding a new model tier`
+          tier,
+          `${file}: model "${model}" is not in the adapter table; ` +
+            `add it to .claude/adapters/claude-code.json under a tier`
         )
 
+        // Reject lead tier on workflow stages.
+        assert.ok(
+          ALLOWED_AGENT_TIERS.includes(tier),
+          `${file}: model "${model}" resolves to tier "${tier}", but workflow ` +
+            `stages may only use ${ALLOWED_AGENT_TIERS.join(' or ')}; ` +
+            `lead is reserved for the session`
+        )
+
+        const expected = EFFORT_BY_TIER[tier]
         const effort = line.match(/effort:\s*'(\w+)'/)?.[1]
         assert.equal(
           effort,
           expected,
-          `${file}: a ${model} stage must pin effort: '${expected}': ${line.trim()}`
+          `${file}: a ${model} stage (tier ${tier}) must pin effort: '${expected}': ${line.trim()}`
         )
       }
     })
 
-    test(`${file}: nothing runs at max effort`, () => {
-      assert.ok(!/effort:\s*'max'/.test(src), `${file} contains effort: 'max'`)
+    test(`${file}: nothing runs at a forbidden effort`, () => {
+      for (const forbidden of FORBIDDEN_EFFORTS) {
+        assert.ok(
+          !new RegExp(`effort:\\s*'${forbidden}'`).test(src),
+          `${file} contains effort: '${forbidden}'`
+        )
+      }
     })
   }
 })

--- a/.claude/workflows/__tests__/role-contract-sync.test.mjs
+++ b/.claude/workflows/__tests__/role-contract-sync.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Role contract sync test (issue #313, review #320 finding 3).
+ *
+ * Asserts that the report contract text in each agent file
+ * (.claude/agents/<role>.md) matches the corresponding section in
+ * docs/architecture/role-contracts.md, and that key normative rules
+ * from the agent files are present in role-contracts.md.
+ *
+ * The agent files are the host-specific binding; role-contracts.md is
+ * the neutral source of truth. Drift in report contracts is caught by
+ * exact text comparison. Normative rules are checked by asserting that
+ * specific sentinel phrases from the agent files appear in
+ * role-contracts.md (paraphrase is allowed; outright omission is not).
+ *
+ * ROLES is derived from readdirSync(agentsDir), so a new agent file
+ * is automatically included.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const agentsDir = join(__dir, '..', '..', 'agents')
+const rcPath = join(__dir, '..', '..', '..', 'docs', 'architecture', 'role-contracts.md')
+
+const ROLES = readdirSync(agentsDir)
+  .filter((f) => f.endsWith('.md'))
+  .map((f) => f.replace(/\.md$/, ''))
+
+// Normalize: trim trailing spaces per line, strip host-specific paths.
+function normalize(text) {
+  return text
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .map((l) => l.replace(/~\/\.claude\/[^\s)]*/g, ''))
+    .join('\n')
+    .trim()
+}
+
+// Extract the report contract from an agent file.
+function extractReportFromAgent(role) {
+  const src = readFileSync(join(agentsDir, `${role}.md`), 'utf8')
+  for (const heading of ['## Report contract', '## Output contract']) {
+    const idx = src.indexOf(heading)
+    if (idx >= 0) {
+      const start = idx + heading.length
+      const nextH = src.indexOf('\n## ', start)
+      const end = nextH >= 0 ? nextH : src.length
+      return normalize(src.slice(start, end))
+    }
+  }
+  return null
+}
+
+// Extract the report contract from role-contracts.md for a given role.
+function extractReportFromRC(role) {
+  const src = readFileSync(rcPath, 'utf8')
+  const roleHeading = `## ${role}\n`
+  const roleIdx = src.indexOf(roleHeading)
+  if (roleIdx < 0) return null
+
+  const nextRoleIdx = src.indexOf('\n## ', roleIdx + roleHeading.length)
+  const roleSection = nextRoleIdx >= 0
+    ? src.slice(roleIdx, nextRoleIdx)
+    : src.slice(roleIdx)
+
+  const rcIdx = roleSection.indexOf('### Report contract')
+  if (rcIdx < 0) return null
+
+  const start = rcIdx + '### Report contract'.length
+  const nextSubIdx = roleSection.indexOf('\n### ', start)
+  const end = nextSubIdx >= 0 ? nextSubIdx : roleSection.length
+  return normalize(roleSection.slice(start, end))
+}
+
+// Sentinel phrases from agent files that MUST appear in role-contracts.md.
+// These are the normative rules that were dropped in round 1 (review #320
+// finding 3). Paraphrase is tolerated by checking lowercase containment
+// of distinctive fragments.
+const SENTINEL_RULES = {
+  'fact-checker': [
+    'one status per claim',
+    'never assign a status from memory',
+    'never silently drop a claim',
+    'never soften a contradi',
+  ],
+  'architect': [
+    'four principles',
+  ],
+}
+
+describe('role contract sync', () => {
+  test('role-contracts.md exists', () => {
+    assert.ok(readFileSync(rcPath, 'utf8').length > 0)
+  })
+
+  test('agent files exist for every role', () => {
+    assert.ok(ROLES.length >= 7, `expected at least 7 role agents, found ${ROLES.length}`)
+  })
+
+  for (const role of ROLES) {
+    test(`${role}: agent report contract matches role-contracts.md`, () => {
+      const agentContract = extractReportFromAgent(role)
+      assert.ok(agentContract, `${role}.md: no "## Report contract" or "## Output contract" section found`)
+
+      const rcContract = extractReportFromRC(role)
+      assert.ok(rcContract, `role-contracts.md: no "### Report contract" under "## ${role}"`)
+
+      assert.equal(
+        agentContract,
+        rcContract,
+        `${role}: report contract in agent file does not match role-contracts.md.\n` +
+          `Normalize both copies to identical text.`
+      )
+    })
+  }
+
+  // Normative rule presence checks for roles with sentinel rules.
+  for (const [role, phrases] of Object.entries(SENTINEL_RULES)) {
+    for (const phrase of phrases) {
+      test(`${role}: role-contracts.md contains "${phrase}"`, () => {
+        const rcText = readFileSync(rcPath, 'utf8').toLowerCase()
+        assert.ok(
+          rcText.includes(phrase.toLowerCase()),
+          `role-contracts.md is missing the normative rule "${phrase}" ` +
+            `that ${role}.md prescribes; restore it in host-neutral wording`
+        )
+      })
+    }
+  }
+})

--- a/docs/architecture/adapter-interface.md
+++ b/docs/architecture/adapter-interface.md
@@ -1,0 +1,109 @@
+# Adapter interface
+
+The minimal interface a host adapter must implement. Derived from the
+existing `criticWithFallback` pattern in the workflow scripts, which is
+the proto-interface already in production.
+
+Status: specification-only as of Phase A (#313). The three operations
+(spawn, detectFailure, retry) are defined here as prose; the existing
+`criticWithFallback` function in the workflow scripts is the
+proto-implementation that will be extracted into this interface in
+Phase C (Hermes adapter, #315) and Phase D (Codex adapter, #316).
+Until then, the workflow scripts call `agent()` directly and inline
+their own fallback logic.
+
+See `docs/superpowers/specs/2026-08-14-portable-orchestrator-design.md`
+section 3.2 for the design rationale.
+
+## Interface
+
+Three operations. Every host adapter implements them.
+
+### spawn(role, task, opts) -> report | null
+
+Dispatch a role agent with a pinned tier and effort. Returns the
+agent's structured report, or null on failure/skip.
+
+Parameters:
+- `role`: `"architect" | "developer" | "tester" | "reviewer" |
+  "fact-checker" | "docs-writer" | "perf-investigator"`
+- `task`: string. The full prompt, including the prefixed `JOB:` line
+  for roles that use job types (architect).
+- `opts`: object with:
+  - `tier`: `"judgment" | "worker"` (resolved to a model+effort pair
+    via the adapter table)
+  - `effort`: `"high" | "xhigh"` (the tier's default, or an override)
+  - `schema`: optional JSON Schema for structured report collection
+  - `isolation`: optional, `"worktree"` when the role needs branch
+    isolation
+
+Returns: the agent's report object matching the schema, or null when
+the agent errors out, returns nothing, or is skipped mid-run.
+
+Host implementations:
+- Claude Code: the Agent tool (for pipeline dispatch) or the Workflow
+  tool's `agent()` function (for workflow scripts). The `model` and
+  `effort` opts map to the Agent tool's `model` and `effort` params.
+- Hermes: `delegate_task` with `output_schema` for structured reports.
+  Model and effort set via the Hermes model/provider config.
+- Codex: `codex exec` with a TOML persona selecting the model. Report
+  collected from stdout or a written file.
+
+### detectFailure(report) -> bool
+
+Return true if the report indicates the agent could not complete. This
+generalizes what `criticWithFallback` does today with `if (first)`: a
+null return, an empty output, an error sentinel, or a quota-exhaustion
+signal all count as failure.
+
+The detection is host-specific because failure manifests differently
+per host: Claude Code returns null, Hermes returns an error in the
+delegated task result, Codex returns a nonzero exit code or empty
+stdout. The adapter translates its host's failure signal into a boolean.
+
+### retry(task, opts, fallbackTier) -> report
+
+Re-dispatch the same task with a degraded model tier. Log the fallback.
+Never re-dispatch an unchanged prompt without modifying something: the
+retry notice appended to the prompt counts, matching the existing
+rule in `tm-kickoff/SKILL.md` ("Never re-dispatch an unchanged prompt;
+something in the task must change first").
+
+The fallback ladder is tier-level, not model-level: a judgment-tier
+failure retries on the worker tier, regardless of which models are
+behind those tiers. This generalizes the existing Opus-to-Sonnet
+fallback.
+
+The retry must:
+1. Log that a fallback occurred (visible in the run output).
+2. Flag the fallback in the report (a `modelFallback` marker, as
+   `criticWithFallback` does today).
+3. Preserve the original task's schema and effort.
+4. Append a retry notice to the prompt explaining the fallback.
+
+## Adapter table
+
+Each host has an adapter table mapping tiers to concrete models and
+efforts. The Claude Code table lives at
+`.claude/adapters/claude-code.json`. The table also carries the
+role-to-tier assignment, so adding a new role means adding a row to
+the `roles` map, not editing the process layer.
+
+Adding a new model means editing the host's tier map in the adapter
+table. On this branch the workflow scripts still pin literal model
+names in their agent() calls; the effort-policy test resolves each
+pinned model through the adapter table to verify it matches the
+declared tier. A future phase (Phase B, issue #314) introduces
+inline TIER_MODELS/TIER_EFFORTS maps in the workflow scripts so the
+scripts reference tiers, not model names, at the callsite.
+
+## What the interface does not specify
+
+- How the host isolates work (worktrees, branches, containers). That
+  is the adapter's implementation detail. The interface only declares
+  `isolation: "worktree"` as a hint; the adapter decides the mechanism.
+- How the host collects the report (inline return, file, stdout). The
+  interface specifies the return shape; the transport is the adapter's
+  concern.
+- How the host authenticates to its model provider. Subscription auth,
+  API keys, or local inference are all transparent to the interface.

--- a/docs/architecture/role-contracts.md
+++ b/docs/architecture/role-contracts.md
@@ -1,0 +1,259 @@
+# Role contracts
+
+Host-neutral role definitions for the orchestrator team. Each role's job
+description and report contract, with no host tool names, no frontmatter
+syntax, and no model names. The host-specific binding (which tools, which
+model, which effort, which isolation) lives in the adapter: for Claude
+Code, in `.claude/agents/<role>.md` frontmatter; for Hermes, in the
+Hermes adapter configuration; for Codex, in TOML personas.
+
+The tier assignment for each role lives in the host adapter table
+(under `roles`). Roles reference tiers (judgment, worker), never
+model names.
+
+See `docs/superpowers/specs/2026-08-14-portable-orchestrator-design.md`
+section 3 for the layer architecture and section 3.2 for the adapter
+interface.
+
+## architect
+
+Advisory lead for approach decisions. Read-only; decides approach,
+never writes code.
+
+Dispatched for exactly one of these jobs. The caller passes the job
+type as the first line of the message: `JOB: SUB_PLAN`,
+`JOB: SPLIT_PROPOSAL`, or `JOB: ARBITRATION`.
+
+### SUB_PLAN
+
+Input: an issue number. Read the issue, its comments, and the relevant
+code. Produce checkpoint bullets: the approach, the files expected to be
+touched, the order, the verification step. Check the plan against the
+issue's size label; if the work is clearly bigger than the label, say
+so and recommend re-labeling.
+
+### SPLIT_PROPOSAL
+
+Input: an issue labeled size:L or size:XL. Propose a split into
+independent size:S or size:M issues. For each: a title, a one-paragraph
+scope, and any dependencies between them as `Blocked by: #N` lines.
+
+### ARBITRATION
+
+Input: a reviewer finding and the developer's pushback. Decide who is
+right and state the required outcome. Decide using the issue text and
+the four principles (simplicity first, no premature abstraction, no
+hidden coupling, no workaround without a TODO linking the root cause).
+
+### Report contract
+
+Start your report with one of:
+
+- `SUB_PLAN`, `SPLIT_PROPOSAL`, or `ARBITRATION`, followed by the result, or
+- `NEEDS_DECISION: <the question>` when two reasonable interpretations exist.
+  Never pick silently. List both interpretations and what each implies.
+
+## developer
+
+Implements exactly one GitHub issue end to end (branch, TDD,
+conventional commits, draft PR).
+
+Orient first: read the issue and its comments. The sub-plan comment is
+the spec. If the task includes fix findings, those take precedence.
+Check out the base, publish every commit, and open the draft PR.
+
+If the issue touches a library or API whose current shape is uncertain,
+fetch that library's current docs before writing code against it, so
+you do not implement against a stale training-data version.
+
+Make a first commit, push the branch, and open the draft PR, in that
+order: the PR needs a pushed commit to exist. Implement with TDD. Run
+the full check suite before reporting. Record each check command and
+its exit code. Commits and style per the project's conventions. Push
+after each green step. On a fix round, fix exactly the numbered findings
+given. If a finding is wrong, say so in the report instead of silently
+skipping it.
+
+### Report contract
+
+End with exactly this structure:
+
+```
+STATUS: DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
+BRANCH: <feat|fix>/<n>-<slug>
+PR: <url; "none" only with NEEDS_CONTEXT or BLOCKED>
+CHECKS: <each check command and its exit code, e.g. `npm test` -> 0; "none" only with NEEDS_CONTEXT or BLOCKED>
+DEVIATIONS: <anything done differently from the sub-plan, or "none">
+NOTES: <concerns, the questions (NEEDS_CONTEXT), or the blocker (BLOCKED)>
+```
+
+## tester
+
+Independent verification of a work package branch. Runs the full check
+suite and tries to break the change. Read-only on the repo; reports PASS
+or numbered failures with reproduction commands. Never fixes code.
+
+Input: a branch name and its issue number. Verify the ref exists, then
+check it out. Read the issue and its sub-plan comment. Extract the
+acceptance criteria. Run the full check suite: typecheck, lint, tests,
+and e2e if the diff touches the full stack. Attack the change: edge
+inputs, the original bug condition for fixes, claims in the issue or PR
+not pinned by any test, weakened or deleted tests.
+
+### Report contract
+
+End with exactly this structure:
+
+```
+VERDICT: PASS | FAIL
+COMMIT: <full SHA of FETCH_HEAD recorded at checkout>
+FINDINGS: <numbered; per failure the exact reproduction command and observed
+vs expected behavior; "none" for PASS>
+UNTESTED CLAIMS: <acceptance criteria no test covers, or "none">
+```
+
+## reviewer
+
+Reviews a work package diff against its issue and sub-plan, in two
+passes: spec compliance then code quality. Read-only; outputs APPROVE
+or CHANGES_REQUESTED with numbered file:line findings. Never edits
+files.
+
+Pass 1 (spec compliance): everything the issue and sub-plan demand is
+present, and nothing extra is. Scope creep, drive-by refactoring, and
+unrequested features are blocking findings, even when the extra code is
+good.
+
+Pass 2 (code quality): only after pass 1 is clean. Correctness first,
+then the principles: simplicity first (could 200 lines be 50?),
+surgical changes, goal-driven execution. A weakened or deleted test is
+always a blocking finding.
+
+### Report contract
+
+End with exactly this structure:
+
+```
+VERDICT: APPROVE | CHANGES_REQUESTED
+STAGE: <spec | quality, the pass that produced the findings, or "both clean">
+FINDINGS: <numbered; each with file:line, severity (must-fix | should-fix |
+nit), the problem, and the required fix; "none" if there are no findings>
+```
+
+Only must-fix findings block: CHANGES_REQUESTED when any exist, APPROVE
+otherwise. Still list should-fix findings and nits; they go to the PR for the
+human review, not into fix rounds.
+
+## fact-checker
+
+Audits the factual claims in a report, sub-plan, PR description, or
+agent output against reproducible evidence. Read-only; returns per-claim
+verdicts (VERIFIED, CONTRADICTED, UNVERIFIED) with the exact command
+behind each. Never fixes anything.
+
+Input: a block of text to audit (quoted verbatim by the caller), plus
+context: the repo state it talks about (a branch, a PR number, an issue
+number, or the default branch).
+
+Extract every statement that asserts something checkable about the
+world: a file exists or contains something, a test passed, a command was
+run, a diff does or does not touch something, an issue or PR says
+something, a number. Skip pure opinions and plans. Statements the author
+explicitly labels as assumption, guess, or untested are compliant as
+labeled: record them as LABELED, do not verify them.
+
+Pick the cheapest authoritative evidence: repo state, GitHub state, or
+a prior report already on the record. Do not re-run test suites or
+builds to verify "tests pass" claims: that is the tester's job. Verify
+instead that evidence of the run exists. If you cannot verify a claim
+with read-only means, mark it UNVERIFIED and say what would verify it.
+
+One status per claim, and every VERIFIED or CONTRADICTED status must
+cite a command you ran in this session plus the relevant line(s) of its
+actual output. Never assign a status from memory, plausibility, or what
+the author seems trustworthy about. Never silently drop a claim, and
+never soften a CONTRADICTED finding.
+
+### Report contract
+
+End with exactly this structure:
+
+```
+VERDICT: GROUNDED | UNGROUNDED
+COMMIT: <full SHA audited, or "n/a" if no branch was involved>
+CLAIMS:
+  1. "<claim, quoted or tightly paraphrased>"
+     STATUS: VERIFIED | CONTRADICTED | UNVERIFIED | LABELED
+     EVIDENCE: <exact command and the output line(s) that decide it; "none" for UNVERIFIED/LABELED>
+     NOTE: <CONTRADICTED: what the evidence shows instead. UNVERIFIED: what would verify it. Otherwise omit.>
+SUMMARY: <n> verified, <n> contradicted, <n> unverified, <n> labeled
+```
+
+VERDICT is GROUNDED only when no claim is CONTRADICTED and every load-bearing
+claim is VERIFIED or LABELED. Any CONTRADICTED claim, or an UNVERIFIED claim
+the caller's decision depends on, makes it UNGROUNDED.
+
+## docs-writer
+
+Authors or updates user-facing documentation (README, guides, API docs)
+from a gap analysis of what is missing or stale. Never part of the
+per-package kickoff pipeline; one dispatch, no fan-out.
+
+Two phases, in order:
+
+1. Gap analysis. Read the repo and list which user-facing docs are
+   missing or stale. Do not fix anything yet.
+2. Author. Write or edit only the docs the dispatch actually asked for.
+   Do not expand scope to every gap found in phase 1; note the rest in
+   the report.
+
+Prose follows the writing-style rules (no em dashes, no AI-cliche
+phrases, plain direct English, short sentences).
+
+### Report contract
+
+End with exactly this structure:
+
+```
+FILES:
+  1. <path> - <created | updated> - <one-line purpose>
+GAPS_NOT_FILLED: <gap found in phase 1 but out of the dispatch's scope, and why; "none" if the dispatch scope covered every gap found>
+ASSUMPTIONS: <anything you had to guess rather than find in the repo, labeled as such; "none" if none>
+```
+
+The lead decides what happens next (dispatch you again for a gap, fold a gap
+into a future issue, or drop it); you do not make that call.
+
+## perf-investigator
+
+Establishes a measured performance baseline and target before any code
+changes, for a reported slowness. Outside the per-package pipeline.
+Never edits code; returns a baseline-and-target report the lead hands to
+developer before implementation and to tester for the after-measurement.
+
+Method:
+
+1. Reproduce the reported slowness with a concrete repro.
+2. Establish the baseline: name each measurement command exactly, run
+   it more than once, and report the spread across runs (min/max or
+   range), not a single number.
+3. Locate the bottleneck: profile or instrument until you can point to
+   the specific file:line or subsystem responsible.
+4. Define a measurable target: a number and the command that reads it.
+
+### Report contract
+
+End with exactly this structure:
+
+```
+BASELINE:
+  1. <what was measured>
+     COMMAND: <exact command>
+     RUNS: <output line(s) from each run; report the spread, not one number>
+BOTTLENECK: <file:line where applicable, or subsystem, plus the evidence that pins it there>
+TARGET: <the measurable target, and the command that reads it>
+RE-MEASURE: <the exact command(s) the tester runs for the after-measurement, to compare against BASELINE and TARGET>
+```
+
+RE-MEASURE is what makes the tester handoff work: without the exact
+commands, the after-measurement is not reproducible against your baseline.

--- a/docs/team-guide-rationale.md
+++ b/docs/team-guide-rationale.md
@@ -41,8 +41,8 @@ No relocated chunks; the fact-checker verdict taxonomy lives in
 
 ### Full annotated tree
 
-Supports: "`.claude/` holds `agents/`, `skills/`, `workflows/`, and
-`settings.json`."
+Supports: "`.claude/` holds `agents/`, `skills/`, `workflows/`,
+`adapters/`, and `settings.json`."
 
 ```
 .claude/
@@ -50,6 +50,7 @@ Supports: "`.claude/` holds `agents/`, `skills/`, `workflows/`, and
                        fact-checker, docs-writer, perf-investigator
   skills/            project skills: /tm-advisor, /tm-grill-me, /tm-kickoff, /tm-new-project
   workflows/         bounded orchestration scripts (tm-review-changes, tm-review-codebase, tm-map-codebase)
+  adapters/          adapter tables: tier-to-model mapping per host (claude-code.json)
   settings.json      project settings; enables the superpowers plugin
                        enabledPlugins is template-managed;
                        permissions, hooks, env, and defaultMode are project-owned


### PR DESCRIPTION
Closes #313

## What this does

Phase A of the portable orchestrator (\#311). Introduces the model
tier abstraction and adapter interface with no behavioral change to
the existing workflow scripts.

## Changes

- **Adapter table** (`.claude/adapters/claude-code.json`): maps tiers
  (judgment, worker, lead) to concrete models and efforts.
- **Agent frontmatters** (all 7): each got a `tier:` field alongside
  existing `model:` and `effort:` pins.
- **Role contracts** (`docs/architecture/role-contracts.md`): host-neutral
  role definitions. All normative rules restored (fact-checker, architect).
- **Adapter interface** (`docs/architecture/adapter-interface.md`): the
  minimal interface (spawn, detectFailure, retry). Spec-only until Phase C/D.
- **Effort-policy test**: policy values hardcoded as authority. Conformance
  runs over every adapter table. Seat-level expectations hardcoded.
- **Adapter-table test**: structure-only checks for every adapter JSON.
- **Role-contract-sync test**: derives ROLES from readdirSync; asserts
  report contracts match and sentinel normative rules are present.

## Verification

```
npm test -> 98 pass, 0 fail (was 70; 28 new tests)
```

Tester: PASS. Reviewer: pending round 3.