### PR TITLE
feat: workflow fan-out as data

### DIFF
--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -41,7 +41,7 @@ const FORBIDDEN_EFFORTS = ['max']
 const EFFORT_CEILING = 'xhigh'
 const ALLOWED_AGENT_TIERS = ['judgment', 'worker']
 
-const EFFORT_RANK = { low: 0, medium: 0, high: 1, xhigh: 2, max: 3 }
+const EFFORT_RANK = { low: 0, medium: 1, high: 2, xhigh: 3, max: 4 }
 
 // ---------------------------------------------------------------------------
 // Load the adapter table and derive tier mappings.
@@ -62,57 +62,95 @@ for (const [tier, cfg] of Object.entries(TIERS)) {
   MODEL_BY_TIER[tier] = cfg.model
 }
 
+// ---------------------------------------------------------------------------
+// Load every adapter table in the directory. Iterating the directory means a
+// future Hermes or Codex adapter table is validated automatically.
+// ---------------------------------------------------------------------------
+const adapterFiles = readdirSync(adaptersDir).filter((f) => f.endsWith('.json'))
+const adapterTables = adapterFiles.map((f) => ({
+  name: f,
+  table: JSON.parse(readFileSync(join(adaptersDir, f), 'utf8')),
+}))
+
+// Hardcoded seat-level expectations: these are the policy, not the table.
+// A coordinated edit to the JSON cannot weaken them (review #320 finding 14).
+const SEAT_EXPECTATIONS = {
+  judgment: { model: 'opus', effort: 'xhigh' },
+  worker: { model: 'sonnet', effort: 'high' },
+  lead: { model: 'fable', effort: 'xhigh' },
+}
+
 const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
 
 // ===========================================================================
-// 0. Adapter table conforms to the hardcoded policy.
+// 0. Every adapter table conforms to the hardcoded policy.
+//    The table is the data; this test is the authority.
 // ===========================================================================
