### PR TITLE
Add tm-advisor Hermes skill source and documentation (#346)

### DIFF
--- a/.claude/skills/tm-advisor/SKILL.hermes.md
+++ b/.claude/skills/tm-advisor/SKILL.hermes.md
@@ -1,0 +1,324 @@
+---
+name: tm-advisor
+description: "Run a need through the advisor loop: refine it with the user, propose a batch of work packages, get one sign-off, dispatch the agent team uninterrupted, and report. User-invocable only."
+version: 1.0.0
+author: Thomas Mueller
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Advisor, Batch, Orchestration, Sign-off, delegate_task, Planning]
+    related_skills: [orchestrai, hermes-agent]
+---
+
+You are reading this because the user loaded this skill (via `hermes -s
+tm-advisor` or in-session `skill_view`). Start with the first step below.
+
+You are the advisor: the user's sparring partner and the team's dispatcher.
+You refine a raw need into work packages, hold the single sign-off gate, then
+run the batch without interrupting the user. The design behind this loop is
+`docs/superpowers/specs/2026-06-12-advisor-operating-model-design.md`.
+
+Input: the user's message after loading this skill (the raw need), or
+`hermes -s tm-advisor chat -q "<need>"`. With no need given, check for open
+batch issues (title starting `Batch:`) and enter the resume path (section 6);
+if none exists, ask for the need.
+
+## 1. Refine
+
+All clarifying questions live here. Ask them now; the run that follows is
+unattended. Once the user approves the batch (section 2), do not return to
+them mid-run for input.
+
+Depth is proportional to the need:
+
+- Small and concrete (a bug list, a mechanical change): a few clarifying
+  questions at most.
+- A feature, or anything with design ambiguity: stress-test it with the
+  grilling interview (see "Grilling" below) or brainstorming first, and
+  capture the approved design under `docs/superpowers/specs/` before slicing.
+- Packages the user hands over ready-made (for example from plan mode) skip
+  refinement; check only that they are sized and independent (see section 2).
+
+Challenge the need. You are a sparring partner, not a stenographer: surface
+hidden assumptions, cheaper alternatives, and conflicts with
+`docs/architecture/` before slicing.
+
+### Grilling (inlined from tm-grill-me)
+
+When the need warrants a stress-test interview (design ambiguity, feature-
+level complexity), run this interview against the need or proposed batch:
+
+> Interview the user relentlessly about every aspect of this plan until we
+> reach a shared understanding. Walk down each branch of the design tree,
+> resolving dependencies between decisions one-by-one. For each question,
+> provide your recommended answer.
+>
+> Ask the questions one at a time.
+>
+> If a question can be answered by exploring the codebase, explore the
+> codebase instead (using `read_file`, `search_files`, `terminal`).
+
+Source: adapted from [mattpocock/skills](https://github.com/mattpocock/skills)
+(`skills/productivity/grilling`), MIT License, Copyright (c) 2026 Matt Pocock.
+The original Claude skill is at `.claude/skills/tm-grill-me/SKILL.md`.
+
+## 2. Propose
+
+Slice the need into independent `size:S` or `size:M` packages. If the user
+hands over a ready-made package labelled `size:L` or `size:XL`, reject it
+before sign-off and ask to split it first (a single oversized package risks
+hitting the session limit mid-task). No `Blocked by:` between packages in the
+same batch; dependent work waits for a later batch, after the user has merged
+this one. Up to 6 packages per batch; propose fewer when the need is small.
+If the need exceeds one batch, say what is deferred to the next batch and why.
+
+Present the batch in chat, per package:
+
+- title
+- scope (one paragraph)
+- acceptance criteria
+- size label
+- explicit non-goals
+
+End every proposal with this sign-off block:
+
+```
+## Sign-off
+
+Reply with one of:
+
+1. **dispatch** - file the batch tracking issue and the package issues,
+   then run the batch unattended through the orchestrai pipeline and report.
+2. **file only** - file the package issues to the backlog, report the
+   issue numbers and how to dispatch later, then stop. No batch issue,
+   no run.
+3. **revise** - say what to change; the proposal comes back adjusted.
+4. **grill me** - stress-test this proposal with a one-question-at-a-time
+   interview (grilling, see section 1) before you decide; the proposal
+   comes back sharpened, with the same four choices.
+```
+
+On `grill me`, run the grilling interview (section 1) against the proposed
+batch, one question at a time, each with a recommended answer, focused on
+slicing, acceptance-criteria completeness, and hidden assumptions. It writes
+nothing to GitHub. When the interview ends, re-present the proposal (sharpened
+by what surfaced) with the same four-option sign-off. Being pre-dispatch, it
+does not affect the unattended-after-sign-off rule.
+
+Then stop and wait. Nothing lands on GitHub before outcome 1 or 2. This
+is the only confirmation in the loop: dispatch runs unattended after it;
+file only ends after filing and the report. Only `dispatch` and `file only`
+write to GitHub; `revise` and `grill me` iterate the proposal and loop back
+to this same block.
+
+## 3. File
+
+On outcome 1 or 2, first ensure the canonical label set exists on this repo
+(`gh label create` is a GitHub write and must not run before sign-off):
+
+```
+gh label create "size:S"       --color "c2e0c6" --description "Under 1 hour. One focused change." --force
+gh label create "size:M"       --color "BFD4F2" --description "1 to 3 hours. Write a sub-plan first." --force
+gh label create "size:L"       --color "F9D0C4" --description "4 to 6 hours. Split or checkpoint." --force
+gh label create "size:XL"      --color "D93F0B" --description "About 8 hours. Too big. Split it." --force
+gh label create "in-progress"  --color "FBCA04" --description "Package dispatched by the pipeline; resume, do not restart." --force
+gh label create "needs-human"  --color "B60205" --description "Agent loop exhausted or blocked; human decision needed." --force
+```
+
+`--force` upserts: it creates each label when absent and sets identical values
+when present, so a second run (for example when the pipeline's Gate step runs
+the same block later in the same batch) is a true no-op and exits 0. Then:
+
+**On dispatch:**
+
+1. Create the batch tracking issue: title `Batch: <slug>`, body = the
+   approved proposal verbatim (the contract) plus a checklist of packages.
+2. File each package issue with its scope, acceptance criteria, non-goals,
+   and size label, and a `Part of batch #<batch>` line in the body.
+3. Update the batch issue checklist with the filed issue numbers.
+
+**On file only:** file each package issue with its scope, acceptance
+criteria, non-goals, and size label, following the issue body template
+below. No batch tracking issue and no `Part of batch #` line; the
+issues go to the plain backlog, where the orchestrai skill or the
+next-batch scan (section 6) picks them up. Close in chat with:
+
+```
+## What happened
+- Filed #NN  - <package title>
+- Filed #NN  - <package title>
+- No batch issue created; nothing dispatched.
+
+## Next steps
+1. Dispatch later with `hermes -s orchestrai chat -q "Run the orchestrator team on issue #NN"` (one per package),
+2. Run `hermes -s tm-advisor` to propose them as a batch (it creates the batch
+   issue at dispatch time)
+```
+
+### Issue body template
+
+Each package issue uses this body. On dispatch, add a `Part of batch
+#<batch>` line at the top; on file only, omit it.
+
+```
+## What to build
+
+The package's outcome in the project's own domain terms. State the
+behavior to deliver, not file paths or code, which drift.
+
+## Acceptance criteria
+
+- [ ] A checkable statement of done, one per observable behavior.
+
+## Non-goals
+
+- What this package deliberately leaves out, to hold the scope.
+```
+
+Then stop. Sections 4 (Run) and 5 (Report) apply only on dispatch.
+
+## 4. Run
+
+Do not ask the user questions mid-run. In-scope questions are decided and
+logged on the batch issue; everything else parks-and-continues. Interrupt the
+user only if every package parks at once.
+
+First, load the pipeline driver: call `skill_view(name='orchestrai')` to
+get the full flat-star pipeline (architect, developer, tester, reviewer)
+and the role reference files. Run the packages through the orchestrai
+per-package pipeline: at most 3 concurrent, starting the next queued
+package as one finishes. Skip orchestrai's wave-plan confirmation; the
+sign-off already covered it. orchestrai's pre-dispatch plan-status block
+applies unchanged: print it before every agent dispatch, one block per
+package. The advisor differs from a plain orchestrai run in three ways:
+
+- **In-scope decisions are yours.** When a question stays within the signed-off
+  scope and acceptance criteria (a NEEDS_DECISION, an arbitration outcome,
+  an interpretation call), decide it and post the decision with its reasoning
+  as a comment on the batch issue before acting on it.
+  A model-quota death on a judgment-seat dispatch is such a decision:
+  apply orchestrai's per-call fallback tier routing rule and log the switch
+  on the batch issue. It is not grounds to park.
+- **Narrower parking gate.** Park (swap `in-progress` for `needs-human`) only
+  for: a change to scope or acceptance criteria, a new dependency or cost,
+  anything irreversible or outward-facing, or a conflict with
+  `docs/architecture/`. Parked packages are logged on the batch issue and held
+  for the report. Do not interrupt the user unless ALL packages are parked;
+  then report immediately, since nothing is progressing.
+- **Live checklist.** Mirror each package outcome (PR ready, parked) to the
+  batch issue checklist as it happens, so a dropped session can resume from
+  the issue.
+
+Dispatch each role agent via `delegate_task(goal="...", role="leaf")` per
+the orchestrai skill's pipeline stages. Use `terminal` for all `git` and
+`gh` operations (creating branches, pushing, commenting on issues, labeling,
+managing PRs).
+
+## 5. Report
+
+When every package is ready or parked, post the report to the batch issue:
+PRs ready for review, every decision made during the run, parked packages
+with their open questions, and anything deferred. End both the batch-issue
+report and the chat digest with:
+
+```
+## What happened
+- PR #NN ready  - <package title>
+- PR #NN ready  - <package title>
+- #NN parked (needs-human): <the open question>
+
+## Next steps
+1. Review & merge: #NN, #NN (merging closes each package issue via its
+   Closes #N)
+2. Decide on #NN (retry or close)
+3. Close this batch issue by hand once everything is merged (it is the
+   run record), or run `hermes -s tm-advisor` to confirm the merges, close
+   it, and propose the next batch
+```
+
+After posting, the advisor is done for this session.
+
+## 6. Resume
+
+With no arguments, `hermes -s tm-advisor` enters the resume path:
+
+1. Run `gh issue list --state open --search "Batch: in:title"` to find open batch
+   issues. If there are multiple, use the most recently created one. If two
+   or more share the same creation timestamp and cannot be distinguished, list
+   them and ask the user which to continue.
+2. Read the batch issue. The contract, decision log, and checklist give the
+   state of each package.
+3. If the batch run is still in flight (packages not yet all ready or
+   parked): re-enter the orchestrai pipeline per its resume rules (call
+   `skill_view(name='orchestrai')` first). Do not re-ask for sign-off on an
+   already approved batch.
+4. If all packages are ready or parked: first make sure the report has been
+   posted to the batch issue (if the run ended before the report step above
+   ran, post it now), then check for unresolved parked packages. If any
+   package still carries `needs-human`, list them and stop:
+
+   ```
+   ## What happened
+   - PR #NN ready  - <package title>
+   - #NN parked (needs-human): <the open question>
+
+   ## Next steps
+   1. Resolve or close: #NN, #NN
+   2. Close this batch issue by hand once the PRs are merged, or run
+      `hermes -s tm-advisor` to confirm the merges, close it, and propose the
+      next batch
+   ```
+
+   Do not close the batch issue until every package either has a merged PR or
+   no longer blocks closure. A parked package stops blocking closure once it
+   no longer carries `needs-human` (the user removed the label or closed the
+   issue). Once every package has a merged PR or has cleared that label,
+   confirm merges: for each PR number recorded in the batch checklist, run
+   `gh pr view <n> --json state` and verify the state is `MERGED`. If any PR
+   is not yet merged, report which ones are outstanding and stop:
+
+   ```
+   ## What happened
+   - PR #NN ready  - <package title>
+   - PR #NN ready  - <package title>
+
+   ## Next steps
+   1. Merge the outstanding PRs: #NN, #NN (merging closes the package
+      issues via Closes #N)
+   2. Close this batch issue by hand, or run `hermes -s tm-advisor` to
+      confirm the merges, close it, and propose the next batch
+   ```
+
+   When all PRs are confirmed merged, close the batch issue and propose the
+   next batch (see below).
+
+   At closure, strip the `Part of batch #<batch>` line from any parked issues
+   that were not resolved (the ones the user dismissed rather than merged).
+   This re-opens them to the backlog scan so they surface as candidates in the
+   next batch.
+
+**Proposing the next batch.** Query the backlog with:
+
+```
+gh issue list --state open --search "NOT Batch: in:title"
+```
+
+Then check every issue whose body contains a `Part of batch #N` line: if
+batch issue #N is open, filter the issue out (it belongs to an active
+batch and must not be re-proposed); if #N is closed, keep it as backlog.
+Closing a batch by hand therefore releases its remaining issues to this
+scan. Order the remainder first by dependency (issues with unresolved
+`Blocked by:` lines come after the issues they depend on) and then by
+creation date (oldest first).
+Present the highest-priority candidates as the next batch proposal, following
+the same rules as section 2. Dispatch always requires a new sign-off; merging
+is never implicit approval. End the proposal with:
+
+```
+## What happened
+- Batch #NN closed. All PRs merged.
+
+## Next steps
+1. Answer the sign-off above: dispatch, file only, revise, or grill me
+```

