### PR TITLE
feat: test migration to tier assertions

### DIFF
--- a/.claude/workflows/__tests__/effort-policy.test.mjs
+++ b/.claude/workflows/__tests__/effort-policy.test.mjs
@@ -72,8 +72,14 @@ const adapterTables = adapterFiles.map((f) => ({
   table: JSON.parse(readFileSync(join(adaptersDir, f), 'utf8')),
 }))
 
-// Hardcoded seat-level expectations: these are the policy, not the table.
-// A coordinated edit to the JSON cannot weaken them (review #320 finding 14).
+// Hardcoded seat-level expectations for the REFERENCE adapter only.
+// These pin the Claude Code model assignments (opus/sonnet/fable) so a
+// coordinated edit to the JSON cannot weaken the reference policy (review
+// #320 finding 14). Non-reference adapters (Hermes, Codex) map tiers to
+// their own models; the universal checks above (forbidden efforts, ceiling,
+// tier completeness) apply to every table, but the model identities are
+// host-specific and not asserted here (issue #317).
+const REFERENCE_ADAPTER = 'claude-code.json'
 const SEAT_EXPECTATIONS = {
   judgment: { model: 'opus', effort: 'xhigh' },
   worker: { model: 'sonnet', effort: 'high' },
@@ -133,22 +139,26 @@ for (const { name, table } of adapterTables) {
       }
     })
 
-    test('seat-level model and effort match hardcoded expectations', () => {
-      for (const [tier, expected] of Object.entries(SEAT_EXPECTATIONS)) {
-        const cfg = table.tiers[tier]
-        assert.ok(cfg, `${name}: missing tier "${tier}"`)
-        assert.equal(
-          cfg.model,
-          expected.model,
-          `${name}: tier "${tier}" model is "${cfg.model}", but the policy hardcodes "${expected.model}"`
-        )
-        assert.equal(
-          cfg.effort,
-          expected.effort,
-          `${name}: tier "${tier}" effort is "${cfg.effort}", but the policy hardcodes "${expected.effort}"`
-        )
-      }
-    })
+    // Seat-level model+effort expectations apply to the reference adapter
+    // only. Other hosts map tiers to their own models (issue #317).
+    if (name === REFERENCE_ADAPTER) {
+      test('reference adapter: seat-level model and effort match hardcoded expectations', () => {
+        for (const [tier, expected] of Object.entries(SEAT_EXPECTATIONS)) {
+          const cfg = table.tiers[tier]
+          assert.ok(cfg, `${name}: missing tier "${tier}"`)
+          assert.equal(
+            cfg.model,
+            expected.model,
+            `${name}: tier "${tier}" model is "${cfg.model}", but the policy hardcodes "${expected.model}"`
+          )
+          assert.equal(
+            cfg.effort,
+            expected.effort,
+            `${name}: tier "${tier}" effort is "${cfg.effort}", but the policy hardcodes "${expected.effort}"`
+          )
+        }
+      })
+    }
   })
 }
 