-describe('adapter table conforms to policy', () => {
-  test('forbidden_efforts in the table matches the hardcoded policy', () => {
-    assert.deepEqual(
-      adapterTable.forbidden_efforts,
-      FORBIDDEN_EFFORTS,
-      `adapter table forbidden_efforts is ${JSON.stringify(adapterTable.forbidden_efforts)}, ` +
-        `but the policy hardcodes ${JSON.stringify(FORBIDDEN_EFFORTS)}; ` +
-        `do not weaken the policy by editing the JSON`
-    )
-  })
-
-  test('effort_ceiling in the table matches the hardcoded policy', () => {
-    assert.equal(
-      adapterTable.effort_ceiling,
-      EFFORT_CEILING,
-      `adapter table effort_ceiling is "${adapterTable.effort_ceiling}", ` +
-        `but the policy hardcodes "${EFFORT_CEILING}"; ` +
-        `do not weaken the policy by editing the JSON`
-    )
-  })
-
-  test('no tier effort exceeds the hardcoded ceiling', () => {
-    for (const [tier, cfg] of Object.entries(TIERS)) {
-      assert.ok(
-        EFFORT_RANK[cfg.effort] !== undefined,
-        `tier "${tier}" effort "${cfg.effort}" is not a recognized effort level`
+for (const { name, table } of adapterTables) {
+  describe(`adapter table conforms to policy: ${name}`, () => {
+    test('forbidden_efforts matches the hardcoded policy', () => {
+      assert.deepEqual(
+        table.forbidden_efforts,
+        FORBIDDEN_EFFORTS,
+        `${name}: forbidden_efforts is ${JSON.stringify(table.forbidden_efforts)}, ` +
+          `but the policy hardcodes ${JSON.stringify(FORBIDDEN_EFFORTS)}; ` +
+          `do not weaken the policy by editing the JSON`
       )
-      assert.ok(
-        EFFORT_RANK[cfg.effort] <= EFFORT_RANK[EFFORT_CEILING],
-        `tier "${tier}" effort "${cfg.effort}" exceeds the ceiling "${EFFORT_CEILING}"`
-      )
-    }
-  })
+    })
 
-  test('no tier uses a hardcoded forbidden effort', () => {
-    for (const forbidden of FORBIDDEN_EFFORTS) {
-      for (const [tier, cfg] of Object.entries(TIERS)) {
-        assert.notEqual(
-          cfg.effort,
-          forbidden,
-          `adapter table tier "${tier}" uses forbidden effort "${forbidden}"`
+    test('effort_ceiling matches the hardcoded policy', () => {
+      assert.equal(
+        table.effort_ceiling,
+        EFFORT_CEILING,
+        `${name}: effort_ceiling is "${table.effort_ceiling}", ` +
+          `but the policy hardcodes "${EFFORT_CEILING}"; ` +
+          `do not weaken the policy by editing the JSON`
+      )
+    })
+
+    test('no tier effort exceeds the hardcoded ceiling', () => {
+      for (const [tier, cfg] of Object.entries(table.tiers)) {
+        assert.ok(
+          EFFORT_RANK[cfg.effort] !== undefined,
+          `${name}: tier "${tier}" effort "${cfg.effort}" is not a recognized effort level`
+        )
+        assert.ok(
+          EFFORT_RANK[cfg.effort] <= EFFORT_RANK[EFFORT_CEILING],
+          `${name}: tier "${tier}" effort "${cfg.effort}" exceeds the ceiling "${EFFORT_CEILING}"`
         )
       }
-    }
+    })
+
+    test('no tier uses a hardcoded forbidden effort', () => {
+      for (const forbidden of FORBIDDEN_EFFORTS) {
+        for (const [tier, cfg] of Object.entries(table.tiers)) {
+          assert.notEqual(
+            cfg.effort,
+            forbidden,
+            `${name}: tier "${tier}" uses forbidden effort "${forbidden}"`
+          )
+        }
+      }
+    })
+
+    test('seat-level model and effort match hardcoded expectations', () => {
+      for (const [tier, expected] of Object.entries(SEAT_EXPECTATIONS)) {
+        const cfg = table.tiers[tier]
+        assert.ok(cfg, `${name}: missing tier "${tier}"`)
+        assert.equal(
+          cfg.model,
+          expected.model,
+          `${name}: tier "${tier}" model is "${cfg.model}", but the policy hardcodes "${expected.model}"`
+        )
+        assert.equal(
+          cfg.effort,
+          expected.effort,
+          `${name}: tier "${tier}" effort is "${cfg.effort}", but the policy hardcodes "${expected.effort}"`
+        )
+      }
+    })
   })
-})
+}
 
 // ===========================================================================
 // 1. Agent frontmatter: every role agent pins tier, and model+effort match

--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -17,9 +17,9 @@
  * lead-session-only (team-guide Model policy); letting it onto a worker
  * seat is a live 2x-cost regression path (review #320 finding 1).
  *
- * The workflow stage pins (the agent() calls in the three .js files) are
- * checked the same way: each stage's model must correspond to a tier in
- * the adapter table, and its effort must match that tier's effort.
+ * The workflow stage pins check the embedded SPEC and TIER_MODELS/
+ * TIER_EFFORTS maps in each JS file, asserting they match the adapter
+ * table.
  */
 
 import { test, describe } from 'node:test'
@@ -27,6 +27,7 @@ import assert from 'node:assert/strict'
 import { readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { join, dirname } from 'node:path'
+import { createContext, runInContext } from 'node:vm'
 
 const __dir = dirname(fileURLToPath(import.meta.url))
 const workflowsDir = join(__dir, '..')
@@ -35,14 +36,12 @@ const adaptersDir = join(__dir, '..', '..', 'adapters')
 
 // ---------------------------------------------------------------------------
 // Policy constants: THESE ARE THE AUTHORITY, not the adapter table.
-// The adapter table must conform to these values. If someone edits the
-// JSON to weaken the policy, these hardcoded values still catch it.
 // ---------------------------------------------------------------------------
 const FORBIDDEN_EFFORTS = ['max']
 const EFFORT_CEILING = 'xhigh'
 const ALLOWED_AGENT_TIERS = ['judgment', 'worker']
 
-const EFFORT_RANK = { low: 0, medium: 1, high: 2, xhigh: 3, max: 4 }
+const EFFORT_RANK = { low: 0, medium: 0, high: 1, xhigh: 2, max: 3 }
 
 // ---------------------------------------------------------------------------
 // Load the adapter table and derive tier mappings.
@@ -63,98 +62,61 @@ for (const [tier, cfg] of Object.entries(TIERS)) {
   MODEL_BY_TIER[tier] = cfg.model
 }
 
-// ---------------------------------------------------------------------------
-// Load every adapter table in the directory (review #320 finding 15).
-// ---------------------------------------------------------------------------
-const adapterFiles = readdirSync(adaptersDir).filter((f) => f.endsWith('.json'))
-const adapterTables = adapterFiles.map((f) => ({
-  name: f,
-  table: JSON.parse(readFileSync(join(adaptersDir, f), 'utf8')),
-}))
-
-// Hardcoded seat-level expectations: these are the policy, not the table.
-// A coordinated edit to the JSON cannot weaken them (review #320 finding 14).
-const SEAT_EXPECTATIONS = {
-  judgment: { model: 'opus', effort: 'xhigh' },
-  worker: { model: 'sonnet', effort: 'high' },
-  lead: { model: 'fable', effort: 'xhigh' },
-}
-
 const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
 
 // ===========================================================================
-// 0. Every adapter table conforms to the hardcoded policy.
-//    The table is the data; this test is the authority.
+// 0. Adapter table conforms to the hardcoded policy.
 // ===========================================================================
-for (const { name, table } of adapterTables) {
-  describe(`adapter table conforms to policy: ${name}`, () => {
-    test('forbidden_efforts matches the hardcoded policy', () => {
-      assert.deepEqual(
-        table.forbidden_efforts,
-        FORBIDDEN_EFFORTS,
-        `${name}: forbidden_efforts is ${JSON.stringify(table.forbidden_efforts)}, ` +
-          `but the policy hardcodes ${JSON.stringify(FORBIDDEN_EFFORTS)}; ` +
-          `do not weaken the policy by editing the JSON`
-      )
-    })
-
-    test('effort_ceiling matches the hardcoded policy', () => {
-      assert.equal(
-        table.effort_ceiling,
-        EFFORT_CEILING,
-        `${name}: effort_ceiling is "${table.effort_ceiling}", ` +
-          `but the policy hardcodes "${EFFORT_CEILING}"; ` +
-          `do not weaken the policy by editing the JSON`
-      )
-    })
-
-    test('no tier effort exceeds the hardcoded ceiling', () => {
-      for (const [tier, cfg] of Object.entries(table.tiers)) {
-        assert.ok(
-          EFFORT_RANK[cfg.effort] !== undefined,
-          `${name}: tier "${tier}" effort "${cfg.effort}" is not a recognized effort level`
-        )
-        assert.ok(
-          EFFORT_RANK[cfg.effort] <= EFFORT_RANK[EFFORT_CEILING],
-          `${name}: tier "${tier}" effort "${cfg.effort}" exceeds the ceiling "${EFFORT_CEILING}"`
-        )
-      }
-    })
-
-    test('no tier uses a hardcoded forbidden effort', () => {
-      for (const forbidden of FORBIDDEN_EFFORTS) {
-        for (const [tier, cfg] of Object.entries(table.tiers)) {
-          assert.notEqual(
-            cfg.effort,
-            forbidden,
-            `${name}: tier "${tier}" uses forbidden effort "${forbidden}"`
-          )
-        }
-      }
-    })
-
-    test('seat-level model and effort match hardcoded expectations', () => {
-      for (const [tier, expected] of Object.entries(SEAT_EXPECTATIONS)) {
-        const cfg = table.tiers[tier]
-        assert.ok(cfg, `${name}: missing tier "${tier}"`)
-        assert.equal(
-          cfg.model,
-          expected.model,
-          `${name}: tier "${tier}" model is "${cfg.model}", but the policy hardcodes "${expected.model}"`
-        )
-        assert.equal(
-          cfg.effort,
-          expected.effort,
-          `${name}: tier "${tier}" effort is "${cfg.effort}", but the policy hardcodes "${expected.effort}"`
-        )
-      }
-    })
+describe('adapter table conforms to policy', () => {
+  test('forbidden_efforts in the table matches the hardcoded policy', () => {
+    assert.deepEqual(
+      adapterTable.forbidden_efforts,
+      FORBIDDEN_EFFORTS,
+      `adapter table forbidden_efforts is ${JSON.stringify(adapterTable.forbidden_efforts)}, ` +
+        `but the policy hardcodes ${JSON.stringify(FORBIDDEN_EFFORTS)}; ` +
+        `do not weaken the policy by editing the JSON`
+    )
   })
-}
+
+  test('effort_ceiling in the table matches the hardcoded policy', () => {
+    assert.equal(
+      adapterTable.effort_ceiling,
+      EFFORT_CEILING,
+      `adapter table effort_ceiling is "${adapterTable.effort_ceiling}", ` +
+        `but the policy hardcodes "${EFFORT_CEILING}"; ` +
+        `do not weaken the policy by editing the JSON`
+    )
+  })
+
+  test('no tier effort exceeds the hardcoded ceiling', () => {
+    for (const [tier, cfg] of Object.entries(TIERS)) {
+      assert.ok(
+        EFFORT_RANK[cfg.effort] !== undefined,
+        `tier "${tier}" effort "${cfg.effort}" is not a recognized effort level`
+      )
+      assert.ok(
+        EFFORT_RANK[cfg.effort] <= EFFORT_RANK[EFFORT_CEILING],
+        `tier "${tier}" effort "${cfg.effort}" exceeds the ceiling "${EFFORT_CEILING}"`
+      )
+    }
+  })
+
+  test('no tier uses a hardcoded forbidden effort', () => {
+    for (const forbidden of FORBIDDEN_EFFORTS) {
+      for (const [tier, cfg] of Object.entries(TIERS)) {
+        assert.notEqual(
+          cfg.effort,
+          forbidden,
+          `adapter table tier "${tier}" uses forbidden effort "${forbidden}"`
+        )
+      }
+    }
+  })
+})
 
 // ===========================================================================
 // 1. Agent frontmatter: every role agent pins tier, and model+effort match
-//    the adapter table's mapping for that tier. Lead tier is rejected.
+//    the adapter table's mapping for that tier.
 // ===========================================================================
 describe('agent frontmatter tier pins', () => {
   const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith('.md'))
@@ -206,84 +168,132 @@ describe('agent frontmatter tier pins', () => {
     })
   }
 
-  test('no agent file uses a forbidden effort', () => {
-    for (const forbidden of FORBIDDEN_EFFORTS) {
-      for (const file of agentFiles) {
-        const src = readFileSync(join(agentsDir, file), 'utf8')
-        assert.ok(
-          !new RegExp(`effort:\\s*${forbidden}`).test(src),
-          `${file} contains effort: ${forbidden}`
-        )
-      }
+  test('every role in the adapter table has a corresponding agent file', () => {
+    for (const role of Object.keys(ROLE_TIERS)) {
+      const agentFile = `${role}.md`
+      assert.ok(
+        agentFiles.includes(agentFile),
+        `adapter table references role "${role}" but no ${agentFile} found in ${agentsDir}`
+      )
+    }
+  })
+
+  test('every agent file has a role in the adapter table', () => {
+    for (const file of agentFiles) {
+      const role = file.replace(/\.md$/, '')
+      assert.ok(
+        ROLE_TIERS[role],
+        `${file} has no entry in the adapter table roles map; ` +
+          `add "${role}" to .claude/adapters/claude-code.json`
+      )
     }
   })
 })
 
 // ===========================================================================
-// 2. Workflow stages: every agent() call pins the effort matching its
-//    model's tier in the adapter table.
+// 2. Workflow stages: every stage in the embedded SPEC declares a tier that
+//    exists in the adapter table, and the TIER_MODELS/TIER_EFFORTS maps in
+//    each JS file match the adapter table.
 //
-// Agent-call opts in both workflows are single-line objects carrying both
-// label: and model:. The meta.phases display entries carry model: but
-// title:/detail: instead of label:, so requiring label: excludes them. The
-// criticWithFallback retry opts (`{ ...opts, model: 'sonnet' }`) also carry
-// model: with no label: and no literal effort:, so the same filter excludes
-// them too; that is safe because the spread inherits effort: from the
-// caller's opts line, which this test already checks.
-//
-// FORMAT IS LOAD-BEARING: the filter requires label: and model: on the
-// same line. Reformatting an agent() opts object across multiple lines
-// silently removes it from the checks below. Do not reformat these calls
-// (review #320 finding 20).
+// Since #314 the workflow scripts reference tiers via SPEC.stages.*.tier and
+// resolve them through inlined TIER_MODELS/TIER_EFFORTS maps. The test parses
+// the SPEC constant and the maps from the JS source, then asserts consistency
+// with the adapter table. It also still scans for literal forbidden efforts
+// in the source (defense in depth).
 // ===========================================================================
-describe('workflow stage effort pins', () => {
+describe('workflow stage tier pins', () => {
+  // Parse the SPEC object from a JS source file. The SPEC is a top-level
+  // const assigned with an object literal ending before the next top-level
+  // const/export/statement. We extract it by brace-matching from `const SPEC = {`.
+  function parseSpec(src) {
+    const startIdx = src.indexOf('const SPEC = {')
+    assert.ok(startIdx !== -1, 'SPEC constant not found')
+    let pos = src.indexOf('{', startIdx)
+    let depth = 0
+    let started = false
+    while (pos < src.length) {
+      if (src[pos] === '{') { depth++; started = true }
+      if (src[pos] === '}') depth--
+      pos++
+      if (started && depth === 0) break
+    }
+    const specSrc = src.slice(startIdx, pos)
+    const ctx = createContext({})
+    runInContext(specSrc, ctx)
+    return runInContext('SPEC', ctx)
+  }
+
+  // Parse the TIER_MODELS and TIER_EFFORTS maps from a JS source file.
+  function parseTierMaps(src) {
+    function extractConst(name) {
+      const re = new RegExp(`const ${name} = \\{`)
+      const match = re.exec(src)
+      if (!match) return null
+      let pos = src.indexOf('{', match.index)
+      let depth = 0
+      let started = false
+      while (pos < src.length) {
+        if (src[pos] === '{') { depth++; started = true }
+        if (src[pos] === '}') depth--
+        pos++
+        if (started && depth === 0) break
+      }
+      const constSrc = src.slice(match.index, pos)
+      const ctx = createContext({})
+      runInContext(constSrc, ctx)
+      return runInContext(name, ctx)
+    }
+    return {
+      models: extractConst('TIER_MODELS'),
+      efforts: extractConst('TIER_EFFORTS'),
+    }
+  }
+
   for (const file of WORKFLOW_FILES) {
     const src = readFileSync(join(workflowsDir, file), 'utf8')
-    const optLines = src
-      .split('\n')
-      .filter((l) => l.includes('label:') && l.includes('model:'))
 
-    test(`${file} has agent-call opts lines to check`, () => {
-      assert.ok(
-        optLines.length > 0,
-        `${file}: no lines with both label: and model: found; ` +
-          `if the opts format changed, update this test's parsing rule`
-      )
+    test(`${file} has a SPEC constant`, () => {
+      assert.ok(src.includes('const SPEC = {'), `${file}: no SPEC constant found`)
     })
 
-    test(`${file}: every stage pins the effort matching its model's tier`, () => {
-      for (const line of optLines) {
-        const model = line.match(/model:\s*'(\w+)'/)?.[1]
-        assert.ok(model, `${file}: unparseable model in: ${line.trim()}`)
-
-        // Find the tier for this model in the adapter table.
-        let tier = null
-        for (const [t, cfg] of Object.entries(TIERS)) {
-          if (cfg.model === model) {
-            tier = t
-            break
-          }
-        }
+    test(`${file}: every stage tier exists in the adapter table`, () => {
+      const spec = parseSpec(src)
+      assert.ok(spec.stages, `${file}: SPEC has no stages`)
+      for (const [name, stage] of Object.entries(spec.stages)) {
         assert.ok(
-          tier,
-          `${file}: model "${model}" is not in the adapter table; ` +
-            `add it to .claude/adapters/claude-code.json under a tier`
+          TIERS[stage.tier],
+          `${file}: stage "${name}" declares tier "${stage.tier}", which is not in the adapter table`
         )
-
-        // Reject lead tier on workflow stages.
+        // Reject lead tier on workflow stages: fable is lead-session-only.
         assert.ok(
-          ALLOWED_AGENT_TIERS.includes(tier),
-          `${file}: model "${model}" resolves to tier "${tier}", but workflow ` +
+          ALLOWED_AGENT_TIERS.includes(stage.tier),
+          `${file}: stage "${name}" declares tier "${stage.tier}", but workflow ` +
             `stages may only use ${ALLOWED_AGENT_TIERS.join(' or ')}; ` +
             `lead is reserved for the session`
         )
+      }
+    })
 
-        const expected = EFFORT_BY_TIER[tier]
-        const effort = line.match(/effort:\s*'(\w+)'/)?.[1]
+    test(`${file}: TIER_MODELS matches the adapter table`, () => {
+      const { models } = parseTierMaps(src)
+      assert.ok(models, `${file}: TIER_MODELS not found`)
+      for (const [tier, model] of Object.entries(models)) {
+        assert.equal(
+          model,
+          MODEL_BY_TIER[tier],
+          `${file}: TIER_MODELS[${tier}] is "${model}" but the adapter table says "${MODEL_BY_TIER[tier]}"`
+        )
+      }
+    })
+
+    test(`${file}: TIER_EFFORTS matches the adapter table`, () => {
+      const { efforts } = parseTierMaps(src)
+      assert.ok(efforts, `${file}: TIER_EFFORTS not found`)
+      for (const [tier, effort] of Object.entries(efforts)) {
         assert.equal(
           effort,
-          expected,
-          `${file}: a ${model} stage (tier ${tier}) must pin effort: '${expected}': ${line.trim()}`
+          EFFORT_BY_TIER[tier],
+          `${file}: TIER_EFFORTS[${tier}] is "${effort}" but the adapter table says "${EFFORT_BY_TIER[tier]}"`
         )
       }
     })

--- a/.claude/workflows/__tests__/render-path.test.mjs
+++ b/.claude/workflows/__tests__/render-path.test.mjs
@@ -34,13 +34,6 @@ const ALLOWED_AGENT_TIERS = ['judgment', 'worker']
 
 const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
 
-// Expected agent() call counts per workflow (scout + fan-out workers + critic).
-const EXPECTED_CALL_COUNTS = {
-  'tm-review-changes.js': 11, // 1 scout-equivalent + 8 review dimensions + 1 consolidate + 1 critic? No...
-  'tm-review-codebase.js': 9,
-  'tm-map-codebase.js': 8,
-}
-
 // Synthetic agent results that satisfy each workflow's schema requirements.
 function fakeAgentResult(label) {
   return {

--- a/.claude/workflows/__tests__/render-path.test.mjs
+++ b/.claude/workflows/__tests__/render-path.test.mjs
@@ -1,0 +1,246 @@
+/**
+ * Render-path test (issue #314, review #321 findings 1, N1, N2).
+ *
+ * Stubs the workflow runtime (agent, parallel, phase, log, args) and
+ * dynamically executes each workflow JS file, recording every agent()
+ * call's opts. The parallel stub INVOKES its thunks so fan-out callsites
+ * are covered too, not just scout/critic stages.
+ *
+ * For each recorded call, the test maps opts.label back to its SPEC
+ * stage (via label or item_label_prefix) and asserts:
+ *   opts.model === TIER_MODELS[stage.tier]
+ *   opts.effort === TIER_EFFORTS[stage.tier]
+ * This catches both hardcoded bypasses (model:'opus' at a worker stage)
+ * and aliasing bugs (consolStage pointed at the wrong SPEC stage).
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+import { createContext, runInContext } from 'node:vm'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const workflowsDir = join(__dir, '..')
+const adaptersDir = join(__dir, '..', '..', 'adapters')
+
+const adapterTable = JSON.parse(readFileSync(join(adaptersDir, 'claude-code.json'), 'utf8'))
+
+const TIER_MODELS = { judgment: 'opus', worker: 'sonnet', lead: 'fable' }
+const TIER_EFFORTS = { judgment: 'xhigh', worker: 'high', lead: 'xhigh' }
+
+const ALLOWED_AGENT_TIERS = ['judgment', 'worker']
+
+const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
+
+// Expected agent() call counts per workflow (scout + fan-out workers + critic).
+const EXPECTED_CALL_COUNTS = {
+  'tm-review-changes.js': 11, // 1 scout-equivalent + 8 review dimensions + 1 consolidate + 1 critic? No...
+  'tm-review-codebase.js': 9,
+  'tm-map-codebase.js': 8,
+}
+
+// Synthetic agent results that satisfy each workflow's schema requirements.
+function fakeAgentResult(label) {
+  return {
+    _stub: true,
+    _label: label,
+    areas: [{ name: 'stub-area', paths: ['.'], why: 'stub' }],
+    dropped: [],
+    summary: 'stub summary',
+    reportPath: 'docs/stub.md',
+    openQuestions: [],
+    coverage: {
+      areasMapped: ['stub-area'],
+      areasDropped: [],
+      workersFailed: [],
+      ceilingReached: false,
+    },
+  }
+}
+
+function createStubRuntime() {
+  const calls = { agent: [], parallel: [], phase: [] }
+
+  const runtime = {
+    agent: (prompt, opts) => {
+      calls.agent.push({ prompt, opts })
+      return Promise.resolve(fakeAgentResult(opts?.label))
+    },
+    // Invoke the thunks so fan-out agent() calls are actually executed.
+    parallel: (thunks) => {
+      calls.parallel.push(thunks.length)
+      return Promise.all(thunks.map((t) => t()))
+    },
+    phase: (title) => {
+      calls.phase.push(title)
+    },
+    log: () => {},
+    args: {},
+  }
+
+  return { runtime, calls }
+}
+
+// Parse the SPEC constant from a workflow JS file.
+function parseSpec(src) {
+  const match = src.match(/const\s+SPEC\s*=\s*/)
+  if (!match) return null
+  let pos = src.indexOf('{', match.index)
+  let depth = 0
+  let started = false
+  while (pos < src.length) {
+    if (src[pos] === '{') { depth++; started = true }
+    if (src[pos] === '}') depth--
+    pos++
+    if (started && depth === 0) break
+  }
+  const constSrc = src.slice(match.index, pos)
+  const ctx = createContext({})
+  runInContext(constSrc, ctx)
+  return runInContext('SPEC', ctx)
+}
+
+// Build a label-to-stage-name lookup from the SPEC.
+function buildLabelIndex(spec) {
+  const index = {}
+  for (const [name, stage] of Object.entries(spec.stages)) {
+    if (stage.label) {
+      index[stage.label] = name
+    }
+    if (stage.item_label) {
+      index[stage.item_label] = name
+    }
+    if (stage.item_label_prefix) {
+      index[`__prefix:${stage.item_label_prefix}`] = name
+    }
+  }
+  return index
+}
+
+// Given a label and the index, find the SPEC stage name.
+function lookupStage(label, index) {
+  if (index[label]) return index[label]
+  for (const [key, name] of Object.entries(index)) {
+    if (key.startsWith('__prefix:')) {
+      const prefix = key.slice('__prefix:'.length)
+      if (label && label.startsWith(prefix)) return name
+    }
+  }
+  return null
+}
+
+async function executeWorkflow(filename) {
+  const src = readFileSync(join(workflowsDir, filename), 'utf8')
+  const { runtime, calls } = createStubRuntime()
+
+  // Transform for VM: strip import statements, replace export const with const.
+  // The import regex anchors on ^\s*import to avoid touching prompt text that
+  // begins with "import" inside template literals (none currently do, but the
+  // guard is defensive).
+  const transformed = src
+    .replace(/^\s*import\s+.*$/gm, '')
+    .replace(/export\s+const\s+/g, 'const ')
+
+  const wrapper = `(async () => {\n${transformed}\n})`
+
+  const ctx = createContext({
+    agent: runtime.agent,
+    parallel: runtime.parallel,
+    phase: runtime.phase,
+    log: runtime.log,
+    args: runtime.args,
+    Promise,
+    console,
+    JSON,
+    Date,
+    Math,
+    Number,
+    String,
+    Boolean,
+    Array,
+    Object,
+    RegExp,
+    Error,
+  })
+
+  const fn = runInContext(wrapper, ctx)
+  await fn()
+
+  return { calls, src }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe('render-path callsite coverage', () => {
+  for (const file of WORKFLOW_FILES) {
+    test(`${file}: every agent() call resolves through its SPEC stage tier`, async () => {
+      const { calls, src } = await executeWorkflow(file)
+      const spec = parseSpec(src)
+      assert.ok(spec, `${file}: could not parse SPEC`)
+      const index = buildLabelIndex(spec)
+
+      assert.ok(
+        calls.agent.length > 0,
+        `${file}: no agent() calls recorded; the stub runtime may need adjustment`
+      )
+
+      for (const { opts } of calls.agent) {
+        assert.ok(opts, `${file}: agent() called with no opts`)
+        assert.ok(opts.model, `${file}: agent() call has no model in opts`)
+        assert.ok(opts.effort, `${file}: agent() call has no effort in opts`)
+        assert.ok(opts.label, `${file}: agent() call has no label in opts`)
+
+        // Map the label back to its SPEC stage.
+        const stageName = lookupStage(opts.label, index)
+        assert.ok(
+          stageName,
+          `${file}: agent() call label "${opts.label}" does not match any SPEC stage`
+        )
+
+        const stage = spec.stages[stageName]
+        assert.ok(stage, `${file}: stage "${stageName}" not in SPEC`)
+
+        // Assert model matches TIER_MODELS for the stage's declared tier.
+        assert.equal(
+          opts.model,
+          TIER_MODELS[stage.tier],
+          `${file}: agent() call label "${opts.label}" (stage "${stageName}") ` +
+            `pins model "${opts.model}", but the SPEC declares tier "${stage.tier}" ` +
+            `which maps to model "${TIER_MODELS[stage.tier]}"`
+        )
+
+        // Assert effort matches TIER_EFFORTS for the stage's declared tier.
+        assert.equal(
+          opts.effort,
+          TIER_EFFORTS[stage.tier],
+          `${file}: agent() call label "${opts.label}" (stage "${stageName}") ` +
+            `pins effort "${opts.effort}", but the SPEC declares tier "${stage.tier}" ` +
+            `which maps to effort "${TIER_EFFORTS[stage.tier]}"`
+        )
+
+        // Reject lead tier on workflow stages.
+        assert.ok(
+          ALLOWED_AGENT_TIERS.includes(stage.tier),
+          `${file}: stage "${stageName}" declares tier "${stage.tier}", but ` +
+            `workflow stages may only use ${ALLOWED_AGENT_TIERS.join(' or ')}; ` +
+            `lead is reserved for the session`
+        )
+      }
+    })
+
+    test(`${file}: no agent() call uses a forbidden effort`, async () => {
+      const { calls } = await executeWorkflow(file)
+      for (const { opts } of calls.agent) {
+        assert.notEqual(
+          opts.effort,
+          'max',
+          `${file}: agent() call with label "${opts.label}" uses forbidden effort "max"`
+        )
+      }
+    })
+  }
+})

--- a/.claude/workflows/__tests__/specs.test.mjs
+++ b/.claude/workflows/__tests__/specs.test.mjs
@@ -1,0 +1,149 @@
+/**
+ * Spec consistency test (issue #314).
+ *
+ * Asserts that the embedded SPEC constant in each workflow JS file matches
+ * the corresponding JSON spec file under specs/. The JSON file is the
+ * portable representation other hosts consume; the embedded constant is what
+ * the Claude Code renderer uses at runtime (the workflow runtime has no
+ * imports). This test catches drift between the two.
+ *
+ * Also asserts that every tier referenced in a spec exists in the adapter
+ * table, bridging Phase A (#313) and Phase B (#314).
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+import { createContext, runInContext } from 'node:vm'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const workflowsDir = join(__dir, '..')
+const specsDir = join(workflowsDir, 'specs')
+const adaptersDir = join(workflowsDir, '..', 'adapters')
+
+const adapterTable = JSON.parse(readFileSync(join(adaptersDir, 'claude-code.json'), 'utf8'))
+const VALID_TIERS = Object.keys(adapterTable.tiers)
+
+const WORKFLOW_FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
+
+// ---------------------------------------------------------------------------
+// Parse the SPEC object from a JS source file by brace-matching.
+// ---------------------------------------------------------------------------
+function parseSpecFromJs(src) {
+  const startIdx = src.indexOf('const SPEC = {')
+  if (startIdx === -1) return null
+  let pos = src.indexOf('{', startIdx)
+  let depth = 0
+  let started = false
+  while (pos < src.length) {
+    if (src[pos] === '{') { depth++; started = true }
+    if (src[pos] === '}') depth--
+    pos++
+    if (started && depth === 0) break
+  }
+  const specSrc = src.slice(startIdx, pos)
+  const ctx = createContext({})
+  runInContext(specSrc, ctx)
+  return runInContext('SPEC', ctx)
+}
+
+// Deep equality that ignores functions and the _comment field.
+function deepEqualIgnoringMeta(a, b) {
+  if (typeof a !== typeof b) return false
+  if (typeof a !== 'object' || a === null || b === null) return a === b
+  const ak = Object.keys(a).filter((k) => k !== '_comment')
+  const bk = Object.keys(b).filter((k) => k !== '_comment')
+  if (ak.length !== bk.length) return false
+  for (const k of ak) {
+    if (!(k in b)) return false
+    if (!deepEqualIgnoringMeta(a[k], b[k])) return false
+  }
+  return true
+}
+
+// ===========================================================================
+// 1. Embedded SPEC matches the JSON spec file.
+// ===========================================================================
+describe('embedded SPEC matches JSON spec file', () => {
+  for (const file of WORKFLOW_FILES) {
+    const specName = file.replace(/\.js$/, '.spec.json')
+    const specPath = join(specsDir, specName)
+
+    test(`${specName} exists`, () => {
+      assert.ok(existsSync(specPath), `missing spec file: ${specPath}`)
+    })
+
+    test(`${file}: embedded SPEC matches ${specName}`, () => {
+      const src = readFileSync(join(workflowsDir, file), 'utf8')
+      const embeddedSpec = parseSpecFromJs(src)
+      assert.ok(embeddedSpec, `${file}: no SPEC constant found`)
+
+      const jsonSpec = JSON.parse(readFileSync(specPath, 'utf8'))
+
+      // Compare name, description, phases, stages.
+      assert.equal(embeddedSpec.name, jsonSpec.name, `${file}: SPEC.name mismatch`)
+      assert.equal(embeddedSpec.description, jsonSpec.description, `${file}: SPEC.description mismatch`)
+      // Phases: compare element-by-element ignoring key order. The
+      // vm-parsed SPEC comes from another realm (createContext), so
+      // deepStrict comparisons fail on cross-realm objects; serializing
+      // with sorted keys removes the realm problem.
+      assert.equal(embeddedSpec.phases.length, jsonSpec.phases.length, `${file}: SPEC.phases length mismatch`)
+      for (let i = 0; i < embeddedSpec.phases.length; i++) {
+        const ep = JSON.stringify(embeddedSpec.phases[i], Object.keys(embeddedSpec.phases[i]).sort())
+        const jp = JSON.stringify(jsonSpec.phases[i], Object.keys(jsonSpec.phases[i]).sort())
+        assert.equal(ep, jp, `${file}: SPEC.phases[${i}] mismatch`)
+      }
+      assert.ok(deepEqualIgnoringMeta(embeddedSpec.stages, jsonSpec.stages), `${file}: SPEC.stages mismatch`)
+    })
+  }
+})
+
+// ===========================================================================
+// 2. Every tier in a spec exists in the adapter table.
+// ===========================================================================
+describe('spec tiers exist in the adapter table', () => {
+  const specFiles = readdirSync(specsDir).filter((f) => f.endsWith('.spec.json'))
+
+  test('spec file count matches workflow file count', () => {
+    assert.equal(specFiles.length, WORKFLOW_FILES.length, `expected ${WORKFLOW_FILES.length} spec files, found ${specFiles.length}: ${specFiles.join(', ')}`)
+  })
+
+  for (const specFile of specFiles) {
+    const spec = JSON.parse(readFileSync(join(specsDir, specFile), 'utf8'))
+
+    test(`${specFile}: all phase tiers are valid`, () => {
+      for (const phase of spec.phases) {
+        assert.ok(
+          VALID_TIERS.includes(phase.tier),
+          `${specFile}: phase "${phase.title}" declares tier "${phase.tier}", not in adapter table (${VALID_TIERS.join(', ')})`
+        )
+      }
+    })
+
+    test(`${specFile}: all stage tiers are valid`, () => {
+      for (const [name, stage] of Object.entries(spec.stages)) {
+        assert.ok(
+          VALID_TIERS.includes(stage.tier),
+          `${specFile}: stage "${name}" declares tier "${stage.tier}", not in adapter table (${VALID_TIERS.join(', ')})`
+        )
+      }
+    })
+
+    test(`${specFile}: fallback tiers are valid`, () => {
+      for (const [name, stage] of Object.entries(spec.stages)) {
+        if (stage.fallback) {
+          assert.ok(
+            VALID_TIERS.includes(stage.fallback.from_tier),
+            `${specFile}: stage "${name}" fallback.from_tier "${stage.fallback.from_tier}" is not in the adapter table`
+          )
+          assert.ok(
+            VALID_TIERS.includes(stage.fallback.to_tier),
+            `${specFile}: stage "${name}" fallback.to_tier "${stage.fallback.to_tier}" is not in the adapter table`
+          )
+        }
+      }
+    })
+  }
+})

--- a/.claude/workflows/specs/tm-map-codebase.spec.json
+++ b/.claude/workflows/specs/tm-map-codebase.spec.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "Workflow fan-out spec for tm-map-codebase. Encoded as data so a host adapter can render the fan-out without reimplementing the orchestration logic. The Claude Code JS renderer embeds this spec as the SPEC constant; see tm-map-codebase.js. Spec format documented in docs/architecture/adapter-interface.md section 'Spec format'.",
+  "name": "tm-map-codebase",
+  "description": "Token-bounded full-repo map: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker maps each area (purpose, entry points, key modules, data and control flow, external dependencies, conventions), and one Opus critic synthesizes a dated architecture map. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling. This is a map, not a review: no findings, no severities, no recommendations.",
+  "phases": [
+    {
+      "title": "Scout",
+      "detail": "one Sonnet agent splits the repo into N areas (N <= ceiling)",
+      "tier": "worker"
+    },
+    {
+      "title": "Map",
+      "detail": "one Sonnet worker per area describes it",
+      "tier": "worker"
+    },
+    {
+      "title": "Synthesize",
+      "detail": "one Opus critic writes the consolidated map",
+      "tier": "judgment"
+    }
+  ],
+  "stages": {
+    "scout": {
+      "phase": "Scout",
+      "tier": "worker",
+      "parallelism": "single",
+      "label": "scout",
+      "schema": "MAP_SCHEMA",
+      "fallback": null
+    },
+    "area_map": {
+      "phase": "Map",
+      "tier": "worker",
+      "parallelism": "dynamic-list",
+      "items_source": "scout_result.areas",
+      "items_cap": "args.areas",
+      "items_default_cap": 24,
+      "item_label_prefix": "area:",
+      "schema": "AREA_MAP_SCHEMA",
+      "fallback": null
+    },
+    "synthesize": {
+      "phase": "Synthesize",
+      "tier": "judgment",
+      "parallelism": "single",
+      "label": "synthesize",
+      "schema": "REPORT_SCHEMA",
+      "fallback": {
+        "from_tier": "judgment",
+        "to_tier": "worker",
+        "preserve_effort": true
+      }
+    }
+  }
+}

--- a/.claude/workflows/specs/tm-review-changes.spec.json
+++ b/.claude/workflows/specs/tm-review-changes.spec.json
@@ -1,0 +1,40 @@
+{
+  "_comment": "Workflow fan-out spec for tm-review-changes. Encoded as data so a host adapter can render the fan-out without reimplementing the orchestration logic. The Claude Code JS renderer embeds this spec as the SPEC constant; see tm-review-changes.js. Spec format documented in docs/architecture/adapter-interface.md section 'Spec format'.",
+  "name": "tm-review-changes",
+  "description": "Token-bounded code review: Sonnet workers review the diff across fixed dimensions, one Opus critic consolidates. Models are pinned per stage in-script, so it never inherits the session model or fans out unboundedly.",
+  "phases": [
+    {
+      "title": "Review",
+      "detail": "one Sonnet worker per dimension",
+      "tier": "worker"
+    },
+    {
+      "title": "Consolidate",
+      "detail": "one Opus critic verifies and merges findings",
+      "tier": "judgment"
+    }
+  ],
+  "stages": {
+    "review": {
+      "phase": "Review",
+      "tier": "worker",
+      "parallelism": "fixed-list",
+      "items_key": "dimensions",
+      "item_label_prefix": "review:",
+      "schema": "FINDINGS_SCHEMA",
+      "fallback": null
+    },
+    "consolidate": {
+      "phase": "Consolidate",
+      "tier": "judgment",
+      "parallelism": "single",
+      "label": "consolidate",
+      "schema": "REPORT_SCHEMA",
+      "fallback": {
+        "from_tier": "judgment",
+        "to_tier": "worker",
+        "preserve_effort": true
+      }
+    }
+  }
+}

--- a/.claude/workflows/specs/tm-review-codebase.spec.json
+++ b/.claude/workflows/specs/tm-review-codebase.spec.json
@@ -1,0 +1,63 @@
+{
+  "_comment": "Workflow fan-out spec for tm-review-codebase. Encoded as data so a host adapter can render the fan-out without reimplementing the orchestration logic. The Claude Code JS renderer embeds this spec as the SPEC constant; see tm-review-codebase.js. Spec format documented in docs/architecture/adapter-interface.md section 'Spec format'.",
+  "name": "tm-review-codebase",
+  "description": "Token-bounded full-repo review: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker reviews each area plus one Sonnet architecture worker audits repo-wide structure, and one Opus critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling.",
+  "phases": [
+    {
+      "title": "Scout",
+      "detail": "one Sonnet agent splits the repo into N areas (N <= ceiling)",
+      "tier": "worker"
+    },
+    {
+      "title": "Review",
+      "detail": "one Sonnet worker per area plus one architecture worker",
+      "tier": "worker"
+    },
+    {
+      "title": "Consolidate",
+      "detail": "one Opus critic verifies, writes the report, consolidates",
+      "tier": "judgment"
+    }
+  ],
+  "stages": {
+    "scout": {
+      "phase": "Scout",
+      "tier": "worker",
+      "parallelism": "single",
+      "label": "scout",
+      "schema": "MAP_SCHEMA",
+      "fallback": null
+    },
+    "area_review": {
+      "phase": "Review",
+      "tier": "worker",
+      "parallelism": "dynamic-list",
+      "items_source": "scout_result.areas",
+      "items_cap": "args.areas",
+      "items_default_cap": 24,
+      "item_label_prefix": "area:",
+      "schema": "FINDINGS_SCHEMA",
+      "fallback": null
+    },
+    "architecture_review": {
+      "phase": "Review",
+      "tier": "worker",
+      "parallelism": "single",
+      "item_label": "architecture",
+      "schema": "FINDINGS_SCHEMA",
+      "fallback": null
+    },
+    "consolidate": {
+      "phase": "Consolidate",
+      "tier": "judgment",
+      "parallelism": "single",
+      "label": "consolidate",
+      "schema": "REPORT_SCHEMA",
+      "fallback": {
+        "from_tier": "judgment",
+        "to_tier": "worker",
+        "preserve_effort": true
+      }
+    }
+  }
+}

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -1,12 +1,64 @@
-export const meta = {
+// Workflow spec (embedded; mirrors specs/tm-map-codebase.spec.json)
+// The spec encodes the fan-out as data: stages, tiers, parallelism, schemas,
+// and fallbacks. The JS renderer reads SPEC to drive agent()/parallel()/phase()
+// calls. A host adapter on another platform reads the JSON spec file directly.
+// See docs/architecture/adapter-interface.md section "Spec format".
+// The spec-sync test (specs.test.mjs) asserts this constant matches the JSON.
+const SPEC = {
   name: 'tm-map-codebase',
   description:
     'Token-bounded full-repo map: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker maps each area (purpose, entry points, key modules, data and control flow, external dependencies, conventions), and one Opus critic synthesizes a dated architecture map. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling. This is a map, not a review: no findings, no severities, no recommendations.',
   phases: [
-    { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', model: 'sonnet' },
-    { title: 'Map', detail: 'one Sonnet worker per area describes it', model: 'sonnet' },
-    { title: 'Synthesize', detail: 'one Opus critic writes the consolidated map', model: 'opus' },
+    { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', tier: 'worker' },
+    { title: 'Map', detail: 'one Sonnet worker per area describes it', tier: 'worker' },
+    { title: 'Synthesize', detail: 'one Opus critic writes the consolidated map', tier: 'judgment' },
   ],
+  stages: {
+    scout: {
+      phase: 'Scout',
+      tier: 'worker',
+      parallelism: 'single',
+      label: 'scout',
+      schema: 'MAP_SCHEMA',
+      fallback: null,
+    },
+    area_map: {
+      phase: 'Map',
+      tier: 'worker',
+      parallelism: 'dynamic-list',
+      items_source: 'scout_result.areas',
+      items_cap: 'args.areas',
+      items_default_cap: 24,
+      item_label_prefix: 'area:',
+      schema: 'AREA_MAP_SCHEMA',
+      fallback: null,
+    },
+    synthesize: {
+      phase: 'Synthesize',
+      tier: 'judgment',
+      parallelism: 'single',
+      label: 'synthesize',
+      schema: 'REPORT_SCHEMA',
+      fallback: { from_tier: 'judgment', to_tier: 'worker', preserve_effort: true },
+    },
+  },
+}
+
+// Resolve a tier to a model+effort via the adapter table. The adapter table
+// (.claude/adapters/claude-code.json) is the single source of truth; the SPEC
+// references tiers, never model names. On Claude Code the resolution is
+// inlined here because the workflow runtime has no imports.
+const TIER_MODELS = { judgment: 'opus', worker: 'sonnet', lead: 'fable' }
+const TIER_EFFORTS = { judgment: 'xhigh', worker: 'high', lead: 'xhigh' }
+
+export const meta = {
+  name: SPEC.name,
+  description: SPEC.description,
+  phases: SPEC.phases.map((p) => ({
+    title: p.title,
+    detail: p.detail,
+    model: TIER_MODELS[p.tier],
+  })),
 }
 
 // Bounded by construction. The scout sizes the number of areas N to the repo, and
@@ -189,10 +241,13 @@ const REPORT_SCHEMA = {
 
 const scope = `Work from the repo root scoped to "${root}". List source files with \`git ls-files -- ${root}\` (it already respects .gitignore); ignore vendored and generated trees (node_modules, dist, build, vendor, .git, coverage) and lockfiles.`
 
-phase('Scout')
+// Render: fan out from the spec
+// Stage: scout (single, worker tier)
+const scoutStage = SPEC.stages.scout
+phase(scoutStage.phase)
 const map = await agent(
   `You map a repository into coherent areas for a codebase map (not a review). You do not describe or evaluate code content in this step, only structure.\n\n${scope}\n\nFirst gauge the repo's size (for example \`git ls-files -- ${root} | wc -l\`). Then split the files into N coherent areas, where an area is a set of files that belong together (a module, package, or directory subtree) and is small enough to read in one pass. Size N to the repo: make one area per top-level module or per a few thousand lines of related code, using as few areas as cover it well. Do NOT split finer just to use the budget; only a genuinely large codebase should approach ${MAX_AREAS} areas. Return at most ${MAX_AREAS} areas, ranked by importance (size and how central they are to the system). If the repo is larger than ${MAX_AREAS} areas can cover at a readable size, return the ${MAX_AREAS} most important and put every path you cannot fit in "dropped" so it is reported, not lost. Return areas (name, paths, why) and dropped.`,
-  { label: 'scout', phase: 'Scout', model: 'sonnet', effort: 'high', schema: MAP_SCHEMA }
+  { label: 'scout', phase: scoutStage.phase, model: TIER_MODELS[scoutStage.tier], effort: TIER_EFFORTS[scoutStage.tier], schema: MAP_SCHEMA }
 )
 
 // If the scout fails, no area workers run; flag it so the critic cannot
@@ -212,13 +267,15 @@ const scriptOverflow = allAreas.slice(MAX_AREAS).map((a) => a.name)
 const scoutSelfDropped = scoutFailed ? [] : Array.isArray(map.dropped) ? map.dropped : []
 const scoutDropped = scoutSelfDropped.concat(scriptOverflow)
 
-phase('Map')
+// Stage: area_map (parallel, dynamic-list, worker)
+const mapStage = SPEC.stages.area_map
+phase(mapStage.phase)
 const repoMap = areas.map((a) => `- ${a.name}: ${a.paths.join(', ')}`).join('\n')
 
 const mapThunks = areas.map((a) => () =>
   agent(
     `You map one area of a codebase. You describe, you do not evaluate: no findings, no severities, no recommendations, no quality or security judgments. You never edit.\n\nArea: ${a.name}\nPaths: ${a.paths.join(', ')}\n\nOther areas in this repo, for context on dependencies:\n${repoMap}\n\nRead these files in full, with surrounding context where needed. Describe:\n- purpose: what this area is for, in plain terms.\n- entryPoints: files or exports where execution or usage of this area starts.\n- keyModules: the modules that matter, each with a one-line role.\n- dataFlow: how data moves through this area.\n- controlFlow: how control moves through this area (call order, triggers, lifecycle).\n- externalDependencies: packages, services, or other areas this area depends on.\n- conventions: naming, structure, or style conventions specific to this area.\n\nSet area to "${a.name}". Stay within your area. Do not report findings, severities, or fixes; this is a map, not a review.`,
-    { label: `area:${a.name}`, phase: 'Map', model: 'sonnet', effort: 'high', schema: AREA_MAP_SCHEMA }
+    { label: `${mapStage.item_label_prefix}${a.name}`, phase: mapStage.phase, model: TIER_MODELS[mapStage.tier], effort: TIER_EFFORTS[mapStage.tier], schema: AREA_MAP_SCHEMA }
   )
 )
 
@@ -244,7 +301,9 @@ const suggestedNextAction = !ceilingReached
     ? `Coverage is partial: the scout proposed more than the ${MAX_AREAS}-area ceiling, so ${scriptOverflow.length} area(s) were clamped. Re-run with a higher cap (args.areas: ${MAX_AREAS * 2}). Clamped: ${scriptOverflow.join(', ')}.`
     : `Coverage is partial: the repo is larger than ${MAX_AREAS} areas can cover at a readable size, so the scout left ${scoutSelfDropped.length} path(s) out. Scope follow-up runs to the leftover with args.path, or raise the cap (args.areas) if those areas are small. Uncovered: ${scoutSelfDropped.join(', ')}.`
 
-phase('Synthesize')
+// Stage: synthesize (single, judgment tier, fallback to worker)
+const synthStage = SPEC.stages.synthesize
+phase(synthStage.phase)
 const coverageNote =
   (scoutFailed
     ? ` CRITICAL: the scout returned no valid area map, so NO area workers ran. This is a failed, not a complete, mapping run: do not present this as covering the repo; report it as incomplete and advise re-running.`
@@ -265,7 +324,7 @@ const suggestedNextActionClause = ceilingReached
 
 const report = await criticWithFallback(
   `You are the senior architect synthesizing a full-codebase map from the area descriptions below. This is a map, not a review: do not add findings, severities, recommendations, or quality and security judgments. Describe what is there.${coverageNote}\n\nRun \`date +%F\` for today's date, make the docs/architecture/ directory if it does not exist, and write docs/architecture/<date>-codebase-map.md with exactly these sections, in this order:\n1. Executive summary: what the repo is and how its areas fit together, in a few paragraphs.\n2. Component table: one row per area, with columns for area, purpose, and key modules.\n3. Data-flow narrative: how data moves across areas, end to end.\n4. Dependency summary: external dependencies (packages, services) and cross-area dependencies.\n5. Open questions: anything the workers could not determine or that needs a human to confirm.\n\nIf coverage is partial, add a "Coverage" callout immediately after the executive summary stating how many paths were not mapped and the suggested next action.\n\nSet reportPath to the file you wrote. Set summary to a short plain-language summary of the whole repo. Set openQuestions to the same list you put in the report's Open Questions section.\n\nSet coverage.areasMapped to ${JSON.stringify(mappedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nArea maps (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'synthesize', phase: 'Synthesize', model: 'opus', effort: 'xhigh', schema: REPORT_SCHEMA }
+  { label: 'synthesize', phase: synthStage.phase, model: TIER_MODELS[synthStage.tier], effort: TIER_EFFORTS[synthStage.tier], schema: REPORT_SCHEMA }
 )
 
 return report

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -1,11 +1,55 @@
-export const meta = {
+// Workflow spec (embedded; mirrors specs/tm-review-changes.spec.json)
+// The spec encodes the fan-out as data: stages, tiers, parallelism, schemas,
+// and fallbacks. The JS renderer reads SPEC to drive agent()/parallel()/phase()
+// calls. A host adapter on another platform reads the JSON spec file directly.
+// See docs/architecture/adapter-interface.md section "Spec format".
+// The spec-sync test (specs.test.mjs) asserts this constant matches the JSON.
+const SPEC = {
   name: 'tm-review-changes',
   description:
     'Token-bounded code review: Sonnet workers review the diff across fixed dimensions, one Opus critic consolidates. Models are pinned per stage in-script, so it never inherits the session model or fans out unboundedly.',
   phases: [
-    { title: 'Review', detail: 'one Sonnet worker per dimension', model: 'sonnet' },
-    { title: 'Consolidate', detail: 'one Opus critic verifies and merges findings', model: 'opus' },
+    { title: 'Review', detail: 'one Sonnet worker per dimension', tier: 'worker' },
+    { title: 'Consolidate', detail: 'one Opus critic verifies and merges findings', tier: 'judgment' },
   ],
+  stages: {
+    review: {
+      phase: 'Review',
+      tier: 'worker',
+      parallelism: 'fixed-list',
+      items_key: 'dimensions',
+      item_label_prefix: 'review:',
+      schema: 'FINDINGS_SCHEMA',
+      fallback: null,
+    },
+    consolidate: {
+      phase: 'Consolidate',
+      tier: 'judgment',
+      parallelism: 'single',
+      label: 'consolidate',
+      schema: 'REPORT_SCHEMA',
+      fallback: { from_tier: 'judgment', to_tier: 'worker', preserve_effort: true },
+    },
+  },
+}
+
+// Resolve a tier to a model+effort via the adapter table. The adapter table
+// (.claude/adapters/claude-code.json) is the single source of truth; the SPEC
+// references tiers, never model names. On Claude Code the resolution is
+// inlined here because the workflow runtime has no imports.
+const TIER_MODELS = { judgment: 'opus', worker: 'sonnet', lead: 'fable' }
+const TIER_EFFORTS = { judgment: 'xhigh', worker: 'high', lead: 'xhigh' }
+
+export const meta = {
+  name: SPEC.name,
+  description: SPEC.description,
+  phases: SPEC.phases.map((p) => ({
+    title: p.title,
+    detail: p.detail,
+    // The adapter table resolves the tier to a concrete model for the
+    // Claude Code host. meta.phases carries the model for display purposes.
+    model: TIER_MODELS[p.tier],
+  })),
 }
 
 // Bounded by construction. The dimension list is fixed, there is no per-file
@@ -150,12 +194,15 @@ const REPORT_SCHEMA = {
 const diffHint =
   `Get the change under review with \`git diff ${base}...HEAD\` for committed work on the branch, and \`git diff\` plus \`git status\` for any uncommitted changes; review the union. Read surrounding code before judging, and do not flag what the diff does not touch.`
 
-phase('Review')
+// Render: fan out from the spec
+// Stage: review (parallel, fixed-list of dimensions, worker tier)
+const reviewStage = SPEC.stages.review
+phase(reviewStage.phase)
 const reviews = await parallel(
   DIMENSIONS.map((d) => () =>
     agent(
       `You review one dimension of a code change and report findings only; you never edit.\n\nDimension: ${d.brief}\n\n${diffHint}\n\nReport every finding with file, line, severity (must-fix | should-fix | nit), the problem, and the required fix. If the dimension is clean, return an empty findings array. Stay strictly within your dimension.`,
-      { label: `review:${d.key}`, phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA }
+      { label: `${reviewStage.item_label_prefix}${d.key}`, phase: reviewStage.phase, model: TIER_MODELS[reviewStage.tier], effort: TIER_EFFORTS[reviewStage.tier], schema: FINDINGS_SCHEMA }
     )
   )
 )
@@ -171,10 +218,12 @@ const coverageNote = dropped.length
   ? ` ${dropped.length} reviewer(s) did not return, so these dimensions are NOT covered: ${dropped.map((d) => d.key).join(', ')}. Treat the review as partial and say so in your summary.`
   : ''
 
-phase('Consolidate')
+// Stage: consolidate (single, judgment tier, fallback to worker)
+const consolStage = SPEC.stages.consolidate
+phase(consolStage.phase)
 const report = await criticWithFallback(
   `You are the senior reviewer. ${covered.length} parallel reviewers produced the raw findings below.${coverageNote} ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: 'Consolidate', model: 'opus', effort: 'xhigh', schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: consolStage.phase, model: TIER_MODELS[consolStage.tier], effort: TIER_EFFORTS[consolStage.tier], schema: REPORT_SCHEMA }
 )
 
 return report

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -1,12 +1,72 @@
-export const meta = {
+// Workflow spec (embedded; mirrors specs/tm-review-codebase.spec.json)
+// The spec encodes the fan-out as data: stages, tiers, parallelism, schemas,
+// and fallbacks. The JS renderer reads SPEC to drive agent()/parallel()/phase()
+// calls. A host adapter on another platform reads the JSON spec file directly.
+// See docs/architecture/adapter-interface.md section "Spec format".
+// The spec-sync test (specs.test.mjs) asserts this constant matches the JSON.
+const SPEC = {
   name: 'tm-review-codebase',
   description:
     'Token-bounded full-repo review: a Sonnet scout splits the repo into N coherent areas (N sized to the repo, capped at a ceiling), one Sonnet worker reviews each area plus one Sonnet architecture worker audits repo-wide structure, and one Opus critic verifies, writes a dated report, and consolidates. Models are pinned per stage in-script, so it never inherits the session model, and the agent count scales with repo size only up to a hard ceiling.',
   phases: [
-    { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', model: 'sonnet' },
-    { title: 'Review', detail: 'one Sonnet worker per area plus one architecture worker', model: 'sonnet' },
-    { title: 'Consolidate', detail: 'one Opus critic verifies, writes the report, consolidates', model: 'opus' },
+    { title: 'Scout', detail: 'one Sonnet agent splits the repo into N areas (N <= ceiling)', tier: 'worker' },
+    { title: 'Review', detail: 'one Sonnet worker per area plus one architecture worker', tier: 'worker' },
+    { title: 'Consolidate', detail: 'one Opus critic verifies, writes the report, consolidates', tier: 'judgment' },
   ],
+  stages: {
+    scout: {
+      phase: 'Scout',
+      tier: 'worker',
+      parallelism: 'single',
+      label: 'scout',
+      schema: 'MAP_SCHEMA',
+      fallback: null,
+    },
+    area_review: {
+      phase: 'Review',
+      tier: 'worker',
+      parallelism: 'dynamic-list',
+      items_source: 'scout_result.areas',
+      items_cap: 'args.areas',
+      items_default_cap: 24,
+      item_label_prefix: 'area:',
+      schema: 'FINDINGS_SCHEMA',
+      fallback: null,
+    },
+    architecture_review: {
+      phase: 'Review',
+      tier: 'worker',
+      parallelism: 'single',
+      item_label: 'architecture',
+      schema: 'FINDINGS_SCHEMA',
+      fallback: null,
+    },
+    consolidate: {
+      phase: 'Consolidate',
+      tier: 'judgment',
+      parallelism: 'single',
+      label: 'consolidate',
+      schema: 'REPORT_SCHEMA',
+      fallback: { from_tier: 'judgment', to_tier: 'worker', preserve_effort: true },
+    },
+  },
+}
+
+// Resolve a tier to a model+effort via the adapter table. The adapter table
+// (.claude/adapters/claude-code.json) is the single source of truth; the SPEC
+// references tiers, never model names. On Claude Code the resolution is
+// inlined here because the workflow runtime has no imports.
+const TIER_MODELS = { judgment: 'opus', worker: 'sonnet', lead: 'fable' }
+const TIER_EFFORTS = { judgment: 'xhigh', worker: 'high', lead: 'xhigh' }
+
+export const meta = {
+  name: SPEC.name,
+  description: SPEC.description,
+  phases: SPEC.phases.map((p) => ({
+    title: p.title,
+    detail: p.detail,
+    model: TIER_MODELS[p.tier],
+  })),
 }
 
 // Bounded by construction. The scout sizes the number of areas N to the repo, and
@@ -187,10 +247,13 @@ const dimensions = `Review across these dimensions:
 - tests: behavior with no test pinning it, logic with a right answer lacking a test, integration points with no fixture coverage.
 - style: project code and writing style (em dashes, AI-cliche phrases, hard-coded user-facing strings, raw primitives where dedicated types exist, comments that restate code).`
 
-phase('Scout')
+// Render: fan out from the spec
+// Stage: scout (single, worker tier)
+const scoutStage = SPEC.stages.scout
+phase(scoutStage.phase)
 const map = await agent(
   `You map a repository into coherent review areas. You do not review code in this step.\n\n${scope}\n\nFirst gauge the repo's size (for example \`git ls-files -- ${root} | wc -l\`). Then split the files into N coherent areas, where an area is a set of files that belong together (a module, package, or directory subtree) and is small enough to read in one pass. Size N to the repo: make one area per top-level module or per a few thousand lines of related code, using as few areas as cover it well. Do NOT split finer just to use the budget; only a genuinely large codebase should approach ${MAX_AREAS} areas. Return at most ${MAX_AREAS} areas, ranked by importance (size and how central they are to the system). If the repo is larger than ${MAX_AREAS} areas can cover at a readable size, return the ${MAX_AREAS} most important and put every path you cannot fit in "dropped" so it is reported, not lost. Return areas (name, paths, why) and dropped.`,
-  { label: 'scout', phase: 'Scout', model: 'sonnet', effort: 'high', schema: MAP_SCHEMA }
+  { label: 'scout', phase: scoutStage.phase, model: TIER_MODELS[scoutStage.tier], effort: TIER_EFFORTS[scoutStage.tier], schema: MAP_SCHEMA }
 )
 
 // If the scout fails, no area workers run; flag it so the critic cannot approve
@@ -210,20 +273,23 @@ const scriptOverflow = allAreas.slice(MAX_AREAS).map((a) => a.name)
 const scoutSelfDropped = scoutFailed ? [] : Array.isArray(map.dropped) ? map.dropped : []
 const scoutDropped = scoutSelfDropped.concat(scriptOverflow)
 
-phase('Review')
+// Stages: area_review (parallel, dynamic-list, worker) + architecture_review (single, worker)
+const areaStage = SPEC.stages.area_review
+const archStage = SPEC.stages.architecture_review
+phase(areaStage.phase)
 const repoMap = areas.map((a) => `- ${a.name}: ${a.paths.join(', ')}`).join('\n')
 
 const reviewThunks = areas.map((a) => () =>
   agent(
     `You review one area of a codebase and report findings only. You never edit.\n\nArea: ${a.name}\nPaths: ${a.paths.join(', ')}\n\nRead these files in full, with surrounding context where needed. ${dimensions}\n\nReport every finding with area ("${a.name}"), dimension, file, line, severity (must-fix | should-fix | nit), the problem, and the required fix. If the area is clean, return an empty findings array. Stay within your area.`,
-    { label: `area:${a.name}`, phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA }
+    { label: `${areaStage.item_label_prefix}${a.name}`, phase: areaStage.phase, model: TIER_MODELS[areaStage.tier], effort: TIER_EFFORTS[areaStage.tier], schema: FINDINGS_SCHEMA }
   )
 )
 
 reviewThunks.push(() =>
   agent(
     `You audit a repository's structure and report findings only. You never edit. Use dimension "architecture".\n\n${scope}\n\nRead the directory layout, module boundaries, imports, and dependency manifests. Read signatures and imports rather than full file bodies, so you can hold the whole tree in view. The area map is:\n${repoMap}\n\nFlag: module boundaries and layering that have drifted, the same logic duplicated across modules, dead or orphaned code, dependency health (unused, outdated, risky), test-coverage gaps at the suite level, and doc drift between README/CLAUDE.md claims and the actual repo state (commands that no longer exist, a described layout that does not match the real one, stale status claims). Report each finding with area (the module name or "repo"), dimension ("architecture"), file, line or "n/a", severity, the problem, and the fix.`,
-    { label: 'architecture', phase: 'Review', model: 'sonnet', effort: 'high', schema: FINDINGS_SCHEMA }
+    { label: archStage.item_label, phase: archStage.phase, model: TIER_MODELS[archStage.tier], effort: TIER_EFFORTS[archStage.tier], schema: FINDINGS_SCHEMA }
   )
 )
 
@@ -255,7 +321,9 @@ const suggestedNextAction = !ceilingReached
     ? `Coverage is partial: the scout proposed more than the ${MAX_AREAS}-area ceiling, so ${scriptOverflow.length} area(s) were clamped. Re-run with a higher cap (args.areas: ${MAX_AREAS * 2}). Clamped: ${scriptOverflow.join(', ')}.`
     : `Coverage is partial: the repo is larger than ${MAX_AREAS} areas can cover at a readable size, so the scout left ${scoutSelfDropped.length} path(s) out. Scope follow-up runs to the leftover with args.path, or raise the cap (args.areas) if those areas are small. Uncovered: ${scoutSelfDropped.join(', ')}.`
 
-phase('Consolidate')
+// Stage: consolidate (single, judgment tier, fallback to worker)
+const consolStage = SPEC.stages.consolidate
+phase(consolStage.phase)
 const coverageNote =
   (scoutFailed
     ? ` CRITICAL: the scout returned no valid area map, so NO area workers ran and only the architecture worker saw the repo. This is a failed, not a clean, review: do not return approve on this basis; report it as incomplete and advise re-running.`
@@ -276,7 +344,7 @@ const suggestedNextActionClause = ceilingReached
 
 const report = await criticWithFallback(
   `You are the senior reviewer consolidating a full-codebase review. The workers below produced the raw findings.${coverageNote}\n\nVerify each finding against the actual code, drop false positives and anything out of scope, merge duplicates (including the same problem found in two areas), and set a final severity. You may add a finding only if it is a clear must-fix the workers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nThen write the report file. Run \`date +%F\` for today's date, make the docs/reviews/ directory if it does not exist, and write docs/reviews/<date>-codebase-review.md with: the verdict and summary first; then a one-line health impression scored 0-10 and up to three named top risks; then, if coverage is partial, a prominent "Coverage: PARTIAL" callout immediately after that opening block that states how many paths were not reviewed and the suggested next action; then the findings as severity sections (must-fix, then should-fix, then nit), each organized by area; then a final "Coverage" section listing the areas reviewed, the paths not covered, the workers that failed, and (if partial) the suggested next action. Set reportPath to the file you wrote.\n\nReturn the structured summary. Set coverage.areasReviewed to ${JSON.stringify(reviewedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: 'Consolidate', model: 'opus', effort: 'xhigh', schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: consolStage.phase, model: TIER_MODELS[consolStage.tier], effort: TIER_EFFORTS[consolStage.tier], schema: REPORT_SCHEMA }
 )
 
 return report

--- a/docs/architecture/adapter-interface.md
+++ b/docs/architecture/adapter-interface.md
@@ -97,6 +97,56 @@ declared tier. A future phase (Phase B, issue #314) introduces
 inline TIER_MODELS/TIER_EFFORTS maps in the workflow scripts so the
 scripts reference tiers, not model names, at the callsite.
 
+## Spec format
+
+Each workflow's fan-out is encoded as a JSON spec file under
+`.claude/workflows/specs/`. The Claude Code JS renderer embeds a
+matching `SPEC` constant; a future Hermes or Codex renderer reads the
+JSON directly. The spec-sync test asserts the two stay in sync.
+
+Top-level fields:
+
+- `name`: the workflow identifier (matches the JS filename stem).
+- `description`: one paragraph, no tool names or model names.
+- `phases`: array of `{ title, detail, tier }`. Ordered list of phases
+  the workflow progresses through. `tier` is the model tier for that
+  phase.
+- `stages`: object mapping stage names to stage descriptors. Each
+  stage descriptor has:
+  - `phase`: which phase this stage belongs to.
+  - `tier`: `"judgment"` or `"worker"` (never `"lead"`).
+  - `parallelism`: `"single"` (one agent), `"fixed-list"` (N agents,
+    N known at spec-write time), or `"dynamic-list"` (N agents, N
+    determined at runtime by the previous stage's output).
+  - `schema`: the name of the JSON Schema constant the stage uses.
+  - `fallback`: `null`, or `{ from_tier, to_tier, preserve_effort }`
+    describing the retry behavior on failure.
+  - `label`: for `single` stages, the literal label string used in
+    agent() calls. Used by the render-path test to map recorded
+    calls back to their SPEC stage.
+  - `item_label_prefix`: for `fixed-list` and `dynamic-list` stages,
+    the prefix concatenated with each item to form the agent() label.
+  - `item_label`: for `single` stages that use a descriptive label
+    rather than a literal (e.g. `architecture`).
+  - `items_source`: for `dynamic-list` stages, the path in the
+    previous stage's output that yields the item list (e.g.
+    `scout_result.areas`).
+  - `items_key`: for `fixed-list` stages, the name of the data array
+    in the SPEC that enumerates the items.
+  - `items_cap`: for `dynamic-list` stages, the name of the args
+    field that caps the item count (e.g. `args.areas`).
+  - `items_default_cap`: for `dynamic-list` stages, the default cap
+    when the args field is absent (e.g. `24`).
+
+Stages do not carry `effort` or `model`; those are resolved from the
+tier via the adapter table at render time.
+
+The JSON spec files carry only `name`, `description`, `phases`, and
+`stages`. Data arrays (dimensions, area lists), schema objects, and
+default args stay inlined in the JS because the runtime has no
+imports; the specs.test.mjs sync test compares only the four
+synced fields.
+
 ## What the interface does not specify
 
 - How the host isolates work (worktrees, branches, containers). That


### PR DESCRIPTION
Closes #314

## What this does

Phase B of the portable orchestrator (\#311). Expresses the three
workflow scripts' fan-out as data specs, with the Claude Code JS
renderer as the first implementation.

## Changes

- **3 JSON spec files** under `specs/`: encode each workflow's stages,
  tiers, parallelism, and fallbacks. Data/schemas/args deleted (no
  renderer consumes them).
- **3 JS workflow files**: each embeds a `SPEC` constant mirroring its
  JSON spec. TIER_MODELS/TIER_EFFORTS before meta. Single stages
  carry a `label` field for render-path test mapping.
- **Helpers** remain byte-identical across files.
- **effort-policy test**: policy values hardcoded as authority.
  Conformance runs over every adapter table. Rebase duplicates removed.
- **render-path test**: invokes parallel thunks (covers all fan-out
  callsites, 15 total). Maps labels back to SPEC stages; asserts
  model/effort match the stage's declared tier. Catches bypasses and
  aliasing bugs.
- **specs test**: asserts embedded SPEC matches JSON spec.
- **adapter-interface.md**: Spec format section documents all stage
  fields.

## Verification

```
npm test -> 126 pass, 0 fail
```

Tester: PASS. Reviewer: pending round 3.