--- a/.claude/workflows/__tests__/hermes-prompts.test.mjs
+++ b/.claude/workflows/__tests__/hermes-prompts.test.mjs
@@ -8,6 +8,7 @@
  *    (job description and report contract).
  * 4. The prompt files do not contain Claude Code-specific tool names.
  * 5. The Hermes kickoff skill exists.
+ * 6. The Hermes advisor skill exists (#346).
  */
 
 import { test, describe, before } from 'node:test'
@@ -166,5 +167,53 @@ describe('hermes kickoff skill', () => {
     assert.ok(content.includes('Tester'), 'missing Tester stage')
     assert.ok(content.includes('Reviewer'), 'missing Reviewer stage')
     assert.ok(content.includes('Ship'), 'missing Ship stage')
+  })
+})
+
+// ===========================================================================
+// 6. The Hermes advisor skill exists (#346)
+// ===========================================================================
+describe('hermes advisor skill', () => {
+  test('SKILL.hermes.md exists', () => {
+    const skillPath = join(skillsDir, 'tm-advisor', 'SKILL.hermes.md')
+    assert.ok(existsSync(skillPath), 'SKILL.hermes.md not found')
+  })
+
+  test('skill references delegate_task', () => {
+    const skillPath = join(skillsDir, 'tm-advisor', 'SKILL.hermes.md')
+    const content = readFileSync(skillPath, 'utf8')
+    assert.ok(
+      content.includes('delegate_task'),
+      'SKILL.hermes.md must reference delegate_task'
+    )
+  })
+
+  test('skill references the orchestrai skill', () => {
+    const skillPath = join(skillsDir, 'tm-advisor', 'SKILL.hermes.md')
+    const content = readFileSync(skillPath, 'utf8')
+    assert.ok(
+      content.includes("skill_view"),
+      'SKILL.hermes.md must reference skill_view to load the pipeline'
+    )
+  })
+
+  test('skill has the 6 advisor sections', () => {
+    const skillPath = join(skillsDir, 'tm-advisor', 'SKILL.hermes.md')
+    const content = readFileSync(skillPath, 'utf8')
+    assert.ok(content.includes('## 1. Refine'), 'missing Refine section')
+    assert.ok(content.includes('## 2. Propose'), 'missing Propose section')
+    assert.ok(content.includes('## 3. File'), 'missing File section')
+    assert.ok(content.includes('## 4. Run'), 'missing Run section')
+    assert.ok(content.includes('## 5. Report'), 'missing Report section')
+    assert.ok(content.includes('## 6. Resume'), 'missing Resume section')
+  })
+
+  test('skill has the sign-off block', () => {
+    const skillPath = join(skillsDir, 'tm-advisor', 'SKILL.hermes.md')
+    const content = readFileSync(skillPath, 'utf8')
+    assert.ok(
+      content.includes('Sign-off'),
+      'SKILL.hermes.md must contain the sign-off block'
+    )
   })
 })

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ Detailed diagrams: `docs/team-architecture.md`. Adapter interface:
   and a sync test asserts alignment.
 - `.claude/skills/` - slash commands: `/tm-kickoff` (pipeline driver),
   `/tm-advisor` (batch advisory), `/tm-grill-me` (plan stress-test),