--- a/.claude/workflows/__tests__/helpers.test.mjs
+++ b/.claude/workflows/__tests__/helpers.test.mjs
@@ -402,7 +402,11 @@ describe('scoutDropped union', () => {
 // ===========================================================================
 describe('criticWithFallback', () => {
   const FILES = ['tm-review-changes.js', 'tm-review-codebase.js', 'tm-map-codebase.js']
-  const baseOpts = { label: 'consolidate', phase: 'Consolidate', model: 'opus', effort: 'xhigh', schema: { type: 'object' } }
+  // Tier-level fixtures: the test asserts the fallback mechanics, not any
+  // particular model name. The primary model stands in for a judgment-tier
+  // model; fallbackModel stands in for the worker-tier model the SPEC's
+  // fallback.to_tier resolves to. This keeps the test host-neutral (issue #317).
+  const baseOpts = { label: 'consolidate', phase: 'Consolidate', model: 'primary-model', fallbackModel: 'fallback-model', effort: 'xhigh', schema: { type: 'object' } }
 
   test('happy path: first agent call succeeds, result returned unchanged', async () => {
     const calls = []
@@ -424,7 +428,7 @@ describe('criticWithFallback', () => {
     assert.equal('modelFallback' in result, false)
   })
 
-  test('first call returns null, retries on sonnet and succeeds', async () => {
+  test('first call returns null, retries on fallback model and succeeds', async () => {
     const calls = []
     const logs = []
     const sandbox = {
@@ -440,7 +444,7 @@ describe('criticWithFallback', () => {
 
     assert.equal(calls.length, 2)
     const secondOpts = calls[1].opts
-    assert.equal(secondOpts.model, 'sonnet')
+    assert.equal(secondOpts.model, baseOpts.fallbackModel)
     assert.equal(secondOpts.effort, baseOpts.effort)
     assert.equal(secondOpts.label, baseOpts.label)
     assert.equal(secondOpts.phase, baseOpts.phase)
@@ -448,7 +452,7 @@ describe('criticWithFallback', () => {
     assert.ok(calls[1].prompt.includes('the prompt'), 'second prompt still carries the original prompt')
     assert.ok(calls[1].prompt.length > 'the prompt'.length, 'second prompt carries an added notice')
     assert.equal(result.verdict, 'approve')
-    assert.equal(result.modelFallback, 'opus -> sonnet')
+    assert.equal(result.modelFallback, `${baseOpts.model} -> ${baseOpts.fallbackModel}`)
     assert.ok(logs.length >= 1, 'log() must be called to surface the fallback')
   })
 
@@ -469,8 +473,8 @@ describe('criticWithFallback', () => {
     // vm-realm errors are not `instanceof` the host's Error, so assert on the
     // message rather than the error's prototype chain.
     assert.match(threw.message, /consolidate/)
-    assert.match(threw.message, /sonnet/)
-    assert.match(threw.message, /opus/)
+    assert.match(threw.message, /fallback-model/)
+    assert.match(threw.message, /primary-model/)
   })
 
   test('is byte-identical across all three workflow files', () => {

--- a/.claude/workflows/__tests__/render-path.test.mjs
+++ b/.claude/workflows/__tests__/render-path.test.mjs
@@ -27,8 +27,15 @@ const adaptersDir = join(__dir, '..', '..', 'adapters')
 
 const adapterTable = JSON.parse(readFileSync(join(adaptersDir, 'claude-code.json'), 'utf8'))
 
-const TIER_MODELS = { judgment: 'opus', worker: 'sonnet', lead: 'fable' }
-const TIER_EFFORTS = { judgment: 'xhigh', worker: 'high', lead: 'xhigh' }
+// Derive tier mappings from the adapter table, not hardcoded model names.
+// The render-path test asserts that agent() calls use the model+effort the
+// adapter table assigns to each stage's declared tier (issue #317).
+const TIER_MODELS = {}
+const TIER_EFFORTS = {}
+for (const [tier, cfg] of Object.entries(adapterTable.tiers)) {
+  TIER_MODELS[tier] = cfg.model
+  TIER_EFFORTS[tier] = cfg.effort
+}
 
 const ALLOWED_AGENT_TIERS = ['judgment', 'worker']
 

--- a/.claude/workflows/tm-map-codebase.js
+++ b/.claude/workflows/tm-map-codebase.js
@@ -123,21 +123,26 @@ async function criticWithFallback(prompt, opts) {
   // is itself an agent() call, so skipping again just returns null and the
   // run ends below with a clear error), while not retrying a quota death
   // costs the entire unattended run. Retry unconditionally.
+  //
+  // The fallback model is resolved from the SPEC's fallback.to_tier via the
+  // adapter table by the caller and passed as opts.fallbackModel. This keeps
+  // the function host-neutral: no hardcoded model names (issue #317).
   if (first) return first
+  const fb = opts.fallbackModel
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on sonnet at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on ${fb} at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the sonnet fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'sonnet' }
+    `${prompt}\n\nNOTE: this is a retry on the ${fb} fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: fb }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the sonnet fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the sonnet fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the ${fb} fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the ${fb} fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> sonnet` }
+  return { ...second, modelFallback: `${opts.model} -> ${fb}` }
 }
 
 const AREA = {
@@ -324,7 +329,7 @@ const suggestedNextActionClause = ceilingReached
 
 const report = await criticWithFallback(
   `You are the senior architect synthesizing a full-codebase map from the area descriptions below. This is a map, not a review: do not add findings, severities, recommendations, or quality and security judgments. Describe what is there.${coverageNote}\n\nRun \`date +%F\` for today's date, make the docs/architecture/ directory if it does not exist, and write docs/architecture/<date>-codebase-map.md with exactly these sections, in this order:\n1. Executive summary: what the repo is and how its areas fit together, in a few paragraphs.\n2. Component table: one row per area, with columns for area, purpose, and key modules.\n3. Data-flow narrative: how data moves across areas, end to end.\n4. Dependency summary: external dependencies (packages, services) and cross-area dependencies.\n5. Open questions: anything the workers could not determine or that needs a human to confirm.\n\nIf coverage is partial, add a "Coverage" callout immediately after the executive summary stating how many paths were not mapped and the suggested next action.\n\nSet reportPath to the file you wrote. Set summary to a short plain-language summary of the whole repo. Set openQuestions to the same list you put in the report's Open Questions section.\n\nSet coverage.areasMapped to ${JSON.stringify(mappedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nArea maps (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'synthesize', phase: synthStage.phase, model: TIER_MODELS[synthStage.tier], effort: TIER_EFFORTS[synthStage.tier], schema: REPORT_SCHEMA }
+  { label: 'synthesize', phase: synthStage.phase, model: TIER_MODELS[synthStage.tier], effort: TIER_EFFORTS[synthStage.tier], fallbackModel: TIER_MODELS[synthStage.fallback.to_tier], schema: REPORT_SCHEMA }
 )
 
 return report

--- a/.claude/workflows/tm-review-changes.js
+++ b/.claude/workflows/tm-review-changes.js
@@ -85,21 +85,26 @@ async function criticWithFallback(prompt, opts) {
   // is itself an agent() call, so skipping again just returns null and the
   // run ends below with a clear error), while not retrying a quota death
   // costs the entire unattended run. Retry unconditionally.
+  //
+  // The fallback model is resolved from the SPEC's fallback.to_tier via the
+  // adapter table by the caller and passed as opts.fallbackModel. This keeps
+  // the function host-neutral: no hardcoded model names (issue #317).
   if (first) return first
+  const fb = opts.fallbackModel
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on sonnet at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on ${fb} at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the sonnet fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'sonnet' }
+    `${prompt}\n\nNOTE: this is a retry on the ${fb} fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: fb }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the sonnet fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the sonnet fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the ${fb} fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the ${fb} fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> sonnet` }
+  return { ...second, modelFallback: `${opts.model} -> ${fb}` }
 }
 
 // This list is diff-scoped and intentionally longer than tm-review-codebase's
@@ -223,7 +228,7 @@ const consolStage = SPEC.stages.consolidate
 phase(consolStage.phase)
 const report = await criticWithFallback(
   `You are the senior reviewer. ${covered.length} parallel reviewers produced the raw findings below.${coverageNote} ${diffHint}\n\nFor each raw finding: verify it against the actual diff, drop false positives and anything out of scope, merge duplicates, and set a final severity. You may add a finding only if it is a clear must-fix the reviewers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: consolStage.phase, model: TIER_MODELS[consolStage.tier], effort: TIER_EFFORTS[consolStage.tier], schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: consolStage.phase, model: TIER_MODELS[consolStage.tier], effort: TIER_EFFORTS[consolStage.tier], fallbackModel: TIER_MODELS[consolStage.fallback.to_tier], schema: REPORT_SCHEMA }
 )
 
 return report

--- a/.claude/workflows/tm-review-codebase.js
+++ b/.claude/workflows/tm-review-codebase.js
@@ -124,21 +124,26 @@ async function criticWithFallback(prompt, opts) {
   // is itself an agent() call, so skipping again just returns null and the
   // run ends below with a clear error), while not retrying a quota death
   // costs the entire unattended run. Retry unconditionally.
+  //
+  // The fallback model is resolved from the SPEC's fallback.to_tier via the
+  // adapter table by the caller and passed as opts.fallbackModel. This keeps
+  // the function host-neutral: no hardcoded model names (issue #317).
   if (first) return first
+  const fb = opts.fallbackModel
   log(
-    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on sonnet at the same effort. Skipping again will end the run.`
+    `${opts.label}: the ${opts.model} critic returned nothing. This could be quota exhaustion or a manual skip; retrying once on ${fb} at the same effort. Skipping again will end the run.`
   )
   const second = await agent(
-    `${prompt}\n\nNOTE: this is a retry on the sonnet fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
-    { ...opts, model: 'sonnet' }
+    `${prompt}\n\nNOTE: this is a retry on the ${fb} fallback after the ${opts.model} critic returned nothing (quota or a skip). If you write a report file, record in it that this fallback produced it.`,
+    { ...opts, model: fb }
   )
-  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the sonnet fallback returned nothing.`)
-  log(`${opts.label}: this critique was produced by the sonnet fallback, not ${opts.model}.`)
+  if (!second) throw new Error(`${opts.label}: both the ${opts.model} critic and the ${fb} fallback returned nothing.`)
+  log(`${opts.label}: this critique was produced by the ${fb} fallback, not ${opts.model}.`)
   // Return a new object rather than mutating `second`: the runtime's returned
   // object could be frozen or sealed, in which case mutating it would either
   // silently drop the `modelFallback` marker (sloppy mode) or throw a
   // TypeError.
-  return { ...second, modelFallback: `${opts.model} -> sonnet` }
+  return { ...second, modelFallback: `${opts.model} -> ${fb}` }
 }
 
 // FINDING and FINDINGS_SCHEMA are a shared base intentionally duplicated with
@@ -344,7 +349,7 @@ const suggestedNextActionClause = ceilingReached
 
 const report = await criticWithFallback(
   `You are the senior reviewer consolidating a full-codebase review. The workers below produced the raw findings.${coverageNote}\n\nVerify each finding against the actual code, drop false positives and anything out of scope, merge duplicates (including the same problem found in two areas), and set a final severity. You may add a finding only if it is a clear must-fix the workers missed. Only must-fix findings block: verdict is changes-requested if any remain, approve otherwise. Record every dropped finding under dismissed with the reason.\n\nThen write the report file. Run \`date +%F\` for today's date, make the docs/reviews/ directory if it does not exist, and write docs/reviews/<date>-codebase-review.md with: the verdict and summary first; then a one-line health impression scored 0-10 and up to three named top risks; then, if coverage is partial, a prominent "Coverage: PARTIAL" callout immediately after that opening block that states how many paths were not reviewed and the suggested next action; then the findings as severity sections (must-fix, then should-fix, then nit), each organized by area; then a final "Coverage" section listing the areas reviewed, the paths not covered, the workers that failed, and (if partial) the suggested next action. Set reportPath to the file you wrote.\n\nReturn the structured summary. Set coverage.areasReviewed to ${JSON.stringify(reviewedAreas)}, coverage.areasDropped to ${JSON.stringify(scoutDropped)}, coverage.workersFailed to ${JSON.stringify(workersFailed)}, coverage.ceilingReached to ${ceilingReached}${suggestedNextActionClause}.\n\nRaw findings (JSON):\n${JSON.stringify(raw, null, 2)}`,
-  { label: 'consolidate', phase: consolStage.phase, model: TIER_MODELS[consolStage.tier], effort: TIER_EFFORTS[consolStage.tier], schema: REPORT_SCHEMA }
+  { label: 'consolidate', phase: consolStage.phase, model: TIER_MODELS[consolStage.tier], effort: TIER_EFFORTS[consolStage.tier], fallbackModel: TIER_MODELS[consolStage.fallback.to_tier], schema: REPORT_SCHEMA }
 )
 
 return report


### PR DESCRIPTION
Closes #317

## What this does

Phase E of the portable orchestrator (#311). Completes the migration of the test suite from hardcoded model-name assertions to tier-level assertions, and removes the last hardcoded model name from the workflow runtime.

## Changes

- **criticWithFallback** (all 3 workflow files): no longer hardcodes `model: 'sonnet'` in the fallback path. Reads `opts.fallbackModel` instead, which the caller resolves from the SPEC's `fallback.to_tier` via the adapter table. Byte-identical across all three files.
- **All 3 callsites**: pass `fallbackModel: TIER_MODELS[stage.fallback.to_tier]`.
- **helpers.test.mjs**: criticWithFallback tests use generic fixture model names (`primary-model` / `fallback-model`) instead of `opus`/`sonnet`. Asserts the fallback mechanic, not any particular model identity.
- **effort-policy.test.mjs**: SEAT_EXPECTATIONS (opus/sonnet/fable) scoped to the reference adapter (claude-code.json) only. Universal policy checks (forbidden efforts, ceiling, tier completeness) still run on every adapter table. Future Hermes/Codex tables map their own models.
- **render-path.test.mjs**: TIER_MODELS/TIER_EFFORTS derived from the adapter table instead of hardcoded.

## Acceptance criteria

- [x] The effort-policy and helpers tests assert against the tier abstraction instead of hardcoded model names.
- [x] A test validates adapter table completeness (all tiers mapped, no max effort) -- adapter-table.test.mjs (structural) + effort-policy.test.mjs (policy conformance).
- [x] All tests green on the Claude Code adapter table.

## Verification

```
npm test -> 127 pass, 0 fail
```

Tester: PASS. Reviewer: pending.
