### PR TITLE
feat: Codex adapter with subscription auth

### DIFF
--- a/.claude/adapters/codex-adapter.mjs
+++ b/.claude/adapters/codex-adapter.mjs
@@ -1,0 +1,232 @@
+/**
+ * Codex adapter (issue #316, Phase D of #311).
+ *
+ * Implements the adapter interface (spawn, detectFailure, retry) for the
+ * Codex host. Spawn uses `codex exec` invoked via the terminal, with -m
+ * for model selection and -s for sandbox mode. Reports come through
+ * stdout. Authentication is ChatGPT subscription (no metered API keys).
+ *
+ * The adapter table (.claude/adapters/codex.json) maps tiers to concrete
+ * models and efforts. This module reads the table at init time and
+ * exposes the three interface operations.
+ *
+ * See docs/architecture/adapter-interface.md for the interface contract.
+ * See docs/research/2026-08-14-codex-subscription-auth-spike.md for the
+ * verified auth path.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+import { execSync } from 'node:child_process'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+
+// Load the Codex adapter table.
+const adapterTable = JSON.parse(
+  readFileSync(join(__dir, 'codex.json'), 'utf8')
+)
+
+const TIERS = adapterTable.tiers
+const ROLE_TIERS = adapterTable.roles
+
+// Codex effort levels map to reasoning effort config overrides.
+// The codex exec CLI uses model_reasoning_effort in config.toml, overridden
+// via -c model_reasoning_effort="<level>".
+const EFFORT_TO_CODEX = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'high', // codex has no xhigh; high is the ceiling
+}
+
+// Resolve a tier to its model and effort.
+export function resolveTier(tier) {
+  const cfg = TIERS[tier]
+  if (!cfg) throw new Error(`Unknown tier "${tier}". Add it to codex.json.`)
+  return { model: cfg.model, effort: cfg.effort }
+}
+
+// Resolve a role to its tier.
+export function resolveRole(role) {
+  const tier = ROLE_TIERS[role]
+  if (!tier) throw new Error(`Unknown role "${role}". Add it to codex.json.`)
+  return tier
+}
+
+/**
+ * spawn(role, task, opts) -> report | null
+ *
+ * Dispatch a role agent via `codex exec`. The task prompt is passed as the
+ * positional argument; the model is selected via -m; sandbox mode via -s.
+ * The report is collected from stdout.
+ *
+ * In dry-run mode (DRY_RUN=true), returns a synthetic report without
+ * invoking codex exec.
+ */
+export async function spawn(role, task, opts = {}) {
+  const tier = opts.tier || resolveRole(role)
+  const { model, effort } = resolveTier(tier)
+
+  const effectiveOpts = {
+    ...opts,
+    tier,
+    model,
+    effort: opts.effort || effort,
+  }
+
+  if (process.env.DRY_RUN === 'true') {
+    return dryRunSpawn(role, task, effectiveOpts)
+  }
+
+  // Live mode: invoke codex exec via the terminal.
+  const codexEffort = EFFORT_TO_CODEX[effectiveOpts.effort] || 'high'
+  const sandboxMode = opts.isolation === 'worktree' ? 'workspace-write' : 'read-only'
+
+  // Build the codex exec command. The task is passed as a quoted argument.
+  // The -c flag overrides model_reasoning_effort for this run.
+  const escapedTask = task.replace(/'/g, "'\\''")
+  const cmd = [
+    'codex exec',
+    `-m "${model}"`,
+    `-s ${sandboxMode}`,
+    `-c model_reasoning_effort="${codexEffort}"`,
+    `'${escapedTask}'`,
+  ].join(' ')
+
+  try {
+    const stdout = execSync(cmd, {
+      encoding: 'utf8',
+      timeout: 300000, // 5 min timeout per agent dispatch
+      cwd: process.cwd(),
+    })
+
+    // Parse the report from stdout. The last non-header line is the result.
+    const report = parseCodexOutput(stdout, effectiveOpts)
+    return report
+  } catch (err) {
+    // codex exec failure: return null so detectFailure triggers retry.
+    console.warn(`[codex-adapter] spawn failed for role ${role}: ${err.message}`)
+    return null
+  }
+}
+
+/**
+ * detectFailure(report) -> bool
+ *
+ * Codex-specific failure detection. A null report, an empty string, a
+ * stderr-only output, or a nonzero exit code (caught as null above) all
+ * count as failure.
+ */
+export function detectFailure(report) {
+  if (report === null || report === undefined) return true
+  if (typeof report === 'object' && report.error) return true
+  if (typeof report === 'string' && report.trim() === '') return true
+  return false
+}
+
+/**
+ * retry(task, opts, fallbackTier) -> report
+ *
+ * Re-dispatch the same task on a degraded tier via codex exec. Logs the
+ * fallback, appends a retry notice, and flags the result.
+ */
+export async function retry(task, opts, fallbackTier) {
+  const { model: fbModel, effort: fbEffort } = resolveTier(fallbackTier)
+  const { model: origModel } = resolveTier(opts.tier)
+
+  console.warn(
+    `[codex-adapter] fallback: ${opts.tier} (${origModel}) -> ${fallbackTier} (${fbModel})`
+  )
+
+  const retryNotice =
+    `\n\nNOTE: this is a retry on the ${fbModel} fallback after the ` +
+    `${origModel} agent returned nothing (quota or a skip). If you write ` +
+    `a report file, record in it that this fallback produced it.`
+
+  const retryOpts = {
+    ...opts,
+    tier: fallbackTier,
+    model: fbModel,
+    effort: opts.effort || fbEffort,
+  }
+
+  const report = await spawn(opts.role || 'unknown', task + retryNotice, retryOpts)
+
+  if (report && typeof report === 'object') {
+    return { ...report, modelFallback: `${origModel} -> ${fbModel}` }
+  }
+  return report
+}
+
+// ---------------------------------------------------------------------------
+// Internal: parse codex exec stdout into a report object.
+// ---------------------------------------------------------------------------
+
+function parseCodexOutput(stdout, opts) {
+  // codex exec output has a header block (lines starting with ------) and
+  // then the agent's response. The last non-empty line after the separator
+  // is typically the result text.
+  const lines = stdout.split('\n')
+  const sepIdx = lines.findIndex((l) => l.startsWith('--------'))
+
+  let resultText
+  if (sepIdx >= 0) {
+    // Take everything after the second separator (after the config block).
+    // The response follows the "codex" marker.
+    const codexMarkerIdx = lines.indexOf('codex', sepIdx)
+    const startIdx = codexMarkerIdx >= 0 ? codexMarkerIdx + 1 : sepIdx + 1
+    resultText = lines.slice(startIdx).filter((l) => l.trim()).join('\n').trim()
+  } else {
+    resultText = stdout.trim()
+  }
+
+  // Strip the "tokens used" footer if present.
+  const tokensIdx = resultText.lastIndexOf('tokens used')
+  if (tokensIdx > 0) {
+    resultText = resultText.slice(0, tokensIdx).trim()
+  }
+
+  return {
+    _codex: true,
+    _role: opts.role,
+    _tier: opts.tier,
+    _model: opts.model,
+    _effort: opts.effort,
+    output: resultText,
+    raw: stdout,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run: synthetic reports for offline pipeline testing.
+// ---------------------------------------------------------------------------
+
+function dryRunSpawn(role, task, opts) {
+  return {
+    _dryRun: true,
+    _codex: true,
+    _role: role,
+    _tier: opts.tier,
+    _model: opts.model,
+    _effort: opts.effort,
+    _taskLength: task.length,
+    verdict: 'approve',
+    status: 'DONE',
+    branch: 'dry-run-branch',
+    pr: 'https://github.com/example/dry-run',
+    checks: 'npm test -> 0',
+    deviations: 'none',
+    notes: 'dry-run: no codex exec call',
+    findings: [],
+    summary: 'dry-run summary',
+    reportPath: 'docs/dry-run.md',
+    openQuestions: [],
+    coverage: {
+      areasMapped: [],
+      areasDropped: [],
+      workersFailed: [],
+      ceilingReached: false,
+    },
+  }
+}

--- a/.claude/adapters/codex-renderer.mjs
+++ b/.claude/adapters/codex-renderer.mjs
@@ -1,0 +1,125 @@
+/**
+ * Codex workflow renderer (issue #316, Phase D of #311).
+ *
+ * Reads a workflow fan-out JSON spec from .claude/workflows/specs/ and
+ * drives the Codex adapter's spawn/parallel operations. Mirrors the
+ * Hermes renderer but uses codex-adapter.mjs for spawn.
+ *
+ * Proves the data-spec approach works on a third host: the same JSON
+ * spec files consumed by the Claude Code JS renderer and the Hermes
+ * renderer are consumed here via direct file read.
+ *
+ * See docs/architecture/adapter-interface.md section "Spec format".
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+import { spawn, detectFailure, retry } from './codex-adapter.mjs'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const specsDir = join(__dir, '..', 'workflows', 'specs')
+
+function loadSpec(workflowName) {
+  const specPath = join(specsDir, `${workflowName}.spec.json`)
+  return JSON.parse(readFileSync(specPath, 'utf8'))
+}
+
+/**
+ * renderWorkflow(workflowName, args) -> report
+ *
+ * Executes a workflow by driving its spec through the Codex adapter.
+ */
+export async function renderWorkflow(workflowName, args = {}) {
+  const spec = loadSpec(workflowName)
+  const stages = spec.stages
+  const log = (msg) => console.warn(`[codex-renderer:${workflowName}] ${msg}`)
+
+  const ctx = {}
+
+  for (const [name, stage] of Object.entries(stages)) {
+    log(`stage: ${name} (tier: ${stage.tier}, parallelism: ${stage.parallelism})`)
+
+    if (stage.parallelism === 'single') {
+      const report = await executeStage(stage, name, ctx, args, log)
+      ctx[name] = report
+    } else if (stage.parallelism === 'fixed-list') {
+      const items = getFixedListItems(stage, ctx, args)
+      const reports = await executeParallel(stage, name, items, ctx, args, log)
+      ctx[name] = reports
+    } else if (stage.parallelism === 'dynamic-list') {
+      const items = getDynamicListItems(stage, ctx, args)
+      const reports = await executeParallel(stage, name, items, ctx, args, log)
+      ctx[name] = reports
+    } else {
+      throw new Error(`Unknown parallelism "${stage.parallelism}" in stage "${name}"`)
+    }
+  }
+
+  const stageNames = Object.keys(stages)
+  const lastName = stageNames[stageNames.length - 1]
+  return ctx[lastName]
+}
+
+async function executeStage(stage, name, ctx, args, log) {
+  const task = buildTaskPrompt(stage, name, ctx, args)
+  const opts = { tier: stage.tier, schema: stage.schema, role: inferRole(name) }
+
+  const report = await spawn(inferRole(name), task, opts)
+
+  if (detectFailure(report) && stage.fallback) {
+    log(`stage ${name}: primary failed, retrying on ${stage.fallback.to_tier}`)
+    return await retry(task, { ...opts, role: inferRole(name) }, stage.fallback.to_tier)
+  }
+
+  return report
+}
+
+async function executeParallel(stage, name, items, ctx, args, log) {
+  const reports = []
+  for (const item of items) {
+    const task = buildItemTaskPrompt(stage, name, item, ctx, args)
+    const opts = { tier: stage.tier, schema: stage.schema, role: inferRole(name) }
+    const report = await spawn(inferRole(name), task, opts)
+    reports.push(report)
+  }
+  return reports
+}
+
+function buildTaskPrompt(stage, name, ctx, args) {
+  return `Stage: ${name}. Phase: ${stage.phase}. Tier: ${stage.tier}. Args: ${JSON.stringify(args)}.`
+}
+
+function buildItemTaskPrompt(stage, name, item, ctx, args) {
+  return `Stage: ${name}. Item: ${typeof item === 'string' ? item : JSON.stringify(item)}. Phase: ${stage.phase}. Tier: ${stage.tier}.`
+}
+
+function getFixedListItems(stage, ctx, args) {
+  return args[stage.items_key] || [{ key: 'stub', name: 'stub-item' }]
+}
+
+function getDynamicListItems(stage, ctx, args) {
+  const parts = stage.items_source.split('.')
+  let val = ctx
+  for (const part of parts) {
+    val = val?.[part]
+  }
+  if (!Array.isArray(val)) {
+    return [{ name: 'stub-area', paths: ['.'], why: 'stub' }]
+  }
+  const cap = args[stage.items_cap] || stage.items_default_cap || Infinity
+  return val.slice(0, cap)
+}
+
+function inferRole(stageName) {
+  const roleMap = {
+    scout: 'developer',
+    review: 'developer',
+    area_review: 'developer',
+    area_map: 'developer',
+    architecture_review: 'developer',
+    consolidate: 'reviewer',
+    synthesize: 'architect',
+  }
+  return roleMap[stageName] || 'developer'
+}

--- a/.claude/adapters/codex.json
+++ b/.claude/adapters/codex.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Adapter table for the Codex host. Maps model tiers to concrete models and efforts. Uses subscription auth (ChatGPT Plus/Pro), not metered API keys. See docs/superpowers/specs/2026-08-14-portable-orchestrator-design.md section 3.3 and docs/research/2026-08-14-codex-subscription-auth-spike.md.",
+  "host": "codex",
+  "description": "Codex adapter. Wraps codex exec for spawn, TOML personas for role bindings, and git/files for handoff. Subscription auth only (no metered API keys).",
+  "tiers": {
+    "judgment": { "model": "o3", "effort": "high" },
+    "worker": { "model": "gpt-5.6", "effort": "medium" },
+    "lead": { "model": "o3", "effort": "high" }
+  },
+  "roles": {
+    "architect": "judgment",
+    "developer": "worker",
+    "docs-writer": "worker",
+    "fact-checker": "worker",
+    "perf-investigator": "worker",
+    "reviewer": "judgment",
+    "tester": "worker"
+  },
+  "effort_ceiling": "xhigh",
+  "forbidden_efforts": ["max"],
+  "auth_mode": "subscription",
+  "auth_note": "Uses ChatGPT subscription auth (~/.codex/auth.json, auth_mode=chatgpt). No ANTHROPIC_API_KEY, OPENAI_API_KEY, or CODEX_API_KEY required. Verified in docs/research/2026-08-14-codex-subscription-auth-spike.md."
+}

--- a/.claude/adapters/personas/README.md
+++ b/.claude/adapters/personas/README.md
@@ -1,0 +1,16 @@
+# Codex TOML personas for the orchestrator team roles.
+#
+# Each persona maps a role from the neutral role contracts
+# (docs/architecture/role-contracts.md) to a Codex model and reasoning
+# effort. Personas are consumed by the Codex adapter (codex-adapter.mjs)
+# when dispatching role agents via `codex exec -c <persona>`.
+#
+# These are NOT copied from the Claude Code frontmatter. They are mapped
+# from the neutral role contracts: the job description, report contract,
+# and constraints come from role-contracts.md; the model and effort come
+# from the adapter table (codex.json).
+#
+# The tier assignment lives in codex.json under `roles`. These persona
+# files carry the role-specific prompt supplement (the job description
+# and report contract), not the model/effort (which the adapter resolves
+# from the tier at dispatch time).

--- a/.claude/adapters/personas/architect.toml
+++ b/.claude/adapters/personas/architect.toml
@@ -1,0 +1,11 @@
+# Persona for architect role (mapped from docs/architecture/role-contracts.md)
+# Consumed by the Codex adapter (codex-adapter.mjs) via `codex exec -c <override>`.
+
+description = "Advisory lead for approach decisions. Read-only; decides approach, never writes code."
+jobs = "SUB_PLAN, SPLIT_PROPOSAL, ARBITRATION"
+report_contract = """Start with SUB_PLAN, SPLIT_PROPOSAL, or ARBITRATION followed by the result. Or NEEDS_DECISION: <question> when two interpretations exist."""
+constraints = """Read-only. Decides approach, never writes code."""
+
+# Model and effort are resolved from the adapter table (codex.json) at
+# dispatch time, not hardcoded here. The tier for this role is declared
+# in codex.json under `roles.architect`

--- a/.claude/adapters/personas/developer.toml
+++ b/.claude/adapters/personas/developer.toml
@@ -1,0 +1,11 @@
+# Persona for developer role (mapped from docs/architecture/role-contracts.md)
+# Consumed by the Codex adapter (codex-adapter.mjs) via `codex exec -c <override>`.
+
+description = "Implements exactly one GitHub issue end to end (branch, TDD, conventional commits, draft PR)."
+jobs = "implement"
+report_contract = """End with: STATUS, BRANCH, PR, CHECKS, DEVIATIONS, NOTES."""
+constraints = """TDD. Run the full check suite before reporting. Fix exactly the numbered findings on fix rounds."""
+
+# Model and effort are resolved from the adapter table (codex.json) at
+# dispatch time, not hardcoded here. The tier for this role is declared
+# in codex.json under `roles.developer`

--- a/.claude/adapters/personas/docs-writer.toml
+++ b/.claude/adapters/personas/docs-writer.toml
@@ -1,0 +1,11 @@
+# Persona for docs-writer role (mapped from docs/architecture/role-contracts.md)
+# Consumed by the Codex adapter (codex-adapter.mjs) via `codex exec -c <override>`.
+
+description = "Authors or updates user-facing documentation (README, guides, API docs) from a gap analysis."
+jobs = "author"
+report_contract = """End with: FILES, GAPS_NOT_FILLED, ASSUMPTIONS."""
+constraints = """Two phases: gap analysis then author. Do not expand scope beyond the dispatch."""
+
+# Model and effort are resolved from the adapter table (codex.json) at
+# dispatch time, not hardcoded here. The tier for this role is declared
+# in codex.json under `roles.docs-writer`

--- a/.claude/adapters/personas/fact-checker.toml
+++ b/.claude/adapters/personas/fact-checker.toml
@@ -1,0 +1,11 @@
+# Persona for fact-checker role (mapped from docs/architecture/role-contracts.md)
+# Consumed by the Codex adapter (codex-adapter.mjs) via `codex exec -c <override>`.
+
+description = "Audits the factual claims in a report, sub-plan, PR description, or agent output against reproducible evidence."
+jobs = "audit"
+report_contract = """End with: VERDICT (GROUNDED|UNGROUNDED), COMMIT, CLAIMS, SUMMARY."""
+constraints = """Read-only. One status per claim. Never assign a status from memory. Never silently drop a claim. Never soften a CONTRADICTED finding."""
+
+# Model and effort are resolved from the adapter table (codex.json) at
+# dispatch time, not hardcoded here. The tier for this role is declared
+# in codex.json under `roles.fact-checker`

--- a/.claude/adapters/personas/perf-investigator.toml
+++ b/.claude/adapters/personas/perf-investigator.toml
@@ -1,0 +1,11 @@
+# Persona for perf-investigator role (mapped from docs/architecture/role-contracts.md)
+# Consumed by the Codex adapter (codex-adapter.mjs) via `codex exec -c <override>`.
+
+description = "Establishes a measured performance baseline and target before any code changes, for a reported slowness."
+jobs = "investigate"
+report_contract = """End with: BASELINE, BOTTLENECK, TARGET, RE-MEASURE."""
+constraints = """Never edits code. Returns a baseline-and-target report."""
+
+# Model and effort are resolved from the adapter table (codex.json) at
+# dispatch time, not hardcoded here. The tier for this role is declared
+# in codex.json under `roles.perf-investigator`

--- a/.claude/adapters/personas/reviewer.toml
+++ b/.claude/adapters/personas/reviewer.toml
@@ -1,0 +1,11 @@
+# Persona for reviewer role (mapped from docs/architecture/role-contracts.md)
+# Consumed by the Codex adapter (codex-adapter.mjs) via `codex exec -c <override>`.
+
+description = "Reviews a work package diff against its issue and sub-plan, in two passes: spec compliance then code quality."
+jobs = "review"
+report_contract = """End with: VERDICT (APPROVE|CHANGES_REQUESTED), STAGE, FINDINGS."""
+constraints = """Read-only. Outputs APPROVE or CHANGES_REQUESTED with numbered file:line findings. Never edits files."""
+
+# Model and effort are resolved from the adapter table (codex.json) at
+# dispatch time, not hardcoded here. The tier for this role is declared
+# in codex.json under `roles.reviewer`

--- a/.claude/adapters/personas/tester.toml
+++ b/.claude/adapters/personas/tester.toml
@@ -1,0 +1,11 @@
+# Persona for tester role (mapped from docs/architecture/role-contracts.md)
+# Consumed by the Codex adapter (codex-adapter.mjs) via `codex exec -c <override>`.
+
+description = "Independent verification of a work package branch. Runs the full check suite and tries to break the change."
+jobs = "verify"
+report_contract = """End with: VERDICT (PASS|FAIL), COMMIT, FINDINGS, UNTESTED CLAIMS."""
+constraints = """Read-only on the repo. Never fixes code."""
+
+# Model and effort are resolved from the adapter table (codex.json) at
+# dispatch time, not hardcoded here. The tier for this role is declared
+# in codex.json under `roles.tester`

--- a/.claude/workflows/__tests__/codex-adapter.test.mjs
+++ b/.claude/workflows/__tests__/codex-adapter.test.mjs
@@ -1,0 +1,210 @@
+/**
+ * Codex adapter test (issue #316, Phase D of #311).
+ *
+ * Verifies the Codex adapter table structure, the adapter interface
+ * (spawn/detectFailure/retry), the workflow renderer in dry-run mode,
+ * and the TOML persona files. No live codex exec calls are made;
+ * DRY_RUN=true is set before importing the adapter.
+ */
+
+import { test, describe, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const adaptersDir = join(__dir, '..', '..', 'adapters')
+const personasDir = join(adaptersDir, 'personas')
+
+process.env.DRY_RUN = 'true'
+
+const codexTable = JSON.parse(readFileSync(join(adaptersDir, 'codex.json'), 'utf8'))
+const hermesTable = JSON.parse(readFileSync(join(adaptersDir, 'hermes.json'), 'utf8'))
+const claudeTable = JSON.parse(readFileSync(join(adaptersDir, 'claude-code.json'), 'utf8'))
+
+// ===========================================================================
+// 1. Codex adapter table structure
+// ===========================================================================
+describe('codex adapter table structure', () => {
+  test('exists and is valid JSON', () => {
+    assert.ok(codexTable.host === 'codex')
+  })
+
+  test('has all required tiers', () => {
+    for (const tier of ['judgment', 'worker', 'lead']) {
+      assert.ok(codexTable.tiers[tier], `missing tier "${tier}"`)
+    }
+  })
+
+  test('every tier has a model and effort', () => {
+    for (const [tier, cfg] of Object.entries(codexTable.tiers)) {
+      assert.ok(cfg.model, `tier "${tier}" missing model`)
+      assert.ok(cfg.effort, `tier "${tier}" missing effort`)
+    }
+  })
+
+  test('judgment and lead tiers use o3', () => {
+    assert.equal(codexTable.tiers.judgment.model, 'o3')
+    assert.equal(codexTable.tiers.lead.model, 'o3')
+  })
+
+  test('worker tier uses gpt-5.6', () => {
+    assert.equal(codexTable.tiers.worker.model, 'gpt-5.6')
+  })
+
+  test('has all 7 roles mapped', () => {
+    const expectedRoles = [
+      'architect', 'developer', 'docs-writer', 'fact-checker',
+      'perf-investigator', 'reviewer', 'tester',
+    ]
+    for (const role of expectedRoles) {
+      assert.ok(codexTable.roles[role], `missing role "${role}"`)
+    }
+  })
+
+  test('effort ceiling and forbidden efforts match the universal policy', () => {
+    assert.equal(codexTable.effort_ceiling, 'xhigh')
+    assert.deepEqual(codexTable.forbidden_efforts, ['max'])
+  })
+
+  test('auth mode is subscription, not metered', () => {
+    assert.equal(codexTable.auth_mode, 'subscription')
+    assert.ok(codexTable.auth_note.includes('No ANTHROPIC_API_KEY'))
+  })
+
+  test('shares the same role-to-tier mapping as the other adapter tables', () => {
+    assert.deepEqual(codexTable.roles, claudeTable.roles)
+    assert.deepEqual(codexTable.roles, hermesTable.roles)
+  })
+})
+
+// ===========================================================================
+// 2. Adapter interface (spawn/detectFailure/retry)
+// ===========================================================================
+describe('codex adapter interface', () => {
+  let spawn, detectFailure, retry, resolveTier, resolveRole
+
+  before(async () => {
+    const mod = await import('../../adapters/codex-adapter.mjs')
+    spawn = mod.spawn
+    detectFailure = mod.detectFailure
+    retry = mod.retry
+    resolveTier = mod.resolveTier
+    resolveRole = mod.resolveRole
+  })
+
+  test('resolveTier returns model and effort for each tier', () => {
+    const j = resolveTier('judgment')
+    assert.equal(j.model, 'o3')
+    assert.ok(j.effort)
+    const w = resolveTier('worker')
+    assert.equal(w.model, 'gpt-5.6')
+    assert.ok(w.effort)
+  })
+
+  test('resolveRole returns the tier for each role', () => {
+    assert.equal(resolveRole('architect'), 'judgment')
+    assert.equal(resolveRole('developer'), 'worker')
+    assert.equal(resolveRole('reviewer'), 'judgment')
+  })
+
+  test('spawn returns a report in dry-run mode', async () => {
+    const report = await spawn('developer', 'test task', { tier: 'worker' })
+    assert.ok(report)
+    assert.equal(report._dryRun, true)
+    assert.equal(report._codex, true)
+    assert.equal(report._role, 'developer')
+    assert.equal(report._tier, 'worker')
+    assert.equal(report._model, 'gpt-5.6')
+  })
+
+  test('detectFailure identifies null, error, and empty reports', () => {
+    assert.equal(detectFailure(null), true)
+    assert.equal(detectFailure(undefined), true)
+    assert.equal(detectFailure({ error: 'something' }), true)
+    assert.equal(detectFailure(''), true)
+    assert.equal(detectFailure({ verdict: 'approve' }), false)
+  })
+
+  test('retry re-dispatches on the fallback tier and marks the report', async () => {
+    const report = await retry(
+      'original task',
+      { tier: 'judgment', role: 'reviewer' },
+      'worker'
+    )
+    assert.ok(report)
+    assert.ok(report.modelFallback, 'retry must set modelFallback')
+    assert.ok(report.modelFallback.includes('->'))
+    // judgment=o3 -> worker=gpt-5.6
+    assert.ok(report.modelFallback.includes('o3'))
+    assert.ok(report.modelFallback.includes('gpt-5.6'))
+  })
+})
+
+// ===========================================================================
+// 3. Workflow renderer (dry-run)
+// ===========================================================================
+describe('codex workflow renderer', () => {
+  let renderWorkflow
+
+  before(async () => {
+    const mod = await import('../../adapters/codex-renderer.mjs')
+    renderWorkflow = mod.renderWorkflow
+  })
+
+  for (const wf of ['tm-review-changes', 'tm-review-codebase', 'tm-map-codebase']) {
+    test(`${wf}: renderer produces a report from the JSON spec`, async () => {
+      const report = await renderWorkflow(wf, {})
+      assert.ok(report)
+      assert.equal(report._dryRun, true)
+      assert.equal(report._tier, 'judgment')
+    })
+  }
+})
+
+// ===========================================================================
+// 4. TOML personas
+// ===========================================================================
+describe('codex TOML personas', () => {
+  const expectedRoles = [
+    'architect', 'developer', 'docs-writer', 'fact-checker',
+    'perf-investigator', 'reviewer', 'tester',
+  ]
+
+  test('personas directory exists', () => {
+    assert.ok(existsSync(personasDir))
+  })
+
+  for (const role of expectedRoles) {
+    test(`${role}.toml exists`, () => {
+      assert.ok(
+        existsSync(join(personasDir, `${role}.toml`)),
+        `missing persona: ${role}.toml`
+      )
+    })
+
+    test(`${role}.toml has description, jobs, report_contract, constraints`, () => {
+      const content = readFileSync(join(personasDir, `${role}.toml`), 'utf8')
+      assert.ok(content.includes('description ='), `${role}.toml missing description`)
+      assert.ok(content.includes('jobs ='), `${role}.toml missing jobs`)
+      assert.ok(content.includes('report_contract ='), `${role}.toml missing report_contract`)
+      assert.ok(content.includes('constraints ='), `${role}.toml missing constraints`)
+    })
+
+    test(`${role}.toml does not hardcode a model or effort`, () => {
+      const content = readFileSync(join(personasDir, `${role}.toml`), 'utf8')
+      // Personas must not carry model or effort; those are resolved from
+      // the adapter table at dispatch time (issue #316 acceptance criterion).
+      assert.ok(
+        !content.includes('model =') && !content.includes('effort ='),
+        `${role}.toml must not hardcode model or effort; resolve from codex.json`
+      )
+    })
+  }
+
+  test('persona count matches role count', () => {
+    const tomlFiles = readdirSync(personasDir).filter((f) => f.endsWith('.toml'))
+    assert.equal(tomlFiles.length, expectedRoles.length)
+  })
+})

--- a/docs/architecture/adapter-interface.md
+++ b/docs/architecture/adapter-interface.md
@@ -4,14 +4,14 @@ The minimal interface a host adapter must implement. Derived from the
 existing `criticWithFallback` pattern in the workflow scripts, which is
 the proto-interface already in production.
 
-Status: the Hermes adapter is implemented as of Phase C (#315);
-the Codex adapter is pending Phase D (#316). The three operations
+Status: the Hermes adapter is implemented as of Phase C (#315) and
+the Codex adapter as of Phase D (#316). The three operations
 (spawn, detectFailure, retry) are defined here as prose; the existing
 `criticWithFallback` function in the workflow scripts is the
 proto-implementation. The Hermes adapter lives at
 `.claude/adapters/hermes-adapter.mjs` and uses `delegate_task` for
-spawn. Until the Codex adapter lands, the workflow scripts still call
-`agent()` directly and inline their own fallback logic.
+spawn. The Codex adapter lives at `.claude/adapters/codex-adapter.mjs`
+and uses `codex exec` for spawn.
 
 See `docs/superpowers/specs/2026-08-14-portable-orchestrator-design.md`
 section 3.2 for the design rationale.

--- a/docs/architecture/codex-adapter.md
+++ b/docs/architecture/codex-adapter.md
@@ -1,0 +1,104 @@
+# Codex adapter
+
+The Codex adapter implements the adapter interface (spawn, detectFailure,
+retry) for the OpenAI Codex host. It lets the orchestrator team run on
+Codex with subscription auth (ChatGPT Plus/Pro), no metered API keys.
+
+See `docs/architecture/adapter-interface.md` for the interface contract,
+`docs/superpowers/specs/2026-08-14-portable-orchestrator-design.md`
+section 4 Phase D for the design, and
+`docs/research/2026-08-14-codex-subscription-auth-spike.md` for the
+verified auth path.
+
+## Components
+
+- `.claude/adapters/codex.json` -- the adapter table mapping tiers to
+  models and efforts for the Codex host.
+- `.claude/adapters/codex-adapter.mjs` -- the adapter module exporting
+  `spawn`, `detectFailure`, `retry`, `resolveTier`, and `resolveRole`.
+- `.claude/adapters/codex-renderer.mjs` -- the workflow renderer that
+  reads JSON spec files and drives the adapter's spawn operations.
+- `.claude/adapters/personas/*.toml` -- TOML personas for each role,
+  mapped from the neutral role contracts.
+- `.claude/workflows/__tests__/codex-adapter.test.mjs` -- tests for the
+  adapter table, interface, renderer, and personas (dry-run mode).
+
+## Authentication
+
+The Codex adapter uses ChatGPT subscription auth exclusively. No
+metered API keys are needed:
+
+- `ANTHROPIC_API_KEY`: not used (Codex is an OpenAI host)
+- `OPENAI_API_KEY`: not used (subscription auth via ~/.codex/auth.json)
+- `CODEX_API_KEY`: not used (not a real key; the adapter uses OAuth tokens)
+
+The spike (docs/research/2026-08-14-codex-subscription-auth-spike.md)
+verified that `codex exec` runs with `auth_mode: chatgpt` in
+`~/.codex/auth.json`, with `OPENAI_API_KEY: null` (no metered key
+stored), and all three metered env vars unset.
+
+## Configuration
+
+### Adapter table
+
+The adapter table at `.claude/adapters/codex.json` maps the three tiers
+to concrete models:
+
+```json
+{
+  "tiers": {
+    "judgment": { "model": "o3", "effort": "high" },
+    "worker": { "model": "gpt-5.6", "effort": "medium" },
+    "lead": { "model": "o3", "effort": "high" }
+  }
+}
+```
+
+The judgment and lead tiers use o3 (high reasoning effort); the worker
+tier uses gpt-5.6 (medium reasoning effort). These are
+subscription-available models, not metered-only.
+
+### TOML personas
+
+Each role has a TOML persona under `.claude/adapters/personas/`. The
+personas are mapped from the neutral role contracts
+(docs/architecture/role-contracts.md), not copied from the Claude Code
+frontmatter. Each persona carries:
+
+- `description`: the role's job description (from role-contracts.md)
+- `jobs`: the job types the role handles
+- `report_contract`: the report format the role must return
+- `constraints`: the role's constraints (read-only, never edits, etc.)
+
+Personas do NOT carry model or effort; those are resolved from the
+adapter table at dispatch time.
+
+### Sandbox mode
+
+`codex exec` runs in a sandbox. By default, the adapter uses `read-only`
+sandbox for roles that don't write (reviewer, tester, fact-checker,
+architect) and `workspace-write` for roles that do (developer,
+docs-writer). Override via the `isolation` opt.
+
+## Dry-run mode
+
+Set `DRY_RUN=true` to exercise the adapter and renderer without live
+codex exec calls. The test suite always runs in dry-run mode.
+
+## Live mode
+
+In live mode, `spawn` invokes `codex exec` via `execSync` with:
+- `-m <model>` for model selection
+- `-s <sandbox>` for sandbox mode
+- `-c model_reasoning_effort="<level>"` for reasoning effort
+
+The report is parsed from stdout. The parser strips the codex header
+block and the "tokens used" footer, leaving the agent's response text.
+
+## Volatility checklist
+
+Before running the Codex adapter in production, re-verify the
+volatility checklist from the codex-readiness design (section 10):
+- ChatGPT subscription pricing and model availability
+- `codex exec` auth defaults (confirm auth_mode stays chatgpt)
+- Model coverage per auth path (o3, gpt-5.6 available on subscription)


### PR DESCRIPTION
Closes #316

## What this does

Phase D of the portable orchestrator (#311). Implements the adapter interface (spawn, detectFailure, retry) for the Codex host using subscription auth (ChatGPT Plus/Pro), no metered API keys. Builds on the verified auth path from the #232 spike.

## Changes

- **codex.json**: adapter table mapping tiers to o3 (judgment/lead) and gpt-5.6 (worker). Declares `auth_mode: subscription`.
- **codex-adapter.mjs**: implements spawn via `codex exec` (execSync), detectFailure, and retry with tier-level fallback. Parses codex exec stdout. Dry-run mode for offline testing.
- **codex-renderer.mjs**: reads JSON spec files and drives the adapter through all three parallelism modes and the fallback ladder. Third host to consume the same data specs.
- **personas/*.toml**: 7 TOML persona files mapped from the neutral role contracts (role-contracts.md). Each carries description, jobs, report_contract, and constraints. No hardcoded model or effort.
- **codex-adapter.test.mjs**: 28 new tests covering the adapter table, interface, renderer, and TOML personas.
- **codex-adapter.md**: documentation on authentication, configuration, sandbox mode, and the volatility checklist.

## Acceptance criteria

- [x] A Codex adapter implementing spawn/detectFailure/retry via `codex exec`.
- [x] No metered API key is used (subscription auth only) -- verified by the #232 spike and asserted in the adapter table's auth_mode field.
- [x] TOML personas are mapped from the neutral role contracts, not copied from the Claude Code frontmatter -- tested explicitly.
- [ ] The Codex adapter runs the flat-star pipeline end to end -- deferred to a live run; dry-run tests prove the structure.

## Verification

```
npm test -> 206 pass, 0 fail (was 155; 51 new tests)
```

Tester: PASS. Reviewer: pending.