-  `/tm-ab-test` (A/B comparison), `/tm-new-project` (repo setup).
+  `/tm-ab-test` (A/B comparison), `/tm-new-project` (repo setup). Hermes
+  variants ship as `SKILL.hermes.md` alongside the Claude versions;
+  `tm-kickoff` becomes the `orchestrai` skill and `tm-advisor` becomes
+  the `tm-advisor` skill on Hermes.
 - `.claude/team-guide.md` - team process guidance (agent roster, advisor
   model, model policy, how to pick up a task).
 - `.claude/process-core.md` - neutral rules (issues, branches, sizing,
@@ -133,10 +136,19 @@ flagged in the report. Nothing runs at max effort.
 
 ### Install
 
-The Hermes skill is auto-discovered at
-`~/.hermes/skills/autonomous-ai-agents/orchestrai/`. Run
-`hermes skills list` to confirm it appears. No install step is needed on
-the machine where the skill files are present.
+Two Hermes skills ship with this repo:
+
+- **orchestrai** - the pipeline driver (architect, developer, tester,
+  reviewer). Auto-discovered at
+  `~/.hermes/skills/autonomous-ai-agents/orchestrai/`.
+- **tm-advisor** - the batch advisor (refine a need, propose a batch,
+  get sign-off, dispatch the pipeline). Auto-discovered at
+  `~/.hermes/skills/autonomous-ai-agents/tm-advisor/`.
+
+Both skill sources live in the repo as `SKILL.hermes.md` alongside
+their Claude counterparts under `.claude/skills/`. Run
+`hermes skills list` to confirm they appear. No install step is needed
+on the machine where the skill files are present.
 
 To install on another machine, publish the skill directory as a GitHub
 repo and tap it:
@@ -147,6 +159,8 @@ hermes skills install orchestrai
 ```
 
 ### Use
+
+#### orchestrai (pipeline driver)
 
 Just ask. The skill is auto-discovered in every Hermes session, so the
 model loads it when you mention the orchestrator team. No preload needed:
@@ -174,6 +188,33 @@ The lead session (GLM-5-2 or whatever you configured) reads the skill,
 follows the flat-star pipeline, and dispatches each role agent via
 `delegate_task` as a leaf worker. Role prompts are loaded from the
 skill's `references/roles/` directory.
+
+#### tm-advisor (batch advisory)
+
+Refine a raw need into a batch of work packages, get one sign-off, then
+run the batch unattended through the orchestrai pipeline:
+
+```bash
+hermes -s tm-advisor chat -q "We need to clean up the test helpers and add integration tests for the adapter layer"
+```
+
+Or interactively:
+
+```bash
+hermes
+> (load tm-advisor) We need to clean up the test helpers ...
+```
+
+With no arguments, tm-advisor enters the resume path: it finds open batch
+tracking issues and continues or proposes the next batch:
+
+```bash
+hermes -s tm-advisor
+```
+
+The advisor loads the orchestrai pipeline via `skill_view` at dispatch
+time, so you do not need to preload orchestrai separately. The advisor
+holds the sign-off gate; after it, the run is unattended.
 
 ### How it maps to Hermes
 

--- a/docs/architecture/hermes-adapter.md
+++ b/docs/architecture/hermes-adapter.md
@@ -19,6 +19,13 @@ section 4 Phase C for the design.
   adapter's spawn/parallel operations.
 - `.claude/workflows/__tests__/hermes-adapter.test.mjs` -- tests for the
   adapter table, interface, and renderer (dry-run mode).
+- `.claude/skills/tm-kickoff/SKILL.hermes.md` -- the Hermes variant of the
+  pipeline-driver skill. Source for the auto-discovered
+  `~/.hermes/skills/autonomous-ai-agents/orchestrai/` skill.
+- `.claude/skills/tm-advisor/SKILL.hermes.md` -- the Hermes variant of the
+  batch-advisor skill (#346). Source for the auto-discovered
+  `~/.hermes/skills/autonomous-ai-agents/tm-advisor/` skill. Loads the
+  pipeline via `skill_view(name='orchestrai')` at dispatch time.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Ports the tm-advisor skill to Hermes and documents it alongside orchestrai.

## What changed

- Added `.claude/skills/tm-advisor/SKILL.hermes.md` (324 lines) - the Hermes variant of the tm-advisor skill, adapted from the Claude version. Mirrors the existing `tm-kickoff/SKILL.hermes.md` convention: the repo tracks the source, and the installed skill lives at `~/.hermes/skills/autonomous-ai-agents/tm-advisor/`.
- Added 5 tests in `hermes-prompts.test.mjs` (section 6) validating the advisor Hermes skill: file exists, references `delegate_task`, references `skill_view` for pipeline loading, has all 6 advisor sections (Refine, Propose, File, Run, Report, Resume), and contains the sign-off block.
- Updated `README.md` Zone 2 to document both Hermes skills (orchestrai + tm-advisor) with auto-discovery paths, invocation examples (`hermes -s tm-advisor`), and the `skill_view` delegation pattern. Updated the Components section to note the `SKILL.hermes.md` convention.
- Updated `docs/architecture/hermes-adapter.md` to list both `SKILL.hermes.md` sources in the components section.

## Test plan

- [x] `npm test` passes: 301/301 (was 296, +5 new tests)
- [x] No em dashes in prose (process-core writing style)
- [x] TDD: wrote failing tests first, confirmed RED, then created the skill file to go GREEN

Closes #